### PR TITLE
Add support for prompts

### DIFF
--- a/pkgs/dart_mcp/lib/src/api.dart
+++ b/pkgs/dart_mcp/lib/src/api.dart
@@ -722,6 +722,9 @@ extension type GetPromptResult.fromMap(Map<String, Object?> _value)
   /// An optional description for the prompt.
   String? get description => _value['description'] as String?;
 
+  /// All the messages in this prompt.
+  ///
+  /// Prompts may be entire conversation flows between users and assistants.
   List<PromptMessage> get messages =>
       (_value['messages'] as List).cast<PromptMessage>();
 }
@@ -781,15 +784,20 @@ extension type PromptMessage.fromMap(Map<String, Object?> _value) {
   factory PromptMessage({required Role role, required List<Content> content}) =>
       PromptMessage.fromMap({'role': role.name, 'content': content});
 
+  /// The expected [Role] for this message in the prompt (multi-message
+  /// prompt flows may outline a back and forth between users and assistants).
   Role get role =>
       Role.values.firstWhere((role) => role.name == _value['role']);
 
+  /// The content of the message, see [Content] docs for the possible types.
   Content get content => _value['content'] as Content;
 }
 
 /// An optional notification from the server to the client, informing it that
-/// the list of prompts it offers has changed. This may be issued by servers
-/// without any previous subscription from the client.
+/// the list of prompts it offers has changed.
+///
+/// This may be issued by servers without any previous subscription from the
+/// client.
 extension type PromptListChangedNotification.fromMap(
   Map<String, Object?> _value
 )
@@ -879,12 +887,15 @@ extension type Content._(Map<String, Object?> _value) {
   /// Whether or not this is a [ImageContent].
   bool get isImage => _value['type'] == ImageContent.expectedType;
 
+  /// Whether or not this is an [EmbeddedResource].
   bool get isEmbeddedResource =>
       _value['type'] == EmbeddedResource.expectedType;
 
-  /// The type of content, you can use this in a switch to handle various types
-  /// (see the the static `expectedType` getters), or you can use [isText],
-  /// [isImage], and [isEmbeddedResource] to determine the actual type.
+  /// The type of content.
+  ///
+  /// You can use this in a switch to handle the various types (see the static
+  /// `expectedType` getters), or you can use [isText], [isImage], and
+  /// [isEmbeddedResource] to determine the type and then do the cast.
   String get type => _value['type'] as String;
 }
 
@@ -1398,6 +1409,10 @@ extension type PromptReference.fromMap(Map<String, Object?> _value) {
   factory PromptReference({required String name}) =>
       PromptReference.fromMap({'name': name, 'type': expectedType});
 
+  /// This should always be [expectedType].
+  ///
+  /// This has a [type] because it exists as a part of a union type, so this
+  /// distinguishes it from other types.
   String get type {
     final type = _value['type'] as String;
     assert(type == expectedType);

--- a/pkgs/dart_mcp/lib/src/api.dart
+++ b/pkgs/dart_mcp/lib/src/api.dart
@@ -731,7 +731,7 @@ extension type Prompt.fromMap(Map<String, Object?> _value) {
   factory Prompt({
     required String name,
     String? description,
-    Map<String, Object?>? arguments,
+    List<PromptArgument>? arguments,
   }) => Prompt.fromMap({
     'name': name,
     if (description != null) 'description': description,

--- a/pkgs/dart_mcp/lib/src/api.dart
+++ b/pkgs/dart_mcp/lib/src/api.dart
@@ -646,110 +646,151 @@ extension type ResourceTemplate.fromMap(Map<String, Object?> _value) {
   String? get mimeType => _value['mimeType'] as String?;
 }
 
-// /* Prompts */
-// /**
-//  * Sent from the client to request a list of prompts and prompt templates the
-//  * server has.
-//  */
-// export interface ListPromptsRequest extends PaginatedRequest {
-//   method: "prompts/list";
-// }
+/// Sent from the client to request a list of prompts and prompt templates the
+/// server has.
+extension type ListPromptsRequest.fromMap(Map<String, Object?> _value)
+    implements PaginatedRequest {
+  static const methodName = 'prompts/list';
 
-// /**
-//  * The server's response to a prompts/list request from the client.
-//  */
-// export interface ListPromptsResult extends PaginatedResult {
-//   prompts: Prompt[];
-// }
+  factory ListPromptsRequest({Cursor? cursor, Meta? meta}) =>
+      ListPromptsRequest.fromMap({
+        if (cursor != null) 'cursor': cursor,
+        if (meta != null) '_meta': meta,
+      });
+}
 
-// /**
-//  * Used by the client to get a prompt provided by the server.
-//  */
-// export interface GetPromptRequest extends Request {
-//   method: "prompts/get";
-//   params: {
-//     /**
-//      * The name of the prompt or prompt template.
-//      */
-//     name: string;
-//     /**
-//      * Arguments to use for templating the prompt.
-//      */
-//     arguments?: { [key: string]: string };
-//   };
-// }
+/// The server's response to a prompts/list request from the client.
+extension type ListPromptsResult.fromMap(Map<String, Object?> _value)
+    implements PaginatedResult {
+  factory ListPromptsResult({
+    required List<Prompt> prompts,
+    Cursor? cursor,
+    Meta? meta,
+  }) => ListPromptsResult.fromMap({
+    'prompts': prompts,
+    if (cursor != null) 'cursor': cursor,
+    if (meta != null) '_meta': meta,
+  });
 
-// /**
-//  * The server's response to a prompts/get request from the client.
-//  */
-// export interface GetPromptResult extends Result {
-//   /**
-//    * An optional description for the prompt.
-//    */
-//   description?: string;
-//   messages: PromptMessage[];
-// }
+  List<Prompt> get prompts => (_value['prompts'] as List).cast<Prompt>();
+}
 
-// /**
-//  * A prompt or prompt template that the server offers.
-//  */
-// export interface Prompt {
-//   /**
-//    * The name of the prompt or prompt template.
-//    */
-//   name: string;
-//   /**
-//    * An optional description of what this prompt provides
-//    */
-//   description?: string;
-//   /**
-//    * A list of arguments to use for templating the prompt.
-//    */
-//   arguments?: PromptArgument[];
-// }
+/// Used by the client to get a prompt provided by the server.
+extension type GetPromptRequest.fromMap(Map<String, Object?> _value)
+    implements Request {
+  static const methodName = 'prompts/get';
 
-// /**
-//  * Describes an argument that a prompt can accept.
-//  */
-// export interface PromptArgument {
-//   /**
-//    * The name of the argument.
-//    */
-//   name: string;
-//   /**
-//    * A human-readable description of the argument.
-//    */
-//   description?: string;
-//   /**
-//    * Whether this argument must be provided.
-//    */
-//   required?: boolean;
-// }
+  factory GetPromptRequest({
+    required String name,
+    Map<String, Object?>? arguments,
+    Meta? meta,
+  }) => GetPromptRequest.fromMap({
+    'name': name,
+    if (arguments != null) 'arguments': arguments,
+    if (meta != null) '_meta': meta,
+  });
 
-// /**
-//  * The sender or recipient of messages and data in a conversation.
-//  */
-// export type Role = "user" | "assistant";
+  /// The name of the prompt or prompt template.
+  String get name => _value['name'] as String;
 
-// /**
-//  * Describes a message returned as part of a prompt.
-//  *
-//  * This is similar to `SamplingMessage`, but also supports the embedding of
-//  * resources from the MCP server.
-//  */
-// export interface PromptMessage {
-//   role: Role;
-//   content: TextContent | ImageContent | EmbeddedResource;
-// }
+  /// Arguments to use for templating the prompt.
+  Map<String, Object?>? get arguments =>
+      (_value['arguments'] as Map?)?.cast<String, Object?>();
+}
 
-// /**
-//  * An optional notification from the server to the client, informing it that
-//  * the list of prompts it offers has changed. This may be issued by servers
-//  * without any previous subscription from the client.
-//  */
-// export interface PromptListChangedNotification extends Notification {
-//   method: "notifications/prompts/list_changed";
-// }
+/// The server's response to a prompts/get request from the client.
+extension type GetPromptResult.fromMap(Map<String, Object?> _value)
+    implements Result {
+  factory GetPromptResult({
+    String? description,
+    required List<PromptMessage> messages,
+    Meta? meta,
+  }) => GetPromptResult.fromMap({
+    if (description != null) 'description': description,
+    'messages': messages,
+    if (meta != null) '_meta': meta,
+  });
+
+  /// An optional description for the prompt.
+  String? get description => _value['description'] as String?;
+
+  List<PromptMessage> get messages =>
+      (_value['messages'] as List).cast<PromptMessage>();
+}
+
+/// A prompt or prompt template that the server offers.
+extension type Prompt.fromMap(Map<String, Object?> _value) {
+  factory Prompt({
+    required String name,
+    String? description,
+    Map<String, Object?>? arguments,
+  }) => Prompt.fromMap({
+    'name': name,
+    if (description != null) 'description': description,
+    if (arguments != null) 'arguments': arguments,
+  });
+
+  /// The name of the prompt or prompt template.
+  String get name => _value['name'] as String;
+
+  /// An optional description of what this prompt provides.
+  String? get description => _value['description'] as String?;
+
+  /// A list of arguments to use for templating the prompt.
+  List<PromptArgument>? get arguments => (_value['arguments'] as List?)?.cast();
+}
+
+/// Describes an argument that a prompt can accept.
+extension type PromptArgument.fromMap(Map<String, Object?> _value) {
+  factory PromptArgument({
+    required String name,
+    String? description,
+    bool? required,
+  }) => PromptArgument.fromMap({
+    'name': name,
+    if (description != null) 'description': description,
+    if (required != null) 'required': required,
+  });
+
+  /// The name of the argument.
+  String get name => _value['name'] as String;
+
+  /// A human-readable description of the argument.
+  String? get description => _value['description'] as String?;
+
+  /// Whether this argument must be provided.
+  bool? get required => _value['required'] as bool?;
+}
+
+/// The sender or recipient of messages and data in a conversation.
+enum Role { user, assistant }
+
+/// Describes a message returned as part of a prompt.
+///
+/// This is similar to `SamplingMessage`, but also supports the embedding of
+/// resources from the MCP server.
+extension type PromptMessage.fromMap(Map<String, Object?> _value) {
+  factory PromptMessage({required Role role, required List<Content> content}) =>
+      PromptMessage.fromMap({'role': role.name, 'content': content});
+
+  Role get role =>
+      Role.values.firstWhere((role) => role.name == _value['role']);
+
+  Content get content => _value['content'] as Content;
+}
+
+/// An optional notification from the server to the client, informing it that
+/// the list of prompts it offers has changed. This may be issued by servers
+/// without any previous subscription from the client.
+extension type PromptListChangedNotification.fromMap(
+  Map<String, Object?> _value
+)
+    implements Notification {
+  static const methodName = 'notifications/prompts/list_changed';
+
+  factory PromptListChangedNotification({Meta? meta}) =>
+      PromptListChangedNotification.fromMap({if (meta != null) '_meta': meta});
+}
 
 /// Sent from the client to request a list of tools the server has.
 extension type ListToolsRequest.fromMap(Map<String, Object?> _value)
@@ -793,7 +834,7 @@ extension type CallToolResult.fromMap(Map<String, Object?> _value)
     implements Result {
   factory CallToolResult({
     Meta? meta,
-    required List<UnionType> content,
+    required List<Content> content,
     bool? isError,
   }) => CallToolResult.fromMap({
     'content': content,
@@ -803,7 +844,7 @@ extension type CallToolResult.fromMap(Map<String, Object?> _value)
 
   /// The type of content, either [TextContent], [ImageContent],
   /// or [EmbeddedResource],
-  List<UnionType> get content => (_value['content'] as List).cast<UnionType>();
+  List<Content> get content => (_value['content'] as List).cast<Content>();
 
   /// Whether the tool call ended in an error.
   ///
@@ -811,24 +852,39 @@ extension type CallToolResult.fromMap(Map<String, Object?> _value)
   bool? get isError => _value['isError'] as bool?;
 }
 
-/// The response type used when something returns more than one type.
+/// Could be either [TextContent], [ImageContent] or [EmbeddedResource].
 ///
-/// Can wrap any response type, but it must have a `type` key.
+/// Use [isText], [isImage] and [isEmbeddedResource] before casting to the more
+/// specific types, or switch on the [type] and then cast.
 ///
-/// Should be used by doing a `switch` on the type, and then calling the
-/// `fromMap` constructor on the appropriate type.
-extension type UnionType._(Map<String, Object?> _value) {
-  factory UnionType(Map<String, Object?> value) {
+/// Doing `is` checks does not work because these are just extension types, they
+/// all have the same runtime type (`Map<String, Object?>`).
+extension type Content._(Map<String, Object?> _value) {
+  factory Content.fromMap(Map<String, Object?> value) {
     assert(value.containsKey('type'));
-    return UnionType._(value);
+    return Content._(value);
   }
+
+  /// Whether or not this is a [TextContent].
+  bool get isText => _value['type'] == TextContent.expectedType;
+
+  /// Whether or not this is a [ImageContent].
+  bool get isImage => _value['type'] == ImageContent.expectedType;
+
+  bool get isEmbeddedResource =>
+      _value['type'] == EmbeddedResource.expectedType;
+
+  /// The type of content, you can use this in a switch to handle various types
+  /// (see the the static `expectedType` getters), or you can use [isText],
+  /// [isImage], and [isEmbeddedResource] to determine the actual type.
+  String get type => _value['type'] as String;
 }
 
 /// Text provided to an LLM.
 ///
 // TODO: implement `Annotated`.
 extension type TextContent.fromMap(Map<String, Object?> _value)
-    implements UnionType {
+    implements Content {
   static const expectedType = 'text';
 
   factory TextContent({required String text}) =>
@@ -848,7 +904,7 @@ extension type TextContent.fromMap(Map<String, Object?> _value)
 ///
 // TODO: implement `Annotated`.
 extension type ImageContent.fromMap(Map<String, Object?> _value)
-    implements UnionType {
+    implements Content {
   static const expectedType = 'image';
 
   factory ImageContent({required String data, required String mimeType}) =>
@@ -879,10 +935,10 @@ extension type ImageContent.fromMap(Map<String, Object?> _value)
 ///
 // TODO: implement `Annotated`.
 extension type EmbeddedResource.fromMap(Map<String, Object?> _value)
-    implements UnionType {
+    implements Content {
   static const expectedType = 'resource';
 
-  factory EmbeddedResource({required UnionType resource}) =>
+  factory EmbeddedResource({required Content resource}) =>
       EmbeddedResource.fromMap({'resource': resource, 'type': expectedType});
 
   String get type {
@@ -892,7 +948,7 @@ extension type EmbeddedResource.fromMap(Map<String, Object?> _value)
   }
 
   /// Either [TextResourceContents] or [BlobResourceContents].
-  UnionType get resource => _value['resource'] as UnionType;
+  ResourceContents get resource => _value['resource'] as ResourceContents;
 
   String? get mimeType => _value['mimeType'] as String?;
 }
@@ -1327,16 +1383,22 @@ extension type InputSchema.fromMap(Map<String, Object?> _value) {
 //   uri: string;
 // }
 
-// /**
-//  * Identifies a prompt.
-//  */
-// export interface PromptReference {
-//   type: "ref/prompt";
-//   /**
-//    * The name of the prompt or prompt template
-//    */
-//   name: string;
-// }
+/// Identifies a prompt.
+extension type PromptReference.fromMap(Map<String, Object?> _value) {
+  static const expectedType = 'ref/prompt';
+
+  factory PromptReference({required String name}) =>
+      PromptReference.fromMap({'name': name, 'type': expectedType});
+
+  String get type {
+    final type = _value['type'] as String;
+    assert(type == expectedType);
+    return type;
+  }
+
+  /// The name of the prompt or prompt template
+  String get name => _value['name'] as String;
+}
 
 // /* Roots */
 // /**

--- a/pkgs/dart_mcp/lib/src/api.dart
+++ b/pkgs/dart_mcp/lib/src/api.dart
@@ -244,12 +244,16 @@ extension type ServerCapabilities.fromMap(Map<String, Object?> _value) {
   /// Present if the server offers any prompt templates.
   Prompts? get prompts => _value['prompts'] as Prompts?;
 
+  /// Sets [prompts] if it is null, otherwise throws.
+  set prompts(Prompts? value) {
+    assert(prompts == null);
+    _value['prompts'] = value;
+  }
+
   /// Whether this server supports subscribing to resource updates.
   Resources? get resources => _value['resources'] as Resources?;
 
   /// Sets [resources] if it is null, otherwise throws.
-  ///
-  // TODO: Add more setters for other types?
   set resources(Resources? value) {
     assert(resources == null);
     _value['resources'] = value;
@@ -259,8 +263,6 @@ extension type ServerCapabilities.fromMap(Map<String, Object?> _value) {
   Tools? get tools => _value['tools'] as Tools?;
 
   /// Sets [tools] if it is null, otherwise throws.
-  ///
-  // TODO: Add more setters for other types?
   set tools(Tools? value) {
     assert(tools == null);
     _value['tools'] = value;
@@ -274,6 +276,12 @@ extension type Prompts.fromMap(Map<String, Object?> _value) {
 
   /// Whether this server supports notifications for changes to the prompt list.
   bool? get listChanged => _value['listChanged'] as bool?;
+
+  /// Sets whether [listChanged] is supported.
+  set listChanged(bool? value) {
+    assert(listChanged == null);
+    _value['listChanged'] = value;
+  }
 }
 
 /// Resources parameter for [ServerCapabilities].

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -85,7 +85,7 @@ class ServerConnection {
       _promptListChangedController.stream;
   final _promptListChangedController =
       StreamController<PromptListChangedNotification>.broadcast();
-  
+
   /// Emits an event any time the server notifies us of a change to the list of
   /// tools it supports.
   ///
@@ -122,7 +122,7 @@ class ServerConnection {
       PromptListChangedNotification.methodName,
       convertParameters(_promptListChangedController.sink.add),
     );
-      
+
     _peer.registerMethod(
       ToolListChangedNotification.methodName,
       convertParameters(_toolListChangedController.sink.add),

--- a/pkgs/dart_mcp/lib/src/server/prompts_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/prompts_support.dart
@@ -13,7 +13,7 @@ part of 'server.dart';
 /// Supports `listChanged` notifications for changes to the prompts list.
 ///
 /// See https://modelcontextprotocol.io/docs/concepts/prompts.
-mixin PromptsSupport on MCPServer {
+base mixin PromptsSupport on MCPServer {
   /// The added prompts by name.
   final Map<String, Prompt> _prompts = {};
 

--- a/pkgs/dart_mcp/lib/src/server/prompts_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/prompts_support.dart
@@ -6,11 +6,18 @@ part of 'server.dart';
 
 /// A mixin for MCP servers which support the `prompts` capability.
 ///
-/// Supports `listChanged` notifications for the prompts list.
+/// Call [addPrompt] to add new prompts, and [removePrompt] to delete prompts,
+/// these are typically done in the [initialize] method, but may be done at any
+/// time.
+///
+/// Supports `listChanged` notifications for changes to the prompts list.
 ///
 /// See https://modelcontextprotocol.io/docs/concepts/prompts.
 mixin PromptsSupport on MCPServer {
+  /// The added prompts by name.
   final Map<String, Prompt> _prompts = {};
+
+  /// The added prompt implementations by name.
   final Map<String, FutureOr<GetPromptResult> Function(GetPromptRequest)>
   _promptImpls = {};
 

--- a/pkgs/dart_mcp/lib/src/server/prompts_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/prompts_support.dart
@@ -1,0 +1,80 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+part of 'server.dart';
+
+/// A mixin for MCP servers which support the `prompts` capability.
+///
+/// Supports `listChanged` notifications for the prompts list.
+///
+/// See https://modelcontextprotocol.io/docs/concepts/prompts.
+mixin PromptsSupport on MCPServer {
+  final Map<String, Prompt> _prompts = {};
+  final Map<String, FutureOr<GetPromptResult> Function(GetPromptRequest)>
+  _promptImpls = {};
+
+  @override
+  FutureOr<InitializeResult> initialize(InitializeRequest request) async {
+    _peer.registerMethod(
+      ListPromptsRequest.methodName,
+      convertParameters(_listPrompts),
+    );
+
+    _peer.registerMethod(
+      GetPromptRequest.methodName,
+      convertParameters(_getPrompt),
+    );
+
+    final result = await super.initialize(request);
+    (result.capabilities.prompts ??= Prompts()).listChanged = true;
+    return result;
+  }
+
+  /// Lists the available prompts.
+  ListPromptsResult _listPrompts(ListPromptsRequest request) =>
+      ListPromptsResult(prompts: _prompts.values.toList());
+
+  /// Gets the response for a given prompt.
+  FutureOr<GetPromptResult> _getPrompt(GetPromptRequest request) {
+    final impl = _promptImpls[request.name];
+    if (impl == null) {
+      throw ArgumentError.value(request.name, 'name', 'Prompt not found');
+    }
+    return impl(request);
+  }
+
+  /// Adds a prompt and notifies clients that the list has changed.
+  void addPrompt(
+    Prompt prompt,
+    FutureOr<GetPromptResult> Function(GetPromptRequest) impl,
+  ) {
+    if (_prompts.containsKey(prompt.name)) {
+      throw StateError(
+        'Failed to add prompt ${prompt.name}, it already exists',
+      );
+    }
+    _prompts[prompt.name] = prompt;
+    _promptImpls[prompt.name] = impl;
+    if (ready) {
+      _notifyPromptListChanged();
+    }
+  }
+
+  /// Removes a prompt and notifies clients that the list has changed.
+  void removePrompt(String name) {
+    _prompts.remove(name);
+    _promptImpls.remove(name);
+    if (ready) {
+      _notifyPromptListChanged();
+    }
+  }
+
+  /// Notifies clients that the prompts list has changed.
+  void _notifyPromptListChanged() {
+    _peer.sendNotification(
+      PromptListChangedNotification.methodName,
+      PromptListChangedNotification(),
+    );
+  }
+}

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -11,8 +11,9 @@ import 'package:stream_channel/stream_channel.dart';
 import '../api.dart';
 import '../util.dart';
 
-part 'tools_support.dart';
+part 'prompts_support.dart';
 part 'resources_support.dart';
+part 'tools_support.dart';
 
 /// Base class to extend when implementing an MCP server.
 ///

--- a/pkgs/dart_mcp/test/prompts_test.dart
+++ b/pkgs/dart_mcp/test/prompts_test.dart
@@ -1,0 +1,115 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:dart_mcp/server.dart';
+import 'package:test/test.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  test('client can list and get prompts from the server', () async {
+    var environment = TestEnvironment(
+      TestMCPClient(),
+      TestMCPServerWithPrompts.new,
+    );
+    var initializeResult = await environment.initializeServer();
+
+    expect(
+      initializeResult.capabilities,
+      ServerCapabilities(prompts: Prompts(listChanged: true)),
+    );
+
+    var serverConnection = environment.serverConnection;
+
+    var promptsResult = await serverConnection.listPrompts(
+      ListPromptsRequest(),
+    );
+    expect(promptsResult.prompts, [TestMCPServerWithPrompts.greeting]);
+
+    var greetingResult = await serverConnection.getPrompt(
+      GetPromptRequest(
+        name: promptsResult.prompts.single.name,
+        arguments: {'style': 'joyously'},
+      ),
+    );
+
+    expect(
+      greetingResult.messages.single,
+      PromptMessage(
+        role: Role.user,
+        content: [TextContent(text: 'Please greet me joyously')],
+      ),
+    );
+  });
+
+  test('client is notified of changes to prompts from the server', () async {
+    var environment = TestEnvironment(
+      TestMCPClient(),
+      TestMCPServerWithPrompts.new,
+    );
+    await environment.initializeServer();
+
+    var serverConnection = environment.serverConnection;
+    expect(
+      serverConnection.promptListChanged,
+      emitsInOrder([
+        PromptListChangedNotification(),
+        PromptListChangedNotification(),
+      ]),
+      reason: 'We should get a notification for new and removed prompts',
+    );
+
+    var server = environment.server;
+    server.addPrompt(
+      Prompt(name: 'new prompt'),
+      (_) => GetPromptResult(messages: []),
+    );
+    server.removePrompt('new prompt');
+    // Give the notifications a chance to propagate.
+    await pumpEventQueue();
+
+    // We need to manually shut down so that the queue of prompt changes doesn't
+    // keep the test active.
+    await environment.shutdown();
+  });
+}
+
+class TestMCPServerWithPrompts extends TestMCPServer with PromptsSupport {
+  TestMCPServerWithPrompts(super.channel);
+
+  @override
+  FutureOr<InitializeResult> initialize(InitializeRequest request) {
+    addPrompt(greeting, _greetingPrompt);
+    return super.initialize(request);
+  }
+
+  FutureOr<GetPromptResult> _greetingPrompt(GetPromptRequest request) {
+    return GetPromptResult(
+      messages: [
+        PromptMessage(
+          role: Role.user,
+          content: [
+            TextContent(text: 'Please greet me ${request.arguments!['style']}'),
+          ],
+        ),
+      ],
+    );
+  }
+
+  static final greeting = Prompt(
+    name: 'greet me',
+    description: 'A prompt for the AI to give a greeting of a particular style',
+    arguments: [
+      PromptArgument(
+        name: 'style',
+        description:
+            'The style in which the greeting should be (for example, '
+            '"joyously" or "angrily")',
+        required: true,
+      ),
+    ],
+  );
+}

--- a/pkgs/dart_mcp/test/prompts_test.dart
+++ b/pkgs/dart_mcp/test/prompts_test.dart
@@ -77,7 +77,7 @@ void main() {
   });
 }
 
-class TestMCPServerWithPrompts extends TestMCPServer with PromptsSupport {
+final class TestMCPServerWithPrompts extends TestMCPServer with PromptsSupport {
   TestMCPServerWithPrompts(super.channel);
 
   @override

--- a/pkgs/dart_mcp/test/test_utils.dart
+++ b/pkgs/dart_mcp/test/test_utils.dart
@@ -65,7 +65,7 @@ class TestEnvironment<Client extends MCPClient, Server extends MCPServer> {
   }
 
   Future<void> shutdown() async {
-    await client.shutdownServer(server.implementation.name);
+    await client.shutdown();
   }
 }
 

--- a/pkgs/dart_mcp/test/test_utils.dart
+++ b/pkgs/dart_mcp/test/test_utils.dart
@@ -21,23 +21,11 @@ class TestEnvironment<Client extends MCPClient, Server extends MCPServer> {
 
   late final clientChannel = StreamChannel<String>.withCloseGuarantee(
     serverController.stream,
-    clientController.sink.transform(
-      StreamSinkTransformer.fromHandlers(
-        handleData: (data, sink) {
-          sink.add('$data\n');
-        },
-      ),
-    ),
+    clientController.sink,
   );
   late final serverChannel = StreamChannel<String>.withCloseGuarantee(
     clientController.stream,
-    serverController.sink.transform(
-      StreamSinkTransformer.fromHandlers(
-        handleData: (data, sink) {
-          sink.add('$data\n');
-        },
-      ),
-    ),
+    serverController.sink,
   );
 
   final Client client;

--- a/pkgs/dart_mcp/test/test_utils.dart
+++ b/pkgs/dart_mcp/test/test_utils.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'package:async/async.dart';
 import 'package:dart_mcp/client.dart';
 import 'package:dart_mcp/server.dart';
 import 'package:stream_channel/stream_channel.dart';


### PR DESCRIPTION
See https://modelcontextprotocol.io/docs/concepts/prompts

Adds server and client support.