### PR TITLE
Add basic Resources support, refactor some things

### DIFF
--- a/pkgs/dart_mcp/lib/src/api.dart
+++ b/pkgs/dart_mcp/lib/src/api.dart
@@ -242,6 +242,14 @@ extension type ServerCapabilities.fromMap(Map<String, Object?> _value) {
   /// Whether this server supports subscribing to resource updates.
   Resources? get resources => _value['resources'] as Resources?;
 
+  /// Sets [resources] if it is null, otherwise throws.
+  ///
+  // TODO: Add more setters for other types?
+  set resources(Resources? value) {
+    assert(resources == null);
+    _value['resources'] = value;
+  }
+
   /// Present if the server offers any tools to call.
   Tools? get tools => _value['tools'] as Tools?;
 
@@ -274,8 +282,20 @@ extension type Resources.fromMap(Map<String, Object?> _value) {
   /// list.
   bool? get listChanged => _value['listChanged'] as bool?;
 
+  /// Sets whether [listChanged] is supported.
+  set listChanged(bool? value) {
+    assert(listChanged == null);
+    _value['listChanged'] = value;
+  }
+
   /// Present if the server offers any resources to read.
   bool? get subscribe => _value['subscribe'] as bool?;
+
+  /// Sets whether [subscribe] is supported.
+  set subscribe(bool? value) {
+    assert(subscribe == null);
+    _value['subscribe'] = value;
+  }
 }
 
 /// Tools parameter for [ServerCapabilities].

--- a/pkgs/dart_mcp/lib/src/api.dart
+++ b/pkgs/dart_mcp/lib/src/api.dart
@@ -42,10 +42,11 @@ extension type MetaWithProgressToken.fromMap(Map<String, Object?> _value)
 /// Should not be constructed directly, and has no public constructor.
 extension type Request._fromMap(Map<String, Object?> _value) {
   /// If specified, the caller is requesting out-of-band progress notifications
-  /// for this request (as represented by notifications/progress). The value of
-  /// this parameter is an opaque token that will be attached to any subsequent
-  /// notifications. The receiver is not obligated to provide these
-  /// notifications.
+  /// for this request (as represented by notifications/progress).
+  ///
+  /// The value of this parameter is an opaque token that will be attached to
+  /// any subsequent notifications. The receiver is not obligated to provide
+  /// these notifications.
   MetaWithProgressToken? get meta => _value['_meta'] as MetaWithProgressToken?;
 }
 
@@ -69,14 +70,14 @@ extension type EmptyResult.fromMap(Map<String, Object?> _) implements Result {
 /// This notification can be sent by either side to indicate that it is
 /// cancelling a previously-issued request.
 ///
-///  The request SHOULD still be in-flight, but due to communication latency, it
+/// The request SHOULD still be in-flight, but due to communication latency, it
 /// is always possible that this notification MAY arrive after the request has
 /// already finished.
 ///
-///  This notification indicates that the result will be unused, so any
-///  associated processing SHOULD cease.
+/// This notification indicates that the result will be unused, so any
+/// associated processing SHOULD cease.
 ///
-///  A client MUST NOT attempt to cancel its `initialize` request.
+/// A client MUST NOT attempt to cancel its `initialize` request.
 extension type CancelledNotification.fromMap(Map<String, Object?> _value)
     implements Notification {
   static const methodName = 'notifications/cancelled';
@@ -126,6 +127,7 @@ extension type InitializeRequest._fromMap(Map<String, Object?> _value)
   });
 
   /// The latest version of the Model Context Protocol that the client supports.
+  ///
   /// The client MAY decide to support older versions as well.
   String get protocolVersion => _value['protocolVersion'] as String;
   ClientCapabilities get capabilities =>
@@ -151,6 +153,7 @@ extension type InitializeResult.fromMap(Map<String, Object?> _value)
   });
 
   /// The version of the Model Context Protocol that the server wants to use.
+  ///
   /// This may not match the version that the client requested. If the client
   /// cannot support this version, it MUST disconnect.
   String get protocolVersion => _value['protocolVersion'] as String;
@@ -179,9 +182,10 @@ extension type InitializedNotification.fromMap(Map<String, Object?> _value)
       InitializedNotification.fromMap({if (meta != null) '_meta': meta});
 }
 
-/// Capabilities a client may support. Known capabilities are defined here, in
-/// this schema, but this is not a closed set: any client can define its own,
-/// additional capabilities.
+/// Capabilities a client may support.
+///
+/// Known capabilities are defined here, in this schema, but this is not a
+/// closed set: any client can define its own, additional capabilities.
 extension type ClientCapabilities.fromMap(Map<String, Object?> _value) {
   factory ClientCapabilities({
     Map<String, Object?>? experimental,
@@ -210,9 +214,10 @@ extension type RootsCapabilities.fromMap(Map<String, Object?> _value) {
   bool? get listChanged => _value['listChanged'] as bool?;
 }
 
-/// Capabilities that a server may support. Known capabilities are defined here,
-/// in this schema, but this is not a closed set: any server can define its own,
-/// additional capabilities.
+/// Capabilities that a server may support.
+///
+/// Known capabilities are defined here, in this schema, but this is not a
+/// closed set: any server can define its own, additional capabilities.
 extension type ServerCapabilities.fromMap(Map<String, Object?> _value) {
   factory ServerCapabilities({
     Map<String, Object?>? experimental,
@@ -385,6 +390,7 @@ extension type ServerImplementation.fromMap(Map<String, Object?> _value) {
 extension type PaginatedRequest._fromMap(Map<String, Object?> _value)
     implements Request {
   /// An opaque token representing the current pagination position.
+  ///
   /// If provided, the server should return results starting after this cursor.
   Cursor? get cursor => _value['cursor'] as Cursor?;
 }
@@ -492,8 +498,10 @@ extension type ReadResourceResult.fromMap(Map<String, Object?> _value)
 }
 
 /// An optional notification from the server to the client, informing it that
-/// the list of resources it can read from has changed. This may be issued by
-/// servers without any previous subscription from the client.
+/// the list of resources it can read from has changed.
+///
+/// This may be issued by servers without any previous subscription from the
+/// client.
 extension type ResourceListChangedNotification.fromMap(
   Map<String, Object?> _value
 )
@@ -520,9 +528,10 @@ extension type SubscribeRequest.fromMap(Map<String, Object?> _value)
   String get uri => _value['uri'] as String;
 }
 
-///  Sent from the client to request cancellation of resources/updated
-/// notifications from the server. This should follow a previous
-/// resources/subscribe request.
+/// Sent from the client to request cancellation of resources/updated
+/// notifications from the server.
+///
+/// This should follow a previous resources/subscribe request.
 extension type UnsubscribeRequest.fromMap(Map<String, Object?> _value)
     implements Request {
   static const methodName = 'resources/unsubscribe';
@@ -535,8 +544,10 @@ extension type UnsubscribeRequest.fromMap(Map<String, Object?> _value)
 }
 
 /// A notification from the server to the client, informing it that a resource
-/// has changed and may need to be read again. This should only be sent if the
-/// client previously sent a resources/subscribe request.
+/// has changed and may need to be read again.
+///
+/// This should only be sent if the client previously sent a
+/// resources/subscribe request.
 extension type ResourceUpdatedNotification.fromMap(Map<String, Object?> _value)
     implements Notification {
   static const methodName = 'notifications/resources/updated';
@@ -547,12 +558,14 @@ extension type ResourceUpdatedNotification.fromMap(Map<String, Object?> _value)
         if (meta != null) '_meta': meta,
       });
 
-  /// The URI of the resource that has been updated. This might be a
-  /// sub-resource of the one that the client actually subscribed to.
+  /// The URI of the resource that has been updated.
+  ///
+  /// This might be a sub-resource of the one that the client actually
+  /// subscribed to.
   String get uri => _value['uri'] as String;
 }
 
-///  A known resource that the server is capable of reading.
+/// A known resource that the server is capable of reading.
 //
 // TODO: Implement Annotated
 extension type Resource.fromMap(Map<String, Object?> _value) {
@@ -596,6 +609,7 @@ extension type Resource.fromMap(Map<String, Object?> _value) {
 }
 
 /// A template description for resources available on the server.
+//
 // TODO: implement Annotated
 extension type ResourceTemplate.fromMap(Map<String, Object?> _value) {
   factory ResourceTemplate({
@@ -625,9 +639,10 @@ extension type ResourceTemplate.fromMap(Map<String, Object?> _value) {
   /// available resources. It can be thought of like a "hint" to the model.
   String? get description => _value['description'] as String?;
 
-  /// The MIME type for all resources that match this template. This should
-  /// only be included if all resources matching this template have the same
-  /// type.
+  /// The MIME type for all resources that match this template.
+  ///
+  /// This should only be included if all resources matching this template have
+  /// the same type.
   String? get mimeType => _value['mimeType'] as String?;
 }
 
@@ -913,8 +928,10 @@ extension type TextResourceContents.fromMap(Map<String, Object?> _value)
     if (mimeType != null) 'mimeType': mimeType,
   });
 
-  /// The text of the item. This must only be set if the item can actually be
-  /// represented as text (not binary data).
+  /// The text of the item.
+  ///
+  /// This must only be set if the item can actually be represented as text
+  /// (not binary data).
   String get text => _value['text'] as String;
 }
 
@@ -959,8 +976,10 @@ extension type CallToolRequest._fromMap(Map<String, Object?> _value)
 }
 
 /// An optional notification from the server to the client, informing it that
-/// the list of tools it offers has changed. This may be issued by servers
-/// without any previous subscription from the client.
+/// the list of tools it offers has changed.
+///
+/// This may be issued by servers without any previous subscription from the
+/// client.
 extension type ToolListChangedNotification.fromMap(Map<String, Object?> _value)
     implements Notification {
   static const methodName = 'notifications/tools/list_changed';

--- a/pkgs/dart_mcp/lib/src/api.dart
+++ b/pkgs/dart_mcp/lib/src/api.dart
@@ -486,6 +486,9 @@ extension type ReadResourceResult.fromMap(Map<String, Object?> _value)
     'contents': contents,
     if (meta != null) '_meta': meta,
   });
+
+  List<ResourceContents> get contents =>
+      (_value['contents'] as List).cast<ResourceContents>();
 }
 
 /// An optional notification from the server to the client, informing it that

--- a/pkgs/dart_mcp/lib/src/api.dart
+++ b/pkgs/dart_mcp/lib/src/api.dart
@@ -50,7 +50,7 @@ extension type Request._fromMap(Map<String, Object?> _value) {
 }
 
 /// Base interface for all notifications.
-extension type Notification(Map<String, Object?> _value) implements Request {
+extension type Notification(Map<String, Object?> _value) {
   /// This parameter name is reserved by MCP to allow clients and servers to
   /// attach additional metadata to their notifications.
   Meta? get meta => _value['_meta'] as Meta?;
@@ -381,195 +381,232 @@ extension type PaginatedResult._fromMap(Map<String, Object?> _value)
   Cursor? get cursor => _value['cursor'] as Cursor?;
 }
 
-// /* Resources */
-// /**
-//  * Sent from the client to request a list of resources the server has.
-//  */
-// export interface ListResourcesRequest extends PaginatedRequest {
-//   method: "resources/list";
-// }
+/// Sent from the client to request a list of resources the server has.
+extension type ListResourcesRequest.fromMap(Map<String, Object?> _value)
+    implements PaginatedRequest {
+  static const methodName = 'resources/list';
 
-// /**
-//  * The server's response to a resources/list request from the client.
-//  */
-// export interface ListResourcesResult extends PaginatedResult {
-//   resources: Resource[];
-// }
+  factory ListResourcesRequest({Cursor? cursor, Meta? meta}) =>
+      ListResourcesRequest.fromMap({
+        if (cursor != null) 'cursor': cursor,
+        if (meta != null) '_meta': meta,
+      });
+}
 
-// /**
-//  * Sent from the client to request a list of resource templates the server
-//  * has.
-//  */
-// export interface ListResourceTemplatesRequest extends PaginatedRequest {
-//   method: "resources/templates/list";
-// }
+/// The server's response to a resources/list request from the client.
+extension type ListResourcesResult.fromMap(Map<String, Object?> _value)
+    implements PaginatedResult {
+  factory ListResourcesResult({
+    required List<Resource> resources,
+    Cursor? cursor,
+    Meta? meta,
+  }) => ListResourcesResult.fromMap({
+    'resources': resources,
+    if (cursor != null) 'cursor': cursor,
+    if (meta != null) '_meta': meta,
+  });
 
-// /**
-//  * The server's response to a resources/templates/list request from the client.
-//  */
-// export interface ListResourceTemplatesResult extends PaginatedResult {
-//   resourceTemplates: ResourceTemplate[];
-// }
+  List<Resource> get resources =>
+      (_value['resources'] as List).cast<Resource>();
+}
 
-// /**
-//  * Sent from the client to the server, to read a specific resource URI.
-//  */
-// export interface ReadResourceRequest extends Request {
-//   method: "resources/read";
-//   params: {
-//     /**
-//      * The URI of the resource to read. The URI can use any protocol; it is
-//      * up to the server how to interpret it.
-//      *
-//      * @format uri
-//      */
-//     uri: string;
-//   };
-// }
+/// Sent from the client to request a list of resource templates the server
+/// has.
+extension type ListResourceTemplatesRequest.fromMap(Map<String, Object?> _value)
+    implements PaginatedRequest {
+  static const methodName = 'resources/templates/list';
 
-// /**
-//  * The server's response to a resources/read request from the client.
-//  */
-// export interface ReadResourceResult extends Result {
-//   contents: (TextResourceContents | BlobResourceContents)[];
-// }
+  factory ListResourceTemplatesRequest({Cursor? cursor, Meta? meta}) =>
+      ListResourceTemplatesRequest.fromMap({
+        if (cursor != null) 'cursor': cursor,
+        if (meta != null) '_meta': meta,
+      });
+}
 
-// /**
-//  * An optional notification from the server to the client, informing it that
-//  * the list of resources it can read from has changed. This may be issued by
-//  * servers without any previous subscription from the client.
-//  */
-// export interface ResourceListChangedNotification extends Notification {
-//   method: "notifications/resources/list_changed";
-// }
+/// The server's response to a resources/templates/list request from the client.
+extension type ListResourceTemplatesResult.fromMap(Map<String, Object?> _value)
+    implements PaginatedResult {
+  factory ListResourceTemplatesResult({
+    required List<ResourceTemplate> resourceTemplates,
+    Cursor? cursor,
+    Meta? meta,
+  }) => ListResourceTemplatesResult.fromMap({
+    'resourceTemplates': resourceTemplates,
+    if (cursor != null) 'cursor': cursor,
+    if (meta != null) '_meta': meta,
+  });
 
-// /**
-//  * Sent from the client to request resources/updated notifications from the
-//  * server whenever a particular resource changes.
-//  */
-// export interface SubscribeRequest extends Request {
-//   method: "resources/subscribe";
-//   params: {
-//     /**
-//      * The URI of the resource to subscribe to. The URI can use any protocol;
-//      * it is up to the server how to interpret it.
-//      *
-//      * @format uri
-//      */
-//     uri: string;
-//   };
-// }
+  List<ResourceTemplate> get resourceTemplates =>
+      (_value['resourceTemplates'] as List).cast<ResourceTemplate>();
+}
 
-// /**
-//  * Sent from the client to request cancellation of resources/updated
-//  * notifications from the server. This should follow a previous
-//  * resources/subscribe request.
-//  */
-// export interface UnsubscribeRequest extends Request {
-//   method: "resources/unsubscribe";
-//   params: {
-//     /**
-//      * The URI of the resource to unsubscribe from.
-//      *
-//      * @format uri
-//      */
-//     uri: string;
-//   };
-// }
+/// Sent from the client to the server, to read a specific resource URI.
+extension type ReadResourceRequest.fromMap(Map<String, Object?> _value)
+    implements Request {
+  static const methodName = 'resources/read';
 
-// /**
-//  * A notification from the server to the client, informing it that a resource
-//  * has changed and may need to be read again. This should only be sent if the
-//  * client previously sent a resources/subscribe request.
-//  */
-// export interface ResourceUpdatedNotification extends Notification {
-//   method: "notifications/resources/updated";
-//   params: {
-//     /**
-//      * The URI of the resource that has been updated. This might be a
-//      * sub-resource of the one that the client actually subscribed to.
-//      *
-//      * @format uri
-//      */
-//     uri: string;
-//   };
-// }
+  factory ReadResourceRequest({required String uri, Meta? meta}) =>
+      ReadResourceRequest.fromMap({
+        'uri': uri,
+        if (meta != null) '_meta': meta,
+      });
 
-// /**
-//  * A known resource that the server is capable of reading.
-//  */
-// export interface Resource extends Annotated {
-//   /**
-//    * The URI of this resource.
-//    *
-//    * @format uri
-//    */
-//   uri: string;
+  /// The URI of the resource to read. The URI can use any protocol; it is
+  /// up to the server how to interpret it.
+  String get uri => _value['uri'] as String;
+}
 
-//   /**
-//    * A human-readable name for this resource.
-//    *
-//    * This can be used by clients to populate UI elements.
-//    */
-//   name: string;
+/// The server's response to a resources/read request from the client.
+extension type ReadResourceResult.fromMap(Map<String, Object?> _value)
+    implements Result {
+  factory ReadResourceResult({
+    required List<ResourceContents> contents,
+    Meta? meta,
+  }) => ReadResourceResult.fromMap({
+    'contents': contents,
+    if (meta != null) '_meta': meta,
+  });
+}
 
-//   /**
-//    * A description of what this resource represents.
-//    *
-//    * This can be used by clients to improve the LLM's understanding of
-//    * available resources. It can be thought of like a "hint" to the model.
-//    */
-//   description?: string;
+/// An optional notification from the server to the client, informing it that
+/// the list of resources it can read from has changed. This may be issued by
+/// servers without any previous subscription from the client.
+extension type ResourceListChangedNotification.fromMap(
+  Map<String, Object?> _value
+)
+    implements Notification {
+  static const methodName = 'notifications/resources/list_changed';
 
-//   /**
-//    * The MIME type of this resource, if known.
-//    */
-//   mimeType?: string;
+  factory ResourceListChangedNotification({Meta? meta}) =>
+      ResourceListChangedNotification.fromMap({
+        if (meta != null) '_meta': meta,
+      });
+}
 
-//   /**
-//    * The size of the raw resource content, in bytes (i.e., before base64
-//    * encoding or any tokenization), if known.
-//    *
-//    * This can be used by Hosts to display file sizes and estimate context
-//    * window usage.
-//    */
-//   size?: number;
-// }
+/// Sent from the client to request resources/updated notifications from the
+/// server whenever a particular resource changes.
+extension type SubscribeRequest.fromMap(Map<String, Object?> _value)
+    implements Request {
+  static const methodName = 'resources/subscribe';
 
-// /**
-//  * A template description for resources available on the server.
-//  */
-// export interface ResourceTemplate extends Annotated {
-//   /**
-//    * A URI template (according to RFC 6570) that can be used to construct
-//    * resource URIs.
-//    *
-//    * @format uri-template
-//    */
-//   uriTemplate: string;
+  factory SubscribeRequest({required String uri, Meta? meta}) =>
+      SubscribeRequest.fromMap({'uri': uri, if (meta != null) '_meta': meta});
 
-//   /**
-//    * A human-readable name for the type of resource this template refers to.
-//    *
-//    * This can be used by clients to populate UI elements.
-//    */
-//   name: string;
+  /// The URI of the resource to subscribe to. The URI can use any protocol;
+  /// it is up to the server how to interpret it.
+  String get uri => _value['uri'] as String;
+}
 
-//   /**
-//    * A description of what this template is for.
-//    *
-//    * This can be used by clients to improve the LLM's understanding of
-//    * available resources. It can be thought of like a "hint" to the model.
-//    */
-//   description?: string;
+///  Sent from the client to request cancellation of resources/updated
+/// notifications from the server. This should follow a previous
+/// resources/subscribe request.
+extension type UnsubscribeRequest.fromMap(Map<String, Object?> _value)
+    implements Request {
+  static const methodName = 'resources/unsubscribe';
 
-//   /**
-//    * The MIME type for all resources that match this template. This should
-//    * only be included if all resources matching this template have the same
-//    * type.
-//    */
-//   mimeType?: string;
-// }
+  factory UnsubscribeRequest({required String uri, Meta? meta}) =>
+      UnsubscribeRequest.fromMap({'uri': uri, if (meta != null) '_meta': meta});
+
+  /// The URI of the resource to unsubscribe from.
+  String get uri => _value['uri'] as String;
+}
+
+/// A notification from the server to the client, informing it that a resource
+/// has changed and may need to be read again. This should only be sent if the
+/// client previously sent a resources/subscribe request.
+extension type ResourceUpdatedNotification.fromMap(Map<String, Object?> _value)
+    implements Notification {
+  static const methodName = 'notifications/resources/updated';
+
+  factory ResourceUpdatedNotification({required String uri, Meta? meta}) =>
+      ResourceUpdatedNotification.fromMap({
+        'uri': uri,
+        if (meta != null) '_meta': meta,
+      });
+
+  /// The URI of the resource that has been updated. This might be a
+  /// sub-resource of the one that the client actually subscribed to.
+  String get uri => _value['uri'] as String;
+}
+
+///  A known resource that the server is capable of reading.
+//
+// TODO: Implement Annotated
+extension type Resource.fromMap(Map<String, Object?> _value) {
+  factory Resource({
+    required String uri,
+    required String name,
+    String? description,
+    String? mimeType,
+    int? size,
+  }) => Resource.fromMap({
+    'uri': uri,
+    'name': name,
+    if (description != null) 'description': description,
+    if (mimeType != null) 'mimeType': mimeType,
+    if (size != null) 'size': size,
+  });
+
+  /// The URI of this resource.
+  String get uri => _value['uri'] as String;
+
+  /// A human-readable name for this resource.
+  ///
+  /// This can be used by clients to populate UI elements.
+  String get name => _value['name'] as String;
+
+  /// A description of what this resource represents.
+  ///
+  /// This can be used by clients to improve the LLM's understanding of
+  /// available resources. It can be thought of like a "hint" to the model.
+  String? get description => _value['description'] as String?;
+
+  /// The MIME type of this resource, if known.
+  String? get mimeType => _value['mimeType'] as String?;
+
+  /// The size of the raw resource content, in bytes (i.e., before base64
+  /// encoding or any tokenization), if known.
+  ///
+  /// This can be used by Hosts to display file sizes and estimate context
+  /// window usage.
+  int? get size => _value['size'] as int;
+}
+
+/// A template description for resources available on the server.
+// TODO: implement Annotated
+extension type ResourceTemplate.fromMap(Map<String, Object?> _value) {
+  factory ResourceTemplate({
+    required String uriTemplate,
+    required String name,
+    String? description,
+    String? mimeType,
+  }) => ResourceTemplate.fromMap({
+    'uriTemplate': uriTemplate,
+    'name': name,
+    if (description != null) 'description': description,
+    if (mimeType != null) 'mimeType': mimeType,
+  });
+
+  /// A URI template (according to RFC 6570) that can be used to construct
+  /// resource URIs.
+  String get uriTemplate => _value['uriTemplate'] as String;
+
+  /// A human-readable name for the type of resource this template refers to.
+  ///
+  /// This can be used by clients to populate UI elements.
+  String get name => _value['name'] as String;
+
+  /// A description of what this template is for.
+  ///
+  /// This can be used by clients to improve the LLM's understanding of
+  /// available resources. It can be thought of like a "hint" to the model.
+  String? get description => _value['description'] as String?;
+
+  /// The MIME type for all resources that match this template. This should
+  /// only be included if all resources matching this template have the same
+  /// type.
+  String? get mimeType => _value['mimeType'] as String?;
+}
 
 // /* Prompts */
 // /**
@@ -823,12 +860,15 @@ extension type EmbeddedResource.fromMap(Map<String, Object?> _value)
 }
 
 /// Base class for the contents of a specific resource or sub-resource.
-extension type ResourceContentsResult.fromMap(Map<String, Object?> _value) {
-  factory ResourceContentsResult({required String uri, String? mimeType}) =>
-      ResourceContentsResult.fromMap({
-        'uri': uri,
-        if (mimeType != null) 'mimeType': mimeType,
-      });
+///
+/// Could be either [TextResourceContents] or [BlobResourceContents],
+/// use [isText] and [isBlob] before casting to the more specific type.
+extension type ResourceContents.fromMap(Map<String, Object?> _value) {
+  /// Whether or not this represents [TextResourceContents].
+  bool get isText => _value.containsKey('text');
+
+  /// Whether or not this represents [BlobResourceContents].
+  bool get isBlob => _value.containsKey('blob');
 
   /// The URI of this resource.
   String get uri => _value['uri'] as String;
@@ -837,9 +877,9 @@ extension type ResourceContentsResult.fromMap(Map<String, Object?> _value) {
   String? get mimeType => _value['mimeType'] as String?;
 }
 
-/// A [ResourceContentsResult] that contains text.
+/// A [ResourceContents] that contains text.
 extension type TextResourceContents.fromMap(Map<String, Object?> _value)
-    implements ResourceContentsResult {
+    implements ResourceContents {
   factory TextResourceContents({
     required String uri,
     required String text,
@@ -855,9 +895,9 @@ extension type TextResourceContents.fromMap(Map<String, Object?> _value)
   String get text => _value['text'] as String;
 }
 
-/// A [ResourceContentsResult] that contains binary data encoded as base64.
+/// A [ResourceContents] that contains binary data encoded as base64.
 extension type BlobResourceContents.fromMap(Map<String, Object?> _value)
-    implements ResourceContentsResult {
+    implements ResourceContents {
   factory BlobResourceContents({
     required String uri,
     required String blob,

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -105,4 +105,24 @@ class ServerConnection {
           .cast(),
     );
   }
+
+  /// Lists all the resources from this server.
+  Future<ListResourcesResult> listResources(
+    ListResourcesRequest request,
+  ) async {
+    return ListResourcesResult.fromMap(
+      ((await _peer.sendRequest(ListResourcesRequest.methodName, request))
+              as Map)
+          .cast(),
+    );
+  }
+
+  /// Reads a [Resource] returned from the [ListResourcesResult].
+  Future<ReadResourceResult> readResource(ReadResourceRequest request) async {
+    return ReadResourceResult.fromMap(
+      ((await _peer.sendRequest(ReadResourceRequest.methodName, request))
+              as Map)
+          .cast(),
+    );
+  }
 }

--- a/pkgs/dart_mcp/lib/src/server/resources_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/resources_support.dart
@@ -1,0 +1,168 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+part of 'server.dart';
+
+/// A mixin for MCP servers which support the `resources` capability.
+///
+/// Servers should add resources using the [addResource] method, typically
+/// inside the [initialize] method, but they may also be added after
+/// initialization if needed.
+///
+/// Resources can later be removed using [removeResource], or the client can be
+/// notified of updates using [updateResource].
+///
+/// Clients will be notified automatically of resource changes.
+///
+/// See https://modelcontextprotocol.io/docs/concepts/resources.
+mixin ResourcesSupport on MCPServer {
+  /// The current resources by URI.
+  final Map<String, Resource> _resources = {};
+
+  /// The current resource implementations by URI.
+  final Map<String, FutureOr<ReadResourceResult> Function(ReadResourceRequest)>
+  _resourceImpls = {};
+
+  /// The list of currently subscribed resources by URI.
+  final Set<String> _subscribedResources = {};
+
+  /// Invoked by the client as a part of initialization.
+  ///
+  /// Resources should usually be added in this function using [addResource]
+  /// when possible.
+  ///
+  /// If resources are added, updated, or removed after [initialized] completes,
+  /// then the client will be notified of the changes based on their
+  /// subscription preferences.
+  @override
+  FutureOr<InitializeResult> initialize(InitializeRequest request) async {
+    _peer.registerMethod(
+      ListResourcesRequest.methodName,
+      convertParameters(_listResources),
+    );
+
+    _peer.registerMethod(
+      ReadResourceRequest.methodName,
+      convertParameters(_readResource),
+    );
+
+    _peer.registerMethod(
+      SubscribeRequest.methodName,
+      convertParameters(_subscribeResource),
+    );
+    _peer.registerMethod(
+      UnsubscribeRequest.methodName,
+      convertParameters(_unsubscribeResource),
+    );
+
+    var result = await super.initialize(request);
+    (result.capabilities.resources ??= Resources())
+      ..listChanged = true
+      ..subscribe = true;
+    return result;
+  }
+
+  /// Register [resource] to call [impl] when invoked.
+  ///
+  /// If this server is already initialized and still connected to a client,
+  /// then the client will be notified that the resources list has changed.
+  ///
+  /// Throws a [StateError] if there is already a [Tool] registered with the
+  /// same name.
+  void addResource(
+    Resource resource,
+    FutureOr<ReadResourceResult> Function(ReadResourceRequest) impl,
+  ) {
+    if (_resources.containsKey(resource.uri)) {
+      throw StateError(
+        'Failed to add resource ${resource.name}, there is already a '
+        'resource that exists at the URI ${resource.uri}.',
+      );
+    }
+    _resources[resource.uri] = resource;
+    _resourceImpls[resource.uri] = impl;
+
+    if (ready) {
+      _notifyResourceListChanged();
+    }
+  }
+
+  /// Notifies the client that [resource] has been updated.
+  ///
+  /// The implementation of that resource can optionally be updated, otherwise
+  /// the previous implementation will be used.
+  ///
+  /// Throws a [StateError] if [resource] does not exist.
+  void updateResource(
+    Resource resource, {
+    FutureOr<ReadResourceResult> Function(ReadResourceRequest)? impl,
+  }) {
+    if (!_resources.containsKey(resource.uri)) {
+      throw StateError(
+        'Failed to update resource ${resource.name}, there is no resource '
+        'at the URI ${resource.uri}, you must add it first using addResource.',
+      );
+    }
+    if (impl != null) _resourceImpls[resource.uri] = impl;
+
+    if (_subscribedResources.contains(resource.uri)) {
+      _peer.sendNotification(
+        ResourceUpdatedNotification.methodName,
+        ResourceUpdatedNotification(uri: resource.uri),
+      );
+    }
+  }
+
+  /// Removes a [Resource] by [uri].
+  ///
+  /// Does not error if the resource hasn't been added yet.
+  void removeResource(String uri) {
+    _resources.remove(uri);
+    _resourceImpls.remove(uri);
+    if (ready) _notifyResourceListChanged();
+  }
+
+  /// Lists all the resources currently available.
+  ListResourcesResult _listResources(ListResourcesRequest request) {
+    return ListResourcesResult(
+      resources: [for (var resource in _resources.values) resource],
+    );
+  }
+
+  /// Reads the resource at `request.uri`.
+  ///
+  /// Throws an [ArgumentError] if it does not exist (this gets translated into
+  /// a generic JSON RPC2 error response).
+  FutureOr<ReadResourceResult> _readResource(ReadResourceRequest request) {
+    final impl = _resourceImpls[request.uri];
+    if (impl == null) {
+      throw ArgumentError.value(request.uri, 'uri', 'Resource not found');
+    }
+
+    return impl(request);
+  }
+
+  /// Subscribes the client to the resource at `request.uri`.
+  void _subscribeResource(SubscribeRequest request) async {
+    // We can't return an error as there is no response, so we just don't do
+    // anything.
+    if (!_resources.containsKey(request.uri)) return;
+
+    _subscribedResources.add(request.uri);
+  }
+
+  /// Unsubscribes the client to the resource at `request.uri`.
+  void _unsubscribeResource(UnsubscribeRequest request) async {
+    _subscribedResources.remove(request.uri);
+  }
+
+  /// Called whenever the list of resources changes, it is the job of the client
+  /// to then ask again for the list of tools.
+  void _notifyResourceListChanged() {
+    _peer.sendNotification(
+      ResourceListChangedNotification.methodName,
+      ResourceListChangedNotification(),
+    );
+  }
+}

--- a/pkgs/dart_mcp/lib/src/server/resources_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/resources_support.dart
@@ -13,7 +13,8 @@ part of 'server.dart';
 /// Resources can later be removed using [removeResource], or the client can be
 /// notified of updates using [updateResource].
 ///
-/// Clients will be notified automatically of resource changes.
+/// Implements the `subscribe` and `listChanges` capabilities for clients, so
+/// they can be notified of changes to resources.
 ///
 /// See https://modelcontextprotocol.io/docs/concepts/resources.
 mixin ResourcesSupport on MCPServer {
@@ -125,9 +126,7 @@ mixin ResourcesSupport on MCPServer {
 
   /// Lists all the resources currently available.
   ListResourcesResult _listResources(ListResourcesRequest request) {
-    return ListResourcesResult(
-      resources: [for (var resource in _resources.values) resource],
-    );
+    return ListResourcesResult(resources: _resources.values.toList());
   }
 
   /// Reads the resource at `request.uri`.

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -17,7 +17,7 @@ part 'resources_support.dart';
 /// Base class to extend when implementing an MCP server.
 ///
 /// Actual functionality beyond server initialization is done by mixing in
-/// additional support mixins such as [ToolsSupport], [ResourceSupport] etc.
+/// additional support mixins such as [ToolsSupport], [ResourcesSupport] etc.
 abstract class MCPServer {
   /// Completes when this server has finished initialization and gotten the
   /// final ack from the client.
@@ -43,8 +43,11 @@ abstract class MCPServer {
       InitializeRequest.methodName,
       convertParameters(initialize),
     );
-    var x = convertParameters(handleInitialized);
-    _peer.registerMethod(InitializedNotification.methodName, x);
+
+    _peer.registerMethod(
+      InitializedNotification.methodName,
+      convertParameters(handleInitialized),
+    );
 
     _peer.listen();
   }

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -12,11 +12,12 @@ import '../api.dart';
 import '../util.dart';
 
 part 'tools_support.dart';
+part 'resources_support.dart';
 
 /// Base class to extend when implementing an MCP server.
 ///
 /// Actual functionality beyond server initialization is done by mixing in
-/// additional support mixins such as [ToolsSupport] etc.
+/// additional support mixins such as [ToolsSupport], [ResourceSupport] etc.
 abstract class MCPServer {
   /// Completes when this server has finished initialization and gotten the
   /// final ack from the client.

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -11,6 +11,8 @@ import 'package:stream_channel/stream_channel.dart';
 import '../api.dart';
 import '../util.dart';
 
+part 'tools_support.dart';
+
 /// Base class to extend when implementing an MCP server.
 ///
 /// Actual functionality beyond server initialization is done by mixing in
@@ -65,109 +67,5 @@ abstract class MCPServer {
   @mustCallSuper
   void handleInitialized(InitializedNotification notification) {
     _initialized.complete();
-  }
-}
-
-/// A mixin for MCP servers which support the `tools` capability.
-///
-/// Servers should register tools using the [registerTool] method, typically
-/// inside the [initialize] method, but they may also be registered after
-/// initialization if needed.
-mixin ToolsSupport on MCPServer {
-  /// The registered tools by name.
-  final Map<String, Tool> _registeredTools = {};
-
-  /// The registered tool implementations by name.
-  final Map<String, FutureOr<CallToolResult> Function(CallToolRequest)>
-  _registeredToolImpls = {};
-
-  /// Invoked by the client as a part of initialization.
-  ///
-  /// Tools should usually be registered in this function using [registerTool]
-  /// when possible.
-  ///
-  /// If tools are registered after [initialized] completes, then the server
-  /// will notify the client
-  @override
-  FutureOr<InitializeResult> initialize(InitializeRequest request) async {
-    _peer.registerMethod(
-      ListToolsRequest.methodName,
-      convertParameters(_listTools),
-    );
-
-    _peer.registerMethod(
-      CallToolRequest.methodName,
-      convertParameters(_callTool),
-    );
-    var result = await super.initialize(request);
-    (result.capabilities.tools ??= Tools()).listChanged = true;
-    return result;
-  }
-
-  /// Register [tool] to call [impl] when invoked.
-  ///
-  /// If this server is already initialized and still connected to a client,
-  /// then the client will be notified that the tools list has changed.
-  ///
-  /// Throws a [StateError] if there is already a [Tool] registered with the
-  /// same name.
-  void registerTool(
-    Tool tool,
-    FutureOr<CallToolResult> Function(CallToolRequest) impl,
-  ) {
-    if (_registeredTools.containsKey(tool.name)) {
-      throw StateError(
-        'Failed to register tool ${tool.name}, it is already registered',
-      );
-    }
-    _registeredTools[tool.name] = tool;
-    _registeredToolImpls[tool.name] = impl;
-
-    if (ready) {
-      _notifyToolListChanged();
-    }
-  }
-
-  /// Un-registers a [Tool] by [name].
-  ///
-  /// Does not error if the tool hasn't been registered yet.
-  void unregisterTool(String name) {
-    _registeredTools.remove(name);
-    _registeredToolImpls.remove(name);
-  }
-
-  /// Returns the list of supported tools for this server.
-  ListToolsResult _listTools(ListToolsRequest request) =>
-      ListToolsResult(tools: [for (var tool in _registeredTools.values) tool]);
-
-  /// Invoked when one of the registered tools is called.
-  Future<CallToolResult> _callTool(CallToolRequest request) async {
-    final impl = _registeredToolImpls[request.name];
-    if (impl == null) {
-      return CallToolResult(
-        isError: true,
-        content: [
-          TextContent(text: 'No tool registered with the name ${request.name}'),
-        ],
-      );
-    }
-
-    try {
-      return await impl(request);
-    } catch (e, s) {
-      return CallToolResult(
-        isError: true,
-        content: [TextContent(text: '$e\n$s')],
-      );
-    }
-  }
-
-  /// Called whenever the list of tools changes, it is the job of the client to
-  /// then ask again for the list of tools.
-  void _notifyToolListChanged() {
-    _peer.sendNotification(
-      ToolListChangedNotification.methodName,
-      ToolListChangedNotification(),
-    );
   }
 }

--- a/pkgs/dart_mcp/lib/src/server/tools_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/tools_support.dart
@@ -1,0 +1,109 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+part of 'server.dart';
+
+/// A mixin for MCP servers which support the `tools` capability.
+///
+/// Servers should register tools using the [registerTool] method, typically
+/// inside the [initialize] method, but they may also be registered after
+/// initialization if needed.
+mixin ToolsSupport on MCPServer {
+  /// The registered tools by name.
+  final Map<String, Tool> _registeredTools = {};
+
+  /// The registered tool implementations by name.
+  final Map<String, FutureOr<CallToolResult> Function(CallToolRequest)>
+  _registeredToolImpls = {};
+
+  /// Invoked by the client as a part of initialization.
+  ///
+  /// Tools should usually be registered in this function using [registerTool]
+  /// when possible.
+  ///
+  /// If tools are registered after [initialized] completes, then the server
+  /// will notify the client
+  @override
+  FutureOr<InitializeResult> initialize(InitializeRequest request) async {
+    _peer.registerMethod(
+      ListToolsRequest.methodName,
+      convertParameters(_listTools),
+    );
+
+    _peer.registerMethod(
+      CallToolRequest.methodName,
+      convertParameters(_callTool),
+    );
+    var result = await super.initialize(request);
+    (result.capabilities.tools ??= Tools()).listChanged = true;
+    return result;
+  }
+
+  /// Register [tool] to call [impl] when invoked.
+  ///
+  /// If this server is already initialized and still connected to a client,
+  /// then the client will be notified that the tools list has changed.
+  ///
+  /// Throws a [StateError] if there is already a [Tool] registered with the
+  /// same name.
+  void registerTool(
+    Tool tool,
+    FutureOr<CallToolResult> Function(CallToolRequest) impl,
+  ) {
+    if (_registeredTools.containsKey(tool.name)) {
+      throw StateError(
+        'Failed to register tool ${tool.name}, it is already registered',
+      );
+    }
+    _registeredTools[tool.name] = tool;
+    _registeredToolImpls[tool.name] = impl;
+
+    if (ready) {
+      _notifyToolListChanged();
+    }
+  }
+
+  /// Un-registers a [Tool] by [name].
+  ///
+  /// Does not error if the tool hasn't been registered yet.
+  void unregisterTool(String name) {
+    _registeredTools.remove(name);
+    _registeredToolImpls.remove(name);
+  }
+
+  /// Returns the list of supported tools for this server.
+  ListToolsResult _listTools(ListToolsRequest request) =>
+      ListToolsResult(tools: [for (var tool in _registeredTools.values) tool]);
+
+  /// Invoked when one of the registered tools is called.
+  Future<CallToolResult> _callTool(CallToolRequest request) async {
+    final impl = _registeredToolImpls[request.name];
+    if (impl == null) {
+      return CallToolResult(
+        isError: true,
+        content: [
+          TextContent(text: 'No tool registered with the name ${request.name}'),
+        ],
+      );
+    }
+
+    try {
+      return await impl(request);
+    } catch (e, s) {
+      return CallToolResult(
+        isError: true,
+        content: [TextContent(text: '$e\n$s')],
+      );
+    }
+  }
+
+  /// Called whenever the list of tools changes, it is the job of the client to
+  /// then ask again for the list of tools.
+  void _notifyToolListChanged() {
+    _peer.sendNotification(
+      ToolListChangedNotification.methodName,
+      ToolListChangedNotification(),
+    );
+  }
+}

--- a/pkgs/dart_mcp/lib/src/server/tools_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/tools_support.dart
@@ -9,6 +9,8 @@ part of 'server.dart';
 /// Servers should register tools using the [registerTool] method, typically
 /// inside the [initialize] method, but they may also be registered after
 /// initialization if needed.
+///
+/// See https://modelcontextprotocol.io/docs/concepts/tools.
 mixin ToolsSupport on MCPServer {
   /// The registered tools by name.
   final Map<String, Tool> _registeredTools = {};

--- a/pkgs/dart_mcp/lib/src/util.dart
+++ b/pkgs/dart_mcp/lib/src/util.dart
@@ -4,12 +4,10 @@
 
 import 'package:json_rpc_2/json_rpc_2.dart';
 
-import 'api.dart';
-
 /// Wraps [wrapped] with a function that takes a [Parameters] object, extracts
 /// out the value of that object as a `Map<String, Object?>`, casts it to type
 /// [T], and then calls [wrapped] with that value and returns the result.
-R Function(Parameters) convertParameters<T extends Request, R extends Object?>(
+R Function(Parameters) convertParameters<T extends Object?, R extends Object?>(
   R Function(T) wrapped,
 ) =>
     (Parameters p) => wrapped(

--- a/pkgs/dart_mcp/test/client_and_server_test.dart
+++ b/pkgs/dart_mcp/test/client_and_server_test.dart
@@ -2,107 +2,30 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
-import 'package:async/async.dart';
 import 'package:dart_mcp/client.dart';
 import 'package:dart_mcp/server.dart';
-import 'package:stream_channel/stream_channel.dart';
+import 'package:json_rpc_2/error_code.dart';
+import 'package:json_rpc_2/json_rpc_2.dart';
 
 import 'package:test/test.dart';
 
+import 'test_utils.dart';
+
 void main() {
   test('client and server can communicate', () async {
-    final clientController = StreamController<String>.broadcast();
-    final serverController = StreamController<String>.broadcast();
+    var environment = TestEnvironment(TestMCPClient(), TestMCPServer.new);
+    var initializeResult = await environment.initializeServer();
 
-    final clientChannel = StreamChannel<String>.withCloseGuarantee(
-      serverController.stream,
-      clientController.sink.transform(
-        StreamSinkTransformer.fromHandlers(
-          handleData: (data, sink) {
-            sink.add('$data\n');
-          },
-        ),
-      ),
-    );
-    final serverChannel = StreamChannel<String>.withCloseGuarantee(
-      clientController.stream,
-      serverController.sink.transform(
-        StreamSinkTransformer.fromHandlers(
-          handleData: (data, sink) {
-            sink.add('$data\n');
-          },
-        ),
-      ),
-    );
-
-    var client = TestMCPClient();
-    var server = TestMCPServer(serverChannel);
-    var serverConnection = client.connectServer('test server', clientChannel);
-
-    var initializeResult = await server.initialize(
-      InitializeRequest(
-        protocolVersion: protocolVersion,
-        capabilities: client.capabilities,
-        clientInfo: client.implementation,
-      ),
-    );
-
-    expect(initializeResult.capabilities.tools, isNot(null));
-    expect(initializeResult.instructions, server.instructions);
-
-    serverConnection.notifyInitialized(InitializedNotification());
-
+    expect(initializeResult.capabilities, isEmpty);
+    expect(initializeResult.instructions, environment.server.instructions);
     expect(initializeResult.protocolVersion, protocolVersion);
 
-    final toolsResult = await serverConnection.listTools();
-    expect(toolsResult.tools.length, 1);
-
-    final tool = toolsResult.tools.single;
-
-    final result = await serverConnection.callTool(
-      CallToolRequest(name: tool.name),
-    );
-    expect(result.isError, isNot(true));
     expect(
-      result.content.single,
-      isA<TextContent>().having((c) => c.text, 'text', equals('hello world!')),
+      environment.serverConnection.listTools(),
+      throwsA(
+        isA<RpcException>().having((e) => e.code, 'code', METHOD_NOT_FOUND),
+      ),
+      reason: 'Calling unsupported methods should throw',
     );
-
-    await client.shutdownServer('test server');
   });
-}
-
-class TestMCPClient extends MCPClient {
-  @override
-  final ClientCapabilities capabilities = ClientCapabilities();
-
-  @override
-  final ClientImplementation implementation = ClientImplementation(
-    name: 'test client',
-    version: '0.1.0',
-  );
-}
-
-class TestMCPServer extends MCPServer with ToolsSupport {
-  @override
-  final ServerImplementation implementation = ServerImplementation(
-    name: 'test server',
-    version: '0.1.0',
-  );
-
-  @override
-  final instructions = 'A test server';
-
-  TestMCPServer(super.channel) : super.fromStreamChannel();
-
-  @override
-  FutureOr<InitializeResult> initialize(InitializeRequest request) {
-    registerTool(
-      Tool(name: 'hello world', inputSchema: InputSchema()),
-      (_) => CallToolResult(content: [TextContent(text: 'hello world!')]),
-    );
-    return super.initialize(request);
-  }
 }

--- a/pkgs/dart_mcp/test/client_and_server_test.dart
+++ b/pkgs/dart_mcp/test/client_and_server_test.dart
@@ -6,7 +6,6 @@ import 'package:dart_mcp/client.dart';
 import 'package:dart_mcp/server.dart';
 import 'package:json_rpc_2/error_code.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';
-
 import 'package:test/test.dart';
 
 import 'test_utils.dart';

--- a/pkgs/dart_mcp/test/resources_support_test.dart
+++ b/pkgs/dart_mcp/test/resources_support_test.dart
@@ -1,0 +1,67 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:dart_mcp/server.dart';
+import 'package:test/test.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  test('client and server can communicate', () async {
+    var environment = TestEnvironment(
+      TestMCPClient(),
+      TestMCPServerWithResources.new,
+    );
+    final initializeResult = await environment.initializeServer();
+
+    expect(
+      initializeResult.capabilities.resources,
+      equals(Resources(listChanged: true, subscribe: true)),
+    );
+
+    final serverConnection = environment.serverConnection;
+
+    final resourcesResult = await serverConnection.listResources(
+      ListResourcesRequest(),
+    );
+    expect(resourcesResult.resources.length, 1);
+
+    final resource = resourcesResult.resources.single;
+
+    final result = await serverConnection.readResource(
+      ReadResourceRequest(uri: resource.uri),
+    );
+    expect(
+      result.contents.single,
+      isA<ResourceContents>()
+          .having((c) => c.isText, 'isText', true)
+          .having(
+            (c) => (c as TextResourceContents).text,
+            'text',
+            'hello world!',
+          ),
+    );
+  });
+}
+
+class TestMCPServerWithResources extends TestMCPServer with ResourcesSupport {
+  TestMCPServerWithResources(super.channel) : super();
+
+  @override
+  FutureOr<InitializeResult> initialize(InitializeRequest request) {
+    addResource(
+      helloWorld,
+      (_) => ReadResourceResult(
+        contents: [
+          TextResourceContents(text: 'hello world!', uri: helloWorld.uri),
+        ],
+      ),
+    );
+    return super.initialize(request);
+  }
+
+  static final helloWorld = Resource(name: 'hello world', uri: 'hello://world');
+}

--- a/pkgs/dart_mcp/test/test_utils.dart
+++ b/pkgs/dart_mcp/test/test_utils.dart
@@ -1,0 +1,106 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:async/async.dart';
+import 'package:dart_mcp/client.dart';
+import 'package:dart_mcp/server.dart';
+import 'package:stream_channel/stream_channel.dart';
+import 'package:test/test.dart';
+
+class TestEnvironment<Client extends MCPClient, Server extends MCPServer> {
+  /// The client side of the communication channel - the stream is the incoming
+  /// data and the sink is outgoing data.
+  final clientController = StreamController<String>();
+
+  /// The server side of the communication channel - the stream is the incoming
+  /// data and the sink is outgoing data.
+  final serverController = StreamController<String>();
+
+  late final clientChannel = StreamChannel<String>.withCloseGuarantee(
+    serverController.stream,
+    clientController.sink.transform(
+      StreamSinkTransformer.fromHandlers(
+        handleData: (data, sink) {
+          sink.add('$data\n');
+        },
+      ),
+    ),
+  );
+  late final serverChannel = StreamChannel<String>.withCloseGuarantee(
+    clientController.stream,
+    serverController.sink.transform(
+      StreamSinkTransformer.fromHandlers(
+        handleData: (data, sink) {
+          sink.add('$data\n');
+        },
+      ),
+    ),
+  );
+
+  final Client client;
+  late final Server server;
+  late final ServerConnection serverConnection;
+
+  /// Creates a [TestEnvironment], and adds a [tearDown] to shut it down
+  /// automatically.
+  ///
+  /// You may manually shut down the environment by calling [shutdown].
+  TestEnvironment(
+    this.client,
+    Server Function(StreamChannel<String>) createServer,
+  ) {
+    server = createServer(serverChannel);
+    serverConnection = client.connectServer(
+      server.implementation.name,
+      clientChannel,
+    );
+    addTearDown(shutdown);
+  }
+
+  /// Initializes the server and waits for it to receive the initialization
+  /// notification, then returns the original [InitializeResult] for tests
+  /// to inspect if desired.
+  Future<InitializeResult> initializeServer() async {
+    var initializeResult = await server.initialize(
+      InitializeRequest(
+        protocolVersion: protocolVersion,
+        capabilities: client.capabilities,
+        clientInfo: client.implementation,
+      ),
+    );
+    serverConnection.notifyInitialized(InitializedNotification());
+    await server.initialized;
+    return initializeResult;
+  }
+
+  Future<void> shutdown() async {
+    await client.shutdownServer(server.implementation.name);
+  }
+}
+
+class TestMCPClient extends MCPClient {
+  @override
+  final ClientCapabilities capabilities = ClientCapabilities();
+
+  @override
+  final ClientImplementation implementation = ClientImplementation(
+    name: 'test client',
+    version: '0.1.0',
+  );
+}
+
+class TestMCPServer extends MCPServer {
+  @override
+  final ServerImplementation implementation = ServerImplementation(
+    name: 'test server',
+    version: '0.1.0',
+  );
+
+  @override
+  final instructions = 'A test server';
+
+  TestMCPServer(super.channel) : super.fromStreamChannel();
+}

--- a/pkgs/dart_mcp/test/tools_support_test.dart
+++ b/pkgs/dart_mcp/test/tools_support_test.dart
@@ -1,0 +1,53 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:async/async.dart';
+import 'package:dart_mcp/client.dart';
+import 'package:dart_mcp/server.dart';
+import 'package:stream_channel/stream_channel.dart';
+
+import 'package:test/test.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  test('client and server can communicate', () async {
+    var environment = TestEnvironment(
+      TestMCPClient(),
+      TestMCPServerWithTools.new,
+    );
+    await environment.initializeServer();
+
+    final serverConnection = environment.serverConnection;
+
+    final toolsResult = await serverConnection.listTools();
+    expect(toolsResult.tools.length, 1);
+
+    final tool = toolsResult.tools.single;
+
+    final result = await serverConnection.callTool(
+      CallToolRequest(name: tool.name),
+    );
+    expect(result.isError, isNot(true));
+    expect(
+      result.content.single,
+      isA<TextContent>().having((c) => c.text, 'text', equals('hello world!')),
+    );
+  });
+}
+
+class TestMCPServerWithTools extends TestMCPServer with ToolsSupport {
+  TestMCPServerWithTools(super.channel) : super();
+
+  @override
+  FutureOr<InitializeResult> initialize(InitializeRequest request) {
+    registerTool(
+      Tool(name: 'hello world', inputSchema: InputSchema()),
+      (_) => CallToolResult(content: [TextContent(text: 'hello world!')]),
+    );
+    return super.initialize(request);
+  }
+}

--- a/pkgs/dart_mcp/test/tools_support_test.dart
+++ b/pkgs/dart_mcp/test/tools_support_test.dart
@@ -4,10 +4,7 @@
 
 import 'dart:async';
 
-import 'package:async/async.dart';
-import 'package:dart_mcp/client.dart';
 import 'package:dart_mcp/server.dart';
-import 'package:stream_channel/stream_channel.dart';
 
 import 'package:test/test.dart';
 
@@ -19,7 +16,11 @@ void main() {
       TestMCPClient(),
       TestMCPServerWithTools.new,
     );
-    await environment.initializeServer();
+    var initializeResult = await environment.initializeServer();
+    expect(
+      initializeResult.capabilities.tools,
+      equals(Tools(listChanged: true)),
+    );
 
     final serverConnection = environment.serverConnection;
 


### PR DESCRIPTION
- Adds support for [resources](https://modelcontextprotocol.io/docs/concepts/resources).
- Refactors some things to separate the mixin implementations out into separate files.
- Introduces a TestEnvironment to encapsulate the basic test setup.
