### PR TITLE
support requests with no request params and no response data, handle null params for ping and listTools

### DIFF
--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -121,12 +121,10 @@ extension type RequestId( /*String|int*/ Parameter _) {}
 /// party is still alive.
 ///
 /// The receiver must promptly respond, or else may be disconnected.
-extension type PingRequest.fromMap(Map<String, Object?> _value)
-    implements Request {
+///
+/// The request itself has no parameters and should always be just `null`.
+extension type PingRequest._(Null _) {
   static const methodName = 'ping';
-
-  factory PingRequest({MetaWithProgressToken? meta}) =>
-      PingRequest.fromMap({if (meta != null) '_meta': meta});
 }
 
 /// An out-of-band notification used to inform the receiver of a progress

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -238,7 +238,7 @@ base class ServerConnection extends MCPBase {
   }
 
   /// List all the tools from this server.
-  Future<ListToolsResult> listTools(ListToolsRequest request) =>
+  Future<ListToolsResult> listTools([ListToolsRequest? request]) =>
       sendRequest(ListToolsRequest.methodName, request);
 
   /// Invokes a [Tool] returned from the [ListToolsResult].

--- a/pkgs/dart_mcp/lib/src/server/tools_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/tools_support.dart
@@ -73,7 +73,7 @@ base mixin ToolsSupport on MCPServer {
   }
 
   /// Returns the list of supported tools for this server.
-  ListToolsResult _listTools(ListToolsRequest request) =>
+  ListToolsResult _listTools([ListToolsRequest? request]) =>
       ListToolsResult(tools: [for (var tool in _registeredTools.values) tool]);
 
   /// Invoked when one of the registered tools is called.

--- a/pkgs/dart_mcp/lib/src/shared.dart
+++ b/pkgs/dart_mcp/lib/src/shared.dart
@@ -51,25 +51,25 @@ base class MCPBase {
   ///
   /// Any errors in [impl] will be reported to the client as JSON-RPC 2.0
   /// errors.
-  void registerRequestHandler<T extends Request, R extends Result>(
+  void registerRequestHandler<T extends Request?, R extends Result?>(
     String name,
     FutureOr<R> Function(T) impl,
   ) => _peer.registerMethod(
     name,
-    (Parameters p) => impl((p.value as Map).cast<String, Object?>() as T),
+    (Parameters p) => impl((p.value as Map?)?.cast<String, Object?>() as T),
   );
 
   /// Registers a notification handler named [name] on this server.
-  void registerNotificationHandler<T extends Notification>(
+  void registerNotificationHandler<T extends Notification?>(
     String name,
     void Function(T) impl,
   ) => _peer.registerMethod(
     name,
-    (Parameters p) => impl((p.value as Map).cast<String, Object?>() as T),
+    (Parameters p) => impl((p.value as Map?)?.cast<String, Object?>() as T),
   );
 
   /// Sends a notification to the peer.
-  void sendNotification(String method, Notification notification) =>
+  void sendNotification(String method, [Notification? notification]) =>
       _peer.sendNotification(method, notification);
 
   /// Notifies the peer of progress towards completing some request.
@@ -81,16 +81,16 @@ base class MCPBase {
   ///
   /// Closes any progress streams for [request] once the response has been
   /// received.
-  Future<T> sendRequest<T extends Result>(
-    String methodName,
-    Request request,
-  ) async {
+  Future<T> sendRequest<T extends Result?>(
+    String methodName, [
+    Request? request,
+  ]) async {
     try {
-      return (await _peer.sendRequest(methodName, request) as Map)
-              .cast<String, Object?>()
+      return ((await _peer.sendRequest(methodName, request)) as Map?)
+              ?.cast<String, Object?>()
           as T;
     } finally {
-      final token = request.meta?.progressToken;
+      final token = request?.meta?.progressToken;
       if (token != null) {
         await _progressControllers.remove(token)?.close();
       }
@@ -99,7 +99,9 @@ base class MCPBase {
 
   /// The peer may ping us at any time, and we should respond with an empty
   /// response.
-  EmptyResult _handlePing(PingRequest request) => EmptyResult();
+  ///
+  /// Note that [PingRequest] is always actually just `null`.
+  EmptyResult _handlePing([PingRequest? _]) => EmptyResult();
 
   /// Handles [ProgressNotification]s and forwards them to the streams returned
   /// by [onProgress] calls.
@@ -138,11 +140,9 @@ base class MCPBase {
   ///
   /// If the timeout is reached, future values or errors from the ping request
   /// are ignored.
-  Future<bool> ping(
-    PingRequest request, {
-    Duration timeout = const Duration(seconds: 1),
-  }) => sendRequest<EmptyResult>(
-    PingRequest.methodName,
-    request,
-  ).then((_) => true).timeout(timeout, onTimeout: () => false);
+  Future<bool> ping({Duration timeout = const Duration(seconds: 1)}) =>
+      sendRequest<EmptyResult>(
+        PingRequest.methodName,
+        null,
+      ).then((_) => true).timeout(timeout, onTimeout: () => false);
 }

--- a/pkgs/dart_mcp/test/client_and_server_test.dart
+++ b/pkgs/dart_mcp/test/client_and_server_test.dart
@@ -45,8 +45,8 @@ void main() {
     var environment = TestEnvironment(TestMCPClient(), TestMCPServer.new);
     await environment.initializeServer();
 
-    expect(await environment.serverConnection.ping(PingRequest()), true);
-    expect(await environment.server.ping(PingRequest()), true);
+    expect(await environment.serverConnection.ping(), true);
+    expect(await environment.server.ping(), true);
   });
 
   test('client can handle ping timeouts', () async {
@@ -66,7 +66,6 @@ void main() {
 
     expect(
       await environment.serverConnection.ping(
-        PingRequest(),
         timeout: const Duration(milliseconds: 1),
       ),
       false,
@@ -89,10 +88,7 @@ void main() {
     await environment.initializeServer();
 
     expect(
-      await environment.server.ping(
-        PingRequest(),
-        timeout: const Duration(milliseconds: 1),
-      ),
+      await environment.server.ping(timeout: const Duration(milliseconds: 1)),
       false,
     );
   });

--- a/pkgs/dart_mcp/test/tools_support_test.dart
+++ b/pkgs/dart_mcp/test/tools_support_test.dart
@@ -23,7 +23,7 @@ void main() {
 
     final serverConnection = environment.serverConnection;
 
-    final toolsResult = await serverConnection.listTools(ListToolsRequest());
+    final toolsResult = await serverConnection.listTools();
     expect(toolsResult.tools.length, 1);
 
     final tool = toolsResult.tools.single;
@@ -33,6 +33,12 @@ void main() {
     );
     expect(result.isError, isNot(true));
     expect(result.content.single, TestMCPServerWithTools.helloWorldContent);
+
+    expect(
+      await serverConnection.listTools(ListToolsRequest()),
+      toolsResult,
+      reason: 'can list tools with a non-null request object',
+    );
   });
 
   test('client can subscribe to tool list updates from the server', () async {


### PR DESCRIPTION
I noticed that pings didn't work from the inspector, and the latest version of cursor no longer sends an empty Params object for `listTools` (its not required so this is OK).

This handles those situations and adds general support for null request params and null responses.