### PR TITLE
Support Pings and Progress events

### DIFF
--- a/pkgs/dart_mcp/lib/src/api.dart
+++ b/pkgs/dart_mcp/lib/src/api.dart
@@ -35,7 +35,10 @@ extension type WithProgressToken.fromMap(Map<String, Object?> _value) {
 ///
 /// Has arbitrary other keys.
 extension type MetaWithProgressToken.fromMap(Map<String, Object?> _value)
-    implements Meta, WithProgressToken {}
+    implements Meta, WithProgressToken {
+  factory MetaWithProgressToken({ProgressToken? progressToken}) =>
+      MetaWithProgressToken.fromMap({'progressToken': progressToken});
+}
 
 /// Base interface for all request types.
 ///
@@ -123,7 +126,7 @@ extension type InitializeRequest._fromMap(Map<String, Object?> _value)
     'protocolVersion': protocolVersion,
     'capabilities': capabilities,
     'clientInfo': clientInfo,
-    if (meta != null) 'meta': meta,
+    if (meta != null) '_meta': meta,
   });
 
   /// The latest version of the Model Context Protocol that the client supports.
@@ -976,7 +979,7 @@ extension type CallToolRequest._fromMap(Map<String, Object?> _value)
   }) => CallToolRequest._fromMap({
     'name': name,
     if (arguments != null) 'arguments': arguments,
-    if (meta != null) 'meta': meta,
+    if (meta != null) '_meta': meta,
   });
 
   /// The name of the method to invoke.
@@ -997,7 +1000,7 @@ extension type ToolListChangedNotification.fromMap(Map<String, Object?> _value)
   static const methodName = 'notifications/tools/list_changed';
 
   factory ToolListChangedNotification({Meta? meta}) =>
-      ToolListChangedNotification.fromMap({if (meta != null) 'meta': meta});
+      ToolListChangedNotification.fromMap({if (meta != null) '_meta': meta});
 }
 
 /// Definition for a tool the client can call.

--- a/pkgs/dart_mcp/lib/src/api.dart
+++ b/pkgs/dart_mcp/lib/src/api.dart
@@ -23,7 +23,7 @@ extension type Cursor(String _) {}
 /// Generic metadata passed with most requests, can be anything.
 extension type Meta.fromMap(Map<String, Object?> _value) {}
 
-/// A "mixin"-like extension type for any extension type that contains a
+/// A "mixin"-like extension type for any extension type that might contain a
 /// [ProgressToken] at the key "progressToken".
 ///
 /// Should be "mixed in" by implementing this type from other extension types.
@@ -118,7 +118,7 @@ extension type InitializeRequest._fromMap(Map<String, Object?> _value)
     required String protocolVersion,
     required ClientCapabilities capabilities,
     required ClientImplementation clientInfo,
-    Meta? meta,
+    MetaWithProgressToken? meta,
   }) => InitializeRequest._fromMap({
     'protocolVersion': protocolVersion,
     'capabilities': capabilities,
@@ -340,45 +340,48 @@ extension type ServerImplementation.fromMap(Map<String, Object?> _value) {
   String get version => _value['version'] as String;
 }
 
-// /* Ping */
-// /**
-//  * A ping, issued by either the server or the client, to check that the other
-//  * party is still alive. The receiver must promptly respond, or else may be
-//  * disconnected.
-//  */
-// export interface PingRequest extends Request {
-//   method: "ping";
-// }
+/// A ping, issued by either the server or the client, to check that the other
+/// party is still alive.
+///
+/// The receiver must promptly respond, or else may be disconnected.
+extension type PingRequest.fromMap(Map<String, Object?> _value)
+    implements Request {
+  static const methodName = 'ping';
 
-// /* Progress notifications */
-// /**
-//  * An out-of-band notification used to inform the receiver of a progress
-//  * update for a long-running request.
-//  */
-// export interface ProgressNotification extends Notification {
-//   method: "notifications/progress";
-//   params: {
-//     /**
-//      * The progress token which was given in the initial request, used to
-//      * associate this notification with the request that is proceeding.
-//      */
-//     progressToken: ProgressToken;
-//     /**
-//      * The progress thus far. This should increase every time progress is
-//      * made, even if the total is unknown.
-//      *
-//      * @TJS-type number
-//      */
-//     progress: number;
-//     /**
-//      * Total number of items to process (or total progress required), if
-//      * known.
-//      *
-//      * @TJS-type number
-//      */
-//     total?: number;
-//   };
-// }
+  factory PingRequest({MetaWithProgressToken? meta}) =>
+      PingRequest.fromMap({if (meta != null) '_meta': meta});
+}
+
+/// An out-of-band notification used to inform the receiver of a progress
+/// update for a long-running request.
+extension type ProgressNotification.fromMap(Map<String, Object?> _value)
+    implements Notification {
+  static const methodName = 'notifications/progress';
+
+  factory ProgressNotification({
+    required ProgressToken progressToken,
+    required int progress,
+    int? total,
+    Meta? meta,
+  }) => ProgressNotification.fromMap({
+    'progressToken': progressToken,
+    'progress': progress,
+    if (total != null) 'total': total,
+    if (meta != null) '_meta': meta,
+  });
+
+  /// The progress token which was given in the initial request, used to
+  /// associate this notification with the request that is proceeding.
+  ProgressToken get progressToken => _value['progressToken'] as ProgressToken;
+
+  /// The progress thus far. This should increase every time progress is
+  /// made, even if the total is unknown.
+  int get progress => _value['progress'] as int;
+
+  /// Total number of items to process (or total progress required), if
+  /// known.
+  int? get total => _value['total'] as int?;
+}
 
 /// A "mixin"-like extension type for any request that contains a [Cursor] at
 /// the key "cursor".
@@ -412,7 +415,7 @@ extension type ListResourcesRequest.fromMap(Map<String, Object?> _value)
     implements PaginatedRequest {
   static const methodName = 'resources/list';
 
-  factory ListResourcesRequest({Cursor? cursor, Meta? meta}) =>
+  factory ListResourcesRequest({Cursor? cursor, MetaWithProgressToken? meta}) =>
       ListResourcesRequest.fromMap({
         if (cursor != null) 'cursor': cursor,
         if (meta != null) '_meta': meta,
@@ -442,11 +445,13 @@ extension type ListResourceTemplatesRequest.fromMap(Map<String, Object?> _value)
     implements PaginatedRequest {
   static const methodName = 'resources/templates/list';
 
-  factory ListResourceTemplatesRequest({Cursor? cursor, Meta? meta}) =>
-      ListResourceTemplatesRequest.fromMap({
-        if (cursor != null) 'cursor': cursor,
-        if (meta != null) '_meta': meta,
-      });
+  factory ListResourceTemplatesRequest({
+    Cursor? cursor,
+    MetaWithProgressToken? meta,
+  }) => ListResourceTemplatesRequest.fromMap({
+    if (cursor != null) 'cursor': cursor,
+    if (meta != null) '_meta': meta,
+  });
 }
 
 /// The server's response to a resources/templates/list request from the client.
@@ -471,11 +476,13 @@ extension type ReadResourceRequest.fromMap(Map<String, Object?> _value)
     implements Request {
   static const methodName = 'resources/read';
 
-  factory ReadResourceRequest({required String uri, Meta? meta}) =>
-      ReadResourceRequest.fromMap({
-        'uri': uri,
-        if (meta != null) '_meta': meta,
-      });
+  factory ReadResourceRequest({
+    required String uri,
+    MetaWithProgressToken? meta,
+  }) => ReadResourceRequest.fromMap({
+    'uri': uri,
+    if (meta != null) '_meta': meta,
+  });
 
   /// The URI of the resource to read. The URI can use any protocol; it is
   /// up to the server how to interpret it.
@@ -520,8 +527,10 @@ extension type SubscribeRequest.fromMap(Map<String, Object?> _value)
     implements Request {
   static const methodName = 'resources/subscribe';
 
-  factory SubscribeRequest({required String uri, Meta? meta}) =>
-      SubscribeRequest.fromMap({'uri': uri, if (meta != null) '_meta': meta});
+  factory SubscribeRequest({
+    required String uri,
+    MetaWithProgressToken? meta,
+  }) => SubscribeRequest.fromMap({'uri': uri, if (meta != null) '_meta': meta});
 
   /// The URI of the resource to subscribe to. The URI can use any protocol;
   /// it is up to the server how to interpret it.
@@ -536,7 +545,10 @@ extension type UnsubscribeRequest.fromMap(Map<String, Object?> _value)
     implements Request {
   static const methodName = 'resources/unsubscribe';
 
-  factory UnsubscribeRequest({required String uri, Meta? meta}) =>
+  factory UnsubscribeRequest({
+    required String uri,
+    MetaWithProgressToken? meta,
+  }) =>
       UnsubscribeRequest.fromMap({'uri': uri, if (meta != null) '_meta': meta});
 
   /// The URI of the resource to unsubscribe from.
@@ -756,7 +768,7 @@ extension type ListToolsRequest.fromMap(Map<String, Object?> _value)
     implements PaginatedRequest {
   static const methodName = 'tools/list';
 
-  factory ListToolsRequest({Cursor? cursor, Meta? meta}) =>
+  factory ListToolsRequest({Cursor? cursor, MetaWithProgressToken? meta}) =>
       ListToolsRequest.fromMap({
         if (cursor != null) 'cursor': cursor,
         if (meta != null) '_meta': meta,
@@ -960,7 +972,7 @@ extension type CallToolRequest._fromMap(Map<String, Object?> _value)
   factory CallToolRequest({
     required String name,
     Map<String, Object?>? arguments,
-    Meta? meta,
+    MetaWithProgressToken? meta,
   }) => CallToolRequest._fromMap({
     'name': name,
     if (arguments != null) 'arguments': arguments,

--- a/pkgs/dart_mcp/lib/src/api.dart
+++ b/pkgs/dart_mcp/lib/src/api.dart
@@ -58,7 +58,7 @@ extension type Notification(Map<String, Object?> _value) {
 }
 
 /// Base interface for all responses to requests.
-extension type Result(Map<String, Object?> _value) {
+extension type Result._(Map<String, Object?> _value) {
   Meta? get meta => _value['_meta'] as Meta?;
 }
 

--- a/pkgs/dart_mcp/lib/src/api.dart
+++ b/pkgs/dart_mcp/lib/src/api.dart
@@ -377,8 +377,10 @@ extension type ProgressNotification.fromMap(Map<String, Object?> _value)
   /// associate this notification with the request that is proceeding.
   ProgressToken get progressToken => _value['progressToken'] as ProgressToken;
 
-  /// The progress thus far. This should increase every time progress is
-  /// made, even if the total is unknown.
+  /// The progress thus far.
+  ///
+  /// This should increase every time progress is made, even if the total is
+  /// unknown.
   int get progress => _value['progress'] as int;
 
   /// Total number of items to process (or total progress required), if

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -39,6 +39,8 @@ abstract base class MCPServer {
 
   MCPServer.fromStreamChannel(StreamChannel<String> channel)
     : _peer = Peer(channel) {
+    _peer.registerMethod(PingRequest.methodName, convertParameters(handlePing));
+
     _peer.registerMethod(
       InitializeRequest.methodName,
       convertParameters(initialize),
@@ -72,4 +74,26 @@ abstract base class MCPServer {
   void handleInitialized(InitializedNotification notification) {
     _initialized.complete();
   }
+
+  /// The client may ping us at any time, and we should respond with an empty
+  /// response.
+  FutureOr<EmptyResult> handlePing(PingRequest request) => EmptyResult();
+
+  /// Pings the client, and returns whether or not it responded within
+  /// [timeout].
+  ///
+  /// The returned future completes after one of the following:
+  ///
+  ///   - The client responds (returns `true`).
+  ///   - The [timeout] is exceeded completes (returns `false`).
+  ///
+  /// If the timeout is reached, future values or errors from the ping request
+  /// are ignored.
+  Future<bool> ping(
+    PingRequest request, {
+    Duration timeout = const Duration(seconds: 1),
+  }) => _peer
+      .sendRequest(PingRequest.methodName, request)
+      .then((_) => true)
+      .timeout(timeout, onTimeout: () => false);
 }

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -96,4 +96,12 @@ abstract base class MCPServer {
       .sendRequest(PingRequest.methodName, request)
       .then((_) => true)
       .timeout(timeout, onTimeout: () => false);
+
+  /// Notifies the client of progress towards completing some request.
+  ///
+  /// Progress tokens may be provided for any [Request] object, through the
+  /// `request.meta.progressToken` but servers are not required to send any
+  /// progress notifications.
+  void notifyProgress(ProgressNotification notification) =>
+      _peer.sendNotification(ProgressNotification.methodName, notification);
 }

--- a/pkgs/dart_mcp/test/client_and_server_test.dart
+++ b/pkgs/dart_mcp/test/client_and_server_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:async/async.dart';
 import 'package:dart_mcp/client.dart';
 import 'package:dart_mcp/server.dart';
 import 'package:json_rpc_2/error_code.dart';
@@ -27,4 +28,63 @@ void main() {
       reason: 'Calling unsupported methods should throw',
     );
   });
+
+  test('client and server can ping each other', () async {
+    var environment = TestEnvironment(TestMCPClient(), TestMCPServer.new);
+    await environment.initializeServer();
+
+    expect(await environment.serverConnection.ping(PingRequest()), true);
+    expect(await environment.server.ping(PingRequest()), true);
+  });
+
+  test('client can handle ping timeouts', () async {
+    var environment = TestEnvironment(
+      TestMCPClient(),
+      DelayedPingTestMCPServer.new,
+    );
+    await environment.initializeServer();
+
+    expect(
+      await environment.serverConnection.ping(
+        PingRequest(),
+        timeout: const Duration(milliseconds: 1),
+      ),
+      false,
+    );
+  });
+
+  test('server can handle ping timeouts', () async {
+    var environment = TestEnvironment(TestMCPClient(), (channel) {
+      channel = channel.transformSink(
+        StreamSinkTransformer.fromHandlers(
+          handleData: (data, sink) async {
+            if (data.contains('"ping"')) {
+              await Future<void>.delayed(const Duration(milliseconds: 100));
+            }
+            sink.add(data);
+          },
+        ),
+      );
+      return TestMCPServer(channel);
+    });
+    await environment.initializeServer();
+
+    expect(
+      await environment.server.ping(
+        PingRequest(),
+        timeout: const Duration(milliseconds: 1),
+      ),
+      false,
+    );
+  });
+}
+
+final class DelayedPingTestMCPServer extends TestMCPServer {
+  DelayedPingTestMCPServer(super.channel);
+
+  @override
+  Future<EmptyResult> handlePing(PingRequest request) async {
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    return EmptyResult();
+  }
 }


### PR DESCRIPTION
See [ping specification](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/utilities/ping/) and [progess specification](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/utilities/progress/).

This does not yet support progress notifications for requests from the server to the client - because we don't implement any of those yet. This will come with support for [sampling](https://spec.modelcontextprotocol.io/specification/2025-03-26/client/sampling/) and/or [roots](https://spec.modelcontextprotocol.io/specification/2025-03-26/client/roots/).

I also did a bit of refactoring to extract out a shared `sendRequest` utility - which handles shutting down the progress event streams for a request once the response comes in.