### PR TITLE
[cleanup] remove the server name argument from the connect methods

### DIFF
--- a/pkgs/dart_mcp/example/client.dart
+++ b/pkgs/dart_mcp/example/client.dart
@@ -9,8 +9,7 @@ void main() async {
     ClientImplementation(name: 'example dart client', version: '0.1.0'),
   );
   print('connecting to server');
-  final serverName = 'example dart server';
-  final server = await client.connectStdioServer(serverName, 'dart', [
+  final server = await client.connectStdioServer('dart', [
     'run',
     'example/server.dart',
   ]);
@@ -52,5 +51,5 @@ void main() async {
     }
   }
 
-  await client.shutdownServer(serverName);
+  await client.shutdown();
 }

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -46,12 +46,11 @@ base class MCPClient {
   /// This can be modified by overriding the [initialize] method.
   final ClientCapabilities capabilities = ClientCapabilities();
 
-  final Map<String, ServerConnection> _connections = {};
+  final Set<ServerConnection> _connections = {};
 
-  /// Connect to a new MCP server with [name], by invoking [command] with
-  /// [arguments] and talking to that process over stdin/stdout.
+  /// Connect to a new MCP server by invoking [command] with [arguments] and
+  /// talking to that process over stdin/stdout.
   Future<ServerConnection> connectStdioServer(
-    String name,
     String command,
     List<String> arguments,
   ) async {
@@ -69,12 +68,12 @@ base class MCPClient {
             },
           ),
         );
-    return connectServer(name, channel);
+    return connectServer(channel);
   }
 
-  /// Returns a connection for an MCP server with [name], communicating over
-  /// [channel], which is already established.
-  ServerConnection connectServer(String name, StreamChannel<String> channel) {
+  /// Returns a connection for an MCP server using a [channel], which is already
+  /// established.
+  ServerConnection connectServer(StreamChannel<String> channel) {
     // For type promotion in this function.
     var self = this;
 
@@ -83,22 +82,14 @@ base class MCPClient {
       rootsSupport: self is RootsSupport ? self : null,
       samplingSupport: self is SamplingSupport ? self : null,
     );
-    _connections[name] = connection;
+    _connections.add(connection);
+    channel.sink.done.then((_) => _connections.remove(connection));
     return connection;
-  }
-
-  /// Shuts down a server connection by [name].
-  Future<void> shutdownServer(String name) {
-    var server = _connections.remove(name);
-    if (server == null) {
-      throw ArgumentError('No server with name $name');
-    }
-    return server.shutdown();
   }
 
   /// Shuts down all active server connections.
   Future<void> shutdown() async {
-    final connections = _connections.values.toList();
+    final connections = _connections.toList();
     _connections.clear();
     await Future.wait([
       for (var connection in connections) connection.shutdown(),

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -10,6 +10,7 @@ import 'dart:io';
 
 import 'package:async/async.dart' hide Result;
 import 'package:json_rpc_2/json_rpc_2.dart';
+import 'package:meta/meta.dart';
 import 'package:stream_channel/stream_channel.dart';
 
 import '../api/api.dart';
@@ -46,7 +47,8 @@ base class MCPClient {
   /// This can be modified by overriding the [initialize] method.
   final ClientCapabilities capabilities = ClientCapabilities();
 
-  final Set<ServerConnection> _connections = {};
+  @visibleForTesting
+  final Set<ServerConnection> connections = {};
 
   /// Connect to a new MCP server by invoking [command] with [arguments] and
   /// talking to that process over stdin/stdout.
@@ -82,15 +84,15 @@ base class MCPClient {
       rootsSupport: self is RootsSupport ? self : null,
       samplingSupport: self is SamplingSupport ? self : null,
     );
-    _connections.add(connection);
-    channel.sink.done.then((_) => _connections.remove(connection));
+    connections.add(connection);
+    channel.sink.done.then((_) => connections.remove(connection));
     return connection;
   }
 
   /// Shuts down all active server connections.
   Future<void> shutdown() async {
-    final connections = _connections.toList();
-    _connections.clear();
+    final connections = this.connections.toList();
+    this.connections.clear();
     await Future.wait([
       for (var connection in connections) connection.shutdown(),
     ]);

--- a/pkgs/dart_mcp/lib/src/client/roots_support.dart
+++ b/pkgs/dart_mcp/lib/src/client/roots_support.dart
@@ -53,7 +53,7 @@ base mixin RootsSupport on MCPClient {
   /// Called whenever the list of roots changes, it is the job of the server to
   /// then ask for the list of roots.
   void _notifyRootsListChanged() {
-    for (var server in _connections) {
+    for (var server in connections) {
       server.sendNotification(
         RootsListChangedNotification.methodName,
         RootsListChangedNotification(),

--- a/pkgs/dart_mcp/lib/src/client/roots_support.dart
+++ b/pkgs/dart_mcp/lib/src/client/roots_support.dart
@@ -53,7 +53,7 @@ base mixin RootsSupport on MCPClient {
   /// Called whenever the list of roots changes, it is the job of the server to
   /// then ask for the list of roots.
   void _notifyRootsListChanged() {
-    for (var server in _connections.values) {
+    for (var server in _connections) {
       server.sendNotification(
         RootsListChangedNotification.methodName,
         RootsListChangedNotification(),

--- a/pkgs/dart_mcp/test/client_and_server_test.dart
+++ b/pkgs/dart_mcp/test/client_and_server_test.dart
@@ -194,6 +194,12 @@ void main() {
     // Give the bad notification time to hit our stream.
     await pumpEventQueue();
   });
+
+  test('closing a server removes the connection', () async {
+    var environment = TestEnvironment(TestMCPClient(), TestMCPServer.new);
+    await environment.serverConnection.shutdown();
+    expect(environment.client.connections, isEmpty);
+  });
 }
 
 final class InitializeProgressTestMCPServer extends TestMCPServer

--- a/pkgs/dart_mcp/test/test_utils.dart
+++ b/pkgs/dart_mcp/test/test_utils.dart
@@ -40,10 +40,7 @@ class TestEnvironment<Client extends MCPClient, Server extends MCPServer> {
     Server Function(StreamChannel<String>) createServer,
   ) {
     server = createServer(serverChannel);
-    serverConnection = client.connectServer(
-      server.implementation.name,
-      clientChannel,
-    );
+    serverConnection = client.connectServer(clientChannel);
     addTearDown(shutdown);
   }
 


### PR DESCRIPTION
This wasn't necessary and it's mostly just awkward, removed the ability to shut down servers by name.

You can close the connections directly by calling `ServerConnection.shutdown`, and that is now the expected way to do it (or by calling `shutdown` on the client to shut down all servers).