### PR TITLE
Add explicit/opinionated methods for registering tools

### DIFF
--- a/pkgs/dart_mcp/example/server.dart
+++ b/pkgs/dart_mcp/example/server.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io' as io;
 
@@ -35,19 +36,11 @@ class DartMCPServer extends MCPServer with ToolsSupport {
   DartMCPServer(super.channel) : super.fromStreamChannel();
 
   @override
-  ListToolsResult listTools(ListToolsRequest request) {
-    return ListToolsResult(
-      tools: [Tool(name: 'hello world', inputSchema: InputSchema())],
+  FutureOr<InitializeResult> initialize(InitializeRequest request) {
+    registerTool(
+      Tool(name: 'hello world', inputSchema: InputSchema()),
+      (_) => CallToolResult(content: [TextContent(text: 'hello world!')]),
     );
-  }
-
-  @override
-  CallToolResult callTool(CallToolRequest request) {
-    switch (request.name) {
-      case 'hello world':
-        return CallToolResult(content: [TextContent(text: 'hello world!')]);
-      default:
-        throw ArgumentError.value(request.name, 'name', 'unknown tool');
-    }
+    return super.initialize(request);
   }
 }

--- a/pkgs/dart_mcp/lib/src/api.dart
+++ b/pkgs/dart_mcp/lib/src/api.dart
@@ -895,11 +895,16 @@ extension type CallToolRequest._fromMap(Map<String, Object?> _value)
       (_value['arguments'] as Map?)?.cast<String, Object?>();
 }
 
-// /**
-//  * An optional notification from the server to the client, informing it that
-//  * the list of tools it offers has changed. This may be issued by servers
-//  * without any previous subscription from the client.
-//  */
+/// An optional notification from the server to the client, informing it that
+/// the list of tools it offers has changed. This may be issued by servers
+/// without any previous subscription from the client.
+extension type ToolListChangedNotification.fromJson(Map<String, Object?> _value)
+    implements Notification {
+  static const methodName = 'notifications/tools/list_changed';
+
+  factory ToolListChangedNotification({Meta? meta}) =>
+      ToolListChangedNotification.fromJson({if (meta != null) 'meta': meta});
+}
 // export interface ToolListChangedNotification extends Notification {
 //   method: "notifications/tools/list_changed";
 // }

--- a/pkgs/dart_mcp/lib/src/api.dart
+++ b/pkgs/dart_mcp/lib/src/api.dart
@@ -905,9 +905,6 @@ extension type ToolListChangedNotification.fromJson(Map<String, Object?> _value)
   factory ToolListChangedNotification({Meta? meta}) =>
       ToolListChangedNotification.fromJson({if (meta != null) 'meta': meta});
 }
-// export interface ToolListChangedNotification extends Notification {
-//   method: "notifications/tools/list_changed";
-// }
 
 /// Definition for a tool the client can call.
 extension type Tool.fromMap(Map<String, Object?> _value) {

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -60,8 +60,6 @@ abstract class MCPClient {
 }
 
 /// An active server connection.
-///
-// TODO: Share interfaces with MCPServer?
 class ServerConnection {
   final Peer _peer;
 

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -16,9 +16,13 @@ import '../util.dart';
 /// Actual functionality beyond server initialization is done by mixing in
 /// additional support mixins such as [ToolsSupport] etc.
 abstract class MCPServer {
-  /// Whether or not this server has finished initialization and gotten the
+  /// Completes when this server has finished initialization and gotten the
   /// final ack from the client.
-  bool initialized = false;
+  FutureOr<void> get initialized => _initialized.future;
+  final Completer<void> _initialized = Completer<void>();
+
+  /// Whether this server is still active and has completed initialization.
+  bool get ready => !_peer.isClosed && _initialized.isCompleted;
 
   final Peer _peer;
 
@@ -40,7 +44,7 @@ abstract class MCPServer {
   /// Mixins should register their methods in this method, as well as editing
   /// the [InitializeResult.capabilities] as needed.
   FutureOr<InitializeResult> initialize(InitializeRequest request) {
-    assert(!initialized);
+    assert(!_initialized.isCompleted);
     return InitializeResult(
       protocolVersion: protocolVersion,
       serverCapabilities: ServerCapabilities(),
@@ -52,39 +56,111 @@ abstract class MCPServer {
   ///
   /// The server should not respond.
   @mustCallSuper
-  Null handleInitialized(InitializedNotification notification) {
-    initialized = true;
+  void handleInitialized(InitializedNotification notification) {
+    _initialized.complete();
   }
 }
 
 /// A mixin for MCP servers which support the `tools` capability.
+///
+/// Servers should register tools using the [registerTool] method, typically
+/// inside the [initialize] method, but they may also be registered after
+/// initialization if needed.
 mixin ToolsSupport on MCPServer {
-  /// Whether or not this server supports sending notifications about the list
-  /// of tools changing.
-  ///
-  /// This should only be overridden to provide the value `true`, otherwise
-  /// different mixins could step on each others toes.
-  bool get supportsListChanged => false;
+  /// The registered tools by name.
+  final Map<String, Tool> _registeredTools = {};
 
+  /// The registered tool implementations by name.
+  final Map<String, FutureOr<CallToolResult> Function(CallToolRequest)>
+  _registeredToolImpls = {};
+
+  /// Invoked by the client as a part of initialization.
+  ///
+  /// Tools should usually be registered in this function using [registerTool]
+  /// when possible.
+  ///
+  /// If tools are registered after [initialized] completes, then the server
+  /// will notify the client
   @override
   FutureOr<InitializeResult> initialize(InitializeRequest request) async {
     _peer.registerMethod(
       ListToolsRequest.methodName,
-      convertParameters(listTools),
+      convertParameters(_listTools),
     );
 
     _peer.registerMethod(
       CallToolRequest.methodName,
-      convertParameters(callTool),
+      convertParameters(_callTool),
     );
     var result = await super.initialize(request);
-    (result.capabilities.tools ??= Tools()).listChanged = supportsListChanged;
+    (result.capabilities.tools ??= Tools()).listChanged = true;
     return result;
   }
 
-  /// Returns the list of supported tools for this server.
-  FutureOr<ListToolsResult> listTools(ListToolsRequest request);
+  /// Register [tool] to call [impl] when invoked.
+  ///
+  /// If this server is already initialized and still connected to a client,
+  /// then the client will be notified that the tools list has changed.
+  ///
+  /// Throws a [StateError] if there is already a [Tool] registered with the
+  /// same name.
+  void registerTool(
+    Tool tool,
+    FutureOr<CallToolResult> Function(CallToolRequest) impl,
+  ) {
+    if (_registeredTools.containsKey(tool.name)) {
+      throw StateError(
+        'Failed to register tool ${tool.name}, it is already registered',
+      );
+    }
+    _registeredTools[tool.name] = tool;
+    _registeredToolImpls[tool.name] = impl;
 
-  /// Invoked when one of the tools from [listTools] is called.
-  FutureOr<CallToolResult> callTool(CallToolRequest request);
+    if (ready) {
+      _notifyToolListChanged();
+    }
+  }
+
+  /// Un-registers a [Tool] by [name].
+  ///
+  /// Does not error if the tool hasn't been registered yet.
+  void unregisterTool(String name) {
+    _registeredTools.remove(name);
+    _registeredToolImpls.remove(name);
+  }
+
+  /// Returns the list of supported tools for this server.
+  ListToolsResult _listTools(ListToolsRequest request) =>
+      ListToolsResult(tools: [for (var tool in _registeredTools.values) tool]);
+
+  /// Invoked when one of the registered tools is called.
+  Future<CallToolResult> _callTool(CallToolRequest request) async {
+    final impl = _registeredToolImpls[request.name];
+    if (impl == null) {
+      return CallToolResult(
+        isError: true,
+        content: [
+          TextContent(text: 'No tool registered with the name ${request.name}'),
+        ],
+      );
+    }
+
+    try {
+      return await impl(request);
+    } catch (e, s) {
+      return CallToolResult(
+        isError: true,
+        content: [TextContent(text: '$e\n$s')],
+      );
+    }
+  }
+
+  /// Called whenever the list of tools changes, it is the job of the client to
+  /// then ask again for the list of tools.
+  void _notifyToolListChanged() {
+    _peer.sendNotification(
+      ToolListChangedNotification.methodName,
+      ToolListChangedNotification(),
+    );
+  }
 }

--- a/pkgs/dart_mcp/test/client_and_server_test.dart
+++ b/pkgs/dart_mcp/test/client_and_server_test.dart
@@ -92,19 +92,11 @@ class TestMCPServer extends MCPServer with ToolsSupport {
   TestMCPServer(super.channel) : super.fromStreamChannel();
 
   @override
-  ListToolsResult listTools(ListToolsRequest request) {
-    return ListToolsResult(
-      tools: [Tool(name: 'hello world', inputSchema: InputSchema())],
+  FutureOr<InitializeResult> initialize(InitializeRequest request) {
+    registerTool(
+      Tool(name: 'hello world', inputSchema: InputSchema()),
+      (_) => CallToolResult(content: [TextContent(text: 'hello world!')]),
     );
-  }
-
-  @override
-  CallToolResult callTool(CallToolRequest request) {
-    switch (request.name) {
-      case 'hello world':
-        return CallToolResult(content: [TextContent(text: 'hello world!')]);
-      default:
-        throw ArgumentError.value(request.name, 'name', 'unknown tool');
-    }
+    return super.initialize(request);
   }
 }


### PR DESCRIPTION
Adds `registerTool` and `unregisterTool` to the ToolSupport mixin, which handles routing, list tools calls, and notifying clients that the tools list has changed (if applicable).

Removes the previous getter indicating whether the server supports notifying about tool changes, because support is built in now. 