### PR TITLE
Add Logging support

### DIFF
--- a/pkgs/dart_mcp/lib/src/api.dart
+++ b/pkgs/dart_mcp/lib/src/api.dart
@@ -224,7 +224,7 @@ extension type RootsCapabilities.fromMap(Map<String, Object?> _value) {
 extension type ServerCapabilities.fromMap(Map<String, Object?> _value) {
   factory ServerCapabilities({
     Map<String, Object?>? experimental,
-    Map<String, Object?>? logging,
+    Logging? logging,
     Prompts? prompts,
     Resources? resources,
     Tools? tools,
@@ -240,9 +240,21 @@ extension type ServerCapabilities.fromMap(Map<String, Object?> _value) {
   Map<String, Object?>? get experimental =>
       (_value['experimental'] as Map?)?.cast<String, Object?>();
 
+  /// Sets [experimental] if it is null, otherwise throws.
+  set experimental(Map<String, Object?>? value) {
+    assert(experimental == null);
+    _value['experimental'] = value;
+  }
+
   /// Present if the server supports sending log messages to the client.
-  Map<String, Object?>? get logging =>
-      (_value['logging'] as Map?)?.cast<String, Object?>();
+  Logging? get logging =>
+      (_value['logging'] as Map?)?.cast<String, Object?>() as Logging?;
+
+  /// Sets [logging] if it is null, otherwise throws.
+  set logging(Logging? value) {
+    assert(logging == null);
+    _value['logging'] = value;
+  }
 
   /// Present if the server offers any prompt templates.
   Prompts? get prompts => _value['prompts'] as Prompts?;
@@ -1121,6 +1133,11 @@ extension type InputSchema.fromMap(Map<String, Object?> _value) {
   List<String>? get required => (_value['required'] as List?)?.cast<String>();
 }
 
+/// Extension type for the `logging` capability.
+extension type Logging.fromMap(Map<String, Object?> _value) {
+  factory Logging() => Logging.fromMap({});
+}
+
 /// A request from the client to the server, to enable or adjust logging.
 extension type SetLevelRequest.fromMap(Map<String, Object?> _value)
     implements Request {
@@ -1187,7 +1204,11 @@ enum LoggingLevel {
   error,
   critical,
   alert,
-  emergency,
+  emergency;
+
+  bool operator <(LoggingLevel other) => index < other.index;
+  bool operator >(LoggingLevel other) => index > other.index;
+  bool operator >=(LoggingLevel other) => index >= other.index;
 }
 
 // /* Sampling */

--- a/pkgs/dart_mcp/lib/src/api.dart
+++ b/pkgs/dart_mcp/lib/src/api.dart
@@ -677,7 +677,7 @@ extension type ListPromptsRequest.fromMap(Map<String, Object?> _value)
     implements PaginatedRequest {
   static const methodName = 'prompts/list';
 
-  factory ListPromptsRequest({Cursor? cursor, Meta? meta}) =>
+  factory ListPromptsRequest({Cursor? cursor, MetaWithProgressToken? meta}) =>
       ListPromptsRequest.fromMap({
         if (cursor != null) 'cursor': cursor,
         if (meta != null) '_meta': meta,
@@ -708,7 +708,7 @@ extension type GetPromptRequest.fromMap(Map<String, Object?> _value)
   factory GetPromptRequest({
     required String name,
     Map<String, Object?>? arguments,
-    Meta? meta,
+    MetaWithProgressToken? meta,
   }) => GetPromptRequest.fromMap({
     'name': name,
     if (arguments != null) 'arguments': arguments,
@@ -1121,59 +1121,74 @@ extension type InputSchema.fromMap(Map<String, Object?> _value) {
   List<String>? get required => (_value['required'] as List?)?.cast<String>();
 }
 
-// /* Logging */
-// /**
-//  * A request from the client to the server, to enable or adjust logging.
-//  */
-// export interface SetLevelRequest extends Request {
-//   method: "logging/setLevel";
-//   params: {
-//     /**
-//      * The level of logging that the client wants to receive from the server.
-//      * The server should send all logs at this level and higher (i.e., more
-//      * severe) to the client as notifications/message.
-//      */
-//     level: LoggingLevel;
-//   };
-// }
+/// A request from the client to the server, to enable or adjust logging.
+extension type SetLevelRequest.fromMap(Map<String, Object?> _value)
+    implements Request {
+  static const methodName = 'logging/setLevel';
 
-// /**
-//  * Notification of a log message passed from server to client. If no logging/setLevel request has been sent from the client, the server MAY decide which messages to send automatically.
-//  */
-// export interface LoggingMessageNotification extends Notification {
-//   method: "notifications/message";
-//   params: {
-//     /**
-//      * The severity of this log message.
-//      */
-//     level: LoggingLevel;
-//     /**
-//      * An optional name of the logger issuing this message.
-//      */
-//     logger?: string;
-//     /**
-//      * The data to be logged, such as a string message or an object. Any JSON
-//      * serializable type is allowed here.
-//      */
-//     data: unknown;
-//   };
-// }
+  factory SetLevelRequest({
+    required LoggingLevel level,
+    MetaWithProgressToken? meta,
+  }) => SetLevelRequest.fromMap({
+    'level': level.name,
+    if (meta != null) '_meta': meta,
+  });
 
-// /**
-//  * The severity of a log message.
-//  *
-//  * These map to syslog message severities, as specified in RFC-5424:
-//  * https://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1
-//  */
-// export type LoggingLevel =
-//   | "debug"
-//   | "info"
-//   | "notice"
-//   | "warning"
-//   | "error"
-//   | "critical"
-//   | "alert"
-//   | "emergency";
+  /// The level of logging that the client wants to receive from the server.
+  ///
+  /// The server should send all logs at this level and higher (i.e., more
+  /// severe) to the client as notifications/message.
+  LoggingLevel get level =>
+      LoggingLevel.values.firstWhere((level) => level.name == _value['level']);
+}
+
+/// Notification of a log message passed from server to client.
+///
+/// If no logging/setLevel request has been sent from the client, the server
+/// MAY decide which messages to send automatically.
+extension type LoggingMessageNotification.fromMap(Map<String, Object?> _value)
+    implements Notification {
+  static const methodName = 'notifications/message';
+
+  factory LoggingMessageNotification({
+    required LoggingLevel level,
+    String? logger,
+    required Object data,
+    Meta? meta,
+  }) => LoggingMessageNotification.fromMap({
+    'level': level.name,
+    if (logger != null) 'logger': logger,
+    'data': data,
+    if (meta != null) '_meta': meta,
+  });
+
+  /// The severity of this log message.
+  LoggingLevel get level =>
+      LoggingLevel.values.firstWhere((level) => level.name == _value['level']);
+
+  /// An optional name of the logger issuing this message.
+  String? get logger => _value['logger'] as String?;
+
+  /// The data to be logged, such as a string message or an object.
+  ///
+  /// Any JSON serializable type is allowed here.
+  Object get data => _value['data'] as Object;
+}
+
+/// The severity of a log message.
+///
+/// These map to syslog message severities, as specified in RFC-5424:
+/// https://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1
+enum LoggingLevel {
+  debug,
+  info,
+  notice,
+  warning,
+  error,
+  critical,
+  alert,
+  emergency,
+}
 
 // /* Sampling */
 // /**

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -122,6 +122,14 @@ class ServerConnection {
   final _resourceUpdatedController =
       StreamController<ResourceUpdatedNotification>.broadcast();
 
+  /// Emits an event any time the server sends a log message.
+  ///
+  /// This is a broadcast stream, events are not buffered and only future events
+  /// are given.
+  Stream<LoggingMessageNotification> get onLog => _logController.stream;
+  final _logController =
+      StreamController<LoggingMessageNotification>.broadcast();
+
   ServerConnection.fromStreamChannel(StreamChannel<String> channel)
     : _peer = Peer(channel) {
     _peer.registerMethod(PingRequest.methodName, convertParameters(handlePing));
@@ -151,17 +159,26 @@ class ServerConnection {
       convertParameters(_resourceUpdatedController.sink.add),
     );
 
+    _peer.registerMethod(
+      LoggingMessageNotification.methodName,
+      convertParameters(_logController.sink.add),
+    );
+
     _peer.listen();
   }
 
   /// Close all connections and streams so the process can cleanly exit.
   Future<void> shutdown() async {
+    final progressControllers = _progressControllers.values.toList();
+    _progressControllers.clear();
     await Future.wait([
       _peer.close(),
       _promptListChangedController.close(),
       _toolListChangedController.close(),
       _resourceListChangedController.close(),
       _resourceUpdatedController.close(),
+      _logController.close(),
+      for (var c in progressControllers) c.close(),
     ]);
   }
 
@@ -290,12 +307,18 @@ class ServerConnection {
   /// Subscribes this client to a resource by URI (at `request.uri`).
   ///
   /// Updates will come on the [resourceUpdated] stream.
-  void subscribeResource(SubscribeRequest request) =>
-      _peer.sendNotification(SubscribeRequest.methodName, request);
+  Future<void> subscribeResource(SubscribeRequest request) =>
+      _sendRequest(SubscribeRequest.methodName, request);
 
   /// Unsubscribes this client to a resource by URI (at `request.uri`).
   ///
   /// Updates will come on the [resourceUpdated] stream.
-  void unsubscribeResource(UnsubscribeRequest request) =>
-      _peer.sendNotification(UnsubscribeRequest.methodName, request);
+  Future<void> unsubscribeResource(UnsubscribeRequest request) =>
+      _sendRequest(UnsubscribeRequest.methodName, request);
+
+  /// Sends a request to change the current logging level.
+  ///
+  /// Completes when the response is received.
+  Future<void> setLogLevel(SetLevelRequest request) =>
+      _sendRequest(SetLevelRequest.methodName, request);
 }

--- a/pkgs/dart_mcp/lib/src/server/logging_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/logging_support.dart
@@ -1,0 +1,71 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+part of 'server.dart';
+
+/// A mixin for MCP servers which support the `logging` capability.
+///
+/// See https://spec.modelcontextprotocol.io/specification/2025-03-26/server/utilities/logging/.
+base mixin LoggingSupport on MCPServer {
+  /// The current logging level, defaults to [LoggingLevel.warning].
+  LoggingLevel loggingLevel = LoggingLevel.warning;
+
+  @override
+  FutureOr<InitializeResult> initialize(InitializeRequest request) async {
+    _peer.registerMethod(
+      SetLevelRequest.methodName,
+      convertParameters(handleSetLevel),
+    );
+
+    final result = await super.initialize(request);
+    result.capabilities.logging ??= Logging();
+    return result;
+  }
+
+  /// Sends a [LoggingMessageNotification] to the client, if the [loggingLevel]
+  /// is <= [level].
+  ///
+  /// The [data] must either be some json serializable object, or a function
+  /// which takes no arguments and returns some json serializable object.
+  ///
+  /// if [data] is a function then it must take zero arguments and return a
+  /// non-nullable result. It will only be invoked if the log message
+  /// will actually be sent.
+  ///
+  /// If [data] is any other type of function, an [ArgumentError] will be
+  /// thrown.
+  void log(LoggingLevel level, Object data, {String? logger, Meta? meta}) {
+    if (loggingLevel > level) return;
+
+    if (data is Function) {
+      if (data is Object Function()) {
+        data = data();
+      } else {
+        throw ArgumentError.value(
+          data,
+          'data',
+          'When logging a lazily evaluated function, it must be of type '
+              '`Object Function()`, but the given function type was '
+              '`${data.runtimeType}`.',
+        );
+      }
+    }
+
+    _peer.sendNotification(
+      LoggingMessageNotification.methodName,
+      LoggingMessageNotification(
+        level: level,
+        data: data,
+        logger: logger,
+        meta: meta,
+      ),
+    );
+  }
+
+  /// Handle a client request to change the logging level.
+  FutureOr<EmptyResult> handleSetLevel(SetLevelRequest request) {
+    loggingLevel = request.level;
+    return EmptyResult();
+  }
+}

--- a/pkgs/dart_mcp/lib/src/server/logging_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/logging_support.dart
@@ -18,9 +18,8 @@ base mixin LoggingSupport on MCPServer {
       convertParameters(handleSetLevel),
     );
 
-    final result = await super.initialize(request);
-    result.capabilities.logging ??= Logging();
-    return result;
+    return (await super.initialize(request))
+      ..capabilities.logging ??= Logging();
   }
 
   /// Sends a [LoggingMessageNotification] to the client, if the [loggingLevel]

--- a/pkgs/dart_mcp/lib/src/server/resources_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/resources_support.dart
@@ -143,17 +143,21 @@ base mixin ResourcesSupport on MCPServer {
   }
 
   /// Subscribes the client to the resource at `request.uri`.
-  void _subscribeResource(SubscribeRequest request) async {
-    // We can't return an error as there is no response, so we just don't do
-    // anything.
-    if (!_resources.containsKey(request.uri)) return;
+  FutureOr<EmptyResult> _subscribeResource(SubscribeRequest request) async {
+    if (!_resources.containsKey(request.uri)) {
+      throw ArgumentError.value(request.uri, 'uri', 'Resource not found');
+    }
 
     _subscribedResources.add(request.uri);
+
+    return EmptyResult();
   }
 
   /// Unsubscribes the client to the resource at `request.uri`.
-  void _unsubscribeResource(UnsubscribeRequest request) async {
+  FutureOr<EmptyResult> _unsubscribeResource(UnsubscribeRequest request) async {
     _subscribedResources.remove(request.uri);
+
+    return EmptyResult();
   }
 
   /// Called whenever the list of resources changes, it is the job of the client

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -11,6 +11,7 @@ import 'package:stream_channel/stream_channel.dart';
 import '../api.dart';
 import '../util.dart';
 
+part 'logging_support.dart';
 part 'prompts_support.dart';
 part 'resources_support.dart';
 part 'tools_support.dart';

--- a/pkgs/dart_mcp/test/logging_test.dart
+++ b/pkgs/dart_mcp/test/logging_test.dart
@@ -137,7 +137,7 @@ void main() {
     );
 
     expect(
-      () => server.log(LoggingLevel.warning, (int x) => 'hello'),
+      () => server.log(LoggingLevel.warning, ({required int x}) => 'hello'),
       throwsA(isA<ArgumentError>()),
       reason: 'Lazy message functions should not have required named arguments',
     );

--- a/pkgs/dart_mcp/test/logging_test.dart
+++ b/pkgs/dart_mcp/test/logging_test.dart
@@ -1,0 +1,125 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dart_mcp/server.dart';
+import 'package:test/test.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  test('client can set the logging level', () async {
+    var environment = TestEnvironment(
+      TestMCPClient(),
+      TestMCPServerWithLogging.new,
+    );
+    final initializeResult = await environment.initializeServer();
+
+    expect(initializeResult.capabilities.logging, Logging());
+
+    final serverConnection = environment.serverConnection;
+    final server = environment.server;
+
+    expect(
+      server.loggingLevel,
+      LoggingLevel.warning,
+      reason: 'The default level is warning',
+    );
+
+    await serverConnection.setLogLevel(
+      SetLevelRequest(level: LoggingLevel.debug),
+    );
+    expect(server.loggingLevel, LoggingLevel.debug);
+
+    await serverConnection.setLogLevel(
+      SetLevelRequest(level: LoggingLevel.error),
+    );
+    expect(server.loggingLevel, LoggingLevel.error);
+  });
+
+  test('client can receive log messages', () async {
+    var environment = TestEnvironment(
+      TestMCPClient(),
+      TestMCPServerWithLogging.new,
+    );
+    await environment.initializeServer();
+
+    final serverConnection = environment.serverConnection;
+    final server = environment.server;
+
+    await serverConnection.setLogLevel(
+      SetLevelRequest(level: LoggingLevel.warning),
+    );
+
+    final logger = 'myLogger';
+    var notifications = [
+      for (var level in LoggingLevel.values)
+        LoggingMessageNotification(
+          data: '${level.name} message',
+          level: level,
+          logger: logger,
+        ),
+    ];
+
+    expect(
+      serverConnection.onLog,
+      emitsInOrder([
+        for (var notification in notifications)
+          if (notification.level >= LoggingLevel.warning) notification,
+      ]),
+    );
+
+    expect(
+      serverConnection.onLog,
+      neverEmits([
+        for (var notification in notifications)
+          if (notification.level < LoggingLevel.warning) notification,
+      ]),
+    );
+
+    for (var notification in notifications) {
+      server.log(
+        notification.level,
+        notification.data,
+        logger: notification.logger,
+      );
+    }
+
+    /// Allow the notifications to propagate.
+    await pumpEventQueue();
+
+    /// Closes the log stream so that `neverEmits` can complete above.
+    await environment.shutdown();
+  });
+
+  test('server can log functions for lazy evaluation', () async {
+    var environment = TestEnvironment(
+      TestMCPClient(),
+      TestMCPServerWithLogging.new,
+    );
+    await environment.initializeServer();
+
+    final serverConnection = environment.serverConnection;
+    final server = environment.server;
+
+    await serverConnection.setLogLevel(
+      SetLevelRequest(level: LoggingLevel.warning),
+    );
+
+    final lazyNotification = LoggingMessageNotification(
+      level: LoggingLevel.warning,
+      data: 'message',
+    );
+
+    expect(serverConnection.onLog, emits(lazyNotification));
+
+    server.log(lazyNotification.level, () => lazyNotification.data);
+
+    // Below logging level, never gets evaluated.
+    server.log(LoggingLevel.info, () => throw StateError('Unreachable'));
+  });
+}
+
+final class TestMCPServerWithLogging extends TestMCPServer with LoggingSupport {
+  TestMCPServerWithLogging(super.channel) : super();
+}

--- a/pkgs/dart_mcp/test/resources_support_test.dart
+++ b/pkgs/dart_mcp/test/resources_support_test.dart
@@ -82,9 +82,9 @@ void main() {
     );
 
     final resourceChangedQueue = StreamQueue(serverConnection.resourceUpdated);
-    serverConnection.subscribeResource(SubscribeRequest(uri: fooResource.uri));
-    // Let the server process the request
-    await pumpEventQueue();
+    await serverConnection.subscribeResource(
+      SubscribeRequest(uri: fooResource.uri),
+    );
 
     fooContents = 'baz';
     server.updateResource(fooResource);
@@ -111,11 +111,9 @@ void main() {
       ),
     );
 
-    serverConnection.unsubscribeResource(
+    await serverConnection.unsubscribeResource(
       UnsubscribeRequest(uri: fooResource.uri),
     );
-    // Let the server process the request
-    await pumpEventQueue();
 
     fooContents = 'zap';
     server.updateResource(fooResource);


### PR DESCRIPTION
See https://spec.modelcontextprotocol.io/specification/2025-03-26/server/utilities/logging/

I also fixed a bug in the resource support - I realized that subscribe/unsubscribe are supposed to return an empty response instead of no response.

Also updated a few of the extension types to take a `MetaWithProgressToken`.