### PR TITLE
Add Schema type for creating input schemas using typed interfaces

### DIFF
--- a/pkgs/dart_mcp/example/server.dart
+++ b/pkgs/dart_mcp/example/server.dart
@@ -41,7 +41,7 @@ base class DartMCPServer extends MCPServer with ToolsSupport {
   @override
   FutureOr<InitializeResult> initialize(InitializeRequest request) {
     registerTool(
-      Tool(name: 'hello world', inputSchema: InputSchema()),
+      Tool(name: 'hello world', inputSchema: ObjectSchema()),
       (_) => CallToolResult(content: [TextContent(text: 'hello world!')]),
     );
     return super.initialize(request);

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -5,6 +5,7 @@
 /// Interfaces are based on https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.json
 library;
 
+import 'package:collection/collection.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';
 
 part 'completions.dart';
@@ -340,13 +341,4 @@ extension type Annotations.fromMap(Map<String, Object?> _value) {
   ///
   /// Must be between 0 and 1.
   double? get priority => _value['priority'] as double?;
-}
-
-extension _IterableHelpers<T> on Iterable<T> {
-  T? firstWhereOrNull(bool Function(T element) test) {
-    for (var element in this) {
-      if (test(element)) return element;
-    }
-    return null;
-  }
 }

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -341,3 +341,12 @@ extension type Annotations.fromMap(Map<String, Object?> _value) {
   /// Must be between 0 and 1.
   double? get priority => _value['priority'] as double?;
 }
+
+extension _IterableHelpers<T> on Iterable<T> {
+  T? firstWhereOrNull(bool Function(T element) test) {
+    for (var element in this) {
+      if (test(element)) return element;
+    }
+    return null;
+  }
+}

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -218,13 +218,13 @@ extension type ObjectSchema.fromMap(Map<String, Object?> _value)
 
   /// A map of the properties of the object to the nested [Schema]s for those
   /// properties.
-  Map<String, Schema?>? get properties =>
-      (_value['properties'] as Map?)?.cast<String, Schema?>();
+  Map<String, Schema>? get properties =>
+      (_value['properties'] as Map?)?.cast<String, Schema>();
 
   /// A map of the property patterns of the object to the nested [Schema]s for
   /// those properties.
-  Map<String, Schema?>? get patternProperties =>
-      (_value['patternProperties'] as Map?)?.cast<String, Schema?>();
+  Map<String, Schema>? get patternProperties =>
+      (_value['patternProperties'] as Map?)?.cast<String, Schema>();
 
   /// A list of the required properties by name.
   List<String>? get required => (_value['required'] as List?)?.cast<String>();

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -113,7 +113,7 @@ extension type Tool.fromMap(Map<String, Object?> _value) {
       Tool.fromMap({
         'name': name,
         if (description != null) 'description': description,
-        'ObjectSchema': ObjectSchema,
+        'inputSchema': inputSchema,
       });
 
   /// The name of the tool.

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -108,12 +108,12 @@ extension type Tool.fromMap(Map<String, Object?> _value) {
   factory Tool({
     required String name,
     String? description,
-    required InputSchema inputSchema,
+    required Schema inputSchema,
   }) =>
       Tool.fromMap({
         'name': name,
         if (description != null) 'description': description,
-        'inputSchema': inputSchema,
+        'ObjectSchema': ObjectSchema,
       });
 
   /// The name of the tool.
@@ -122,26 +122,259 @@ extension type Tool.fromMap(Map<String, Object?> _value) {
   /// A human-readable description of the tool.
   String? get description => _value['description'] as String?;
 
-  /// A JSON Schema object defining the expected parameters for the tool.
-  InputSchema get inputSchema => _value['inputSchema'] as InputSchema;
+  /// A JSON [Schema] object defining the expected parameters for the tool.
+  Schema get inputSchema => _value['inputSchema'] as Schema;
 }
 
-/// A JSON Schema object defining the expected parameters for the tool.
-extension type InputSchema.fromMap(Map<String, Object?> _value) {
-  factory InputSchema({
-    Map<String, Object?>? properties,
+/// The valid types for properties in a JSON-RCP2 schema.
+enum JsonType {
+  object('object'),
+  list('array'),
+  string('string'),
+  number('number'),
+  integer('integer'),
+  bool('boolean'),
+  nil('null');
+
+  const JsonType(this.typeName);
+
+  final String typeName;
+}
+
+/// A JSON Schema object defining the any kind of property.
+///
+/// See the subtypes [ObjectSchema], [ListSchema], [StringSchema],
+/// [NumberSchema], [IntegerSchema], [BooleanSchema], [NullSchema].
+///
+/// To get an instance of a subtype, switch on the [type] and cast to the
+/// appropriate type. Normal `is` checks do not work on extension types.
+extension type Schema._(Map<String, Object?> _value) {
+  /// The [JsonType] of this schema.
+  ///
+  /// This is `null` if the type is a combination type such as [AllOf], [AnyOf],
+  /// [OneOf], or [not].
+  ///
+  /// Use this in switch statements to determine the type of schema and cast to
+  /// the appropriate subtype.
+  ///
+  /// Note that it is good practice to include a default case, to avoid breakage
+  /// in the case that a new type is added.
+  JsonType? get type => JsonType.values
+      .firstWhereOrNull((t) => _value['type'] as String == t.typeName);
+}
+
+/// A JSON Schema definition for an object with properties.
+extension type ObjectSchema.fromMap(Map<String, Object?> _value)
+    implements Schema {
+  factory ObjectSchema({
+    Map<String, Schema>? properties,
+    Map<String, Schema>? patternProperties,
     List<String>? required,
+
+    /// Must be one of bool, Schema, or Null
+    Object? additionalProperties,
+    bool? unevaluatedProperties,
+    StringSchema? propertyNames,
+    int? minProperties,
+    int? maxProperties,
   }) =>
-      InputSchema.fromMap({
-        'type': 'object',
+      ObjectSchema.fromMap({
+        'type': JsonType.object.typeName,
         if (properties != null) 'properties': properties,
+        if (patternProperties != null) 'patternProperties': patternProperties,
         if (required != null) 'required': required,
+        if (additionalProperties != null)
+          'additionalProperties': additionalProperties,
+        if (unevaluatedProperties != null)
+          'unevaluatedProperties': unevaluatedProperties,
+        if (propertyNames != null) 'propertyNames': propertyNames,
+        if (minProperties != null) 'minProperties': minProperties,
+        if (maxProperties != null) 'maxProperties': maxProperties,
       });
 
-  String get type => _value['type'] as String;
+  /// A map of the properties of the object to the nested [Schema]s for those
+  /// properties.
+  Map<String, Schema?>? get properties =>
+      (_value['properties'] as Map?)?.cast<String, Schema?>();
 
-  Map<String, Object?>? get properties =>
-      (_value['properties'] as Map?)?.cast<String, Object?>();
+  /// A map of the property patterns of the object to the nested [Schema]s for
+  /// those properties.
+  Map<String, Schema?>? get patternProperties =>
+      (_value['patternProperties'] as Map?)?.cast<String, Schema?>();
 
+  /// A list of the required properties by name.
   List<String>? get required => (_value['required'] as List?)?.cast<String>();
+
+  /// Rules for additional properties that don't match the
+  /// [properties] or [patternProperties] schemas.
+  ///
+  /// Can be either a [bool] or a [Schema], if it is a [Schema] then additional
+  /// properties should match that [Schema].
+  /*bool|Schema|Null*/ Object? get additionalProperties =>
+      _value['additionalProperties'];
+
+  /// Similar to [additionalProperties] but more flexible, see
+  /// https://json-schema.org/understanding-json-schema/reference/object#unevaluatedproperties
+  bool? get unevaluatedProperties => _value['unevaluatedProperties'] as bool?;
+
+  /// A list of valid patterns for all property names.
+  StringSchema? get propertyNames =>
+      (_value['propertyNames'] as Map?)?.cast<String, Object?>()
+          as StringSchema?;
+
+  /// The minimum number of properties in this object.
+  int? get minProperties => _value['minProperties'] as int?;
+
+  /// The maximum number of properties in this object.
+  int? get maxProperties => _value['maxProperties'] as int?;
+}
+
+/// A JSON Schema definition for a String.
+extension type const StringSchema.fromMap(Map<String, Object?> _value)
+    implements Schema {
+  factory StringSchema({
+    int? minLength,
+    int? maxLength,
+    String? pattern,
+  }) =>
+      StringSchema.fromMap({
+        'type': JsonType.string.typeName,
+        if (minLength != null) 'minLength': minLength,
+        if (maxLength != null) 'maxLength': maxLength,
+        if (pattern != null) 'pattern': pattern,
+      });
+
+  /// The minimum allowed length of this String.
+  int? get minLength => _value['minLength'] as int?;
+
+  /// The maximum allowed length of this String.
+  int? get maxLength => _value['maxLength'] as int?;
+
+  /// A regular expression pattern that the String must match.
+  String? get pattern => _value['pattern'] as String?;
+}
+
+/// A JSON Schema definition for a [num].
+extension type NumberSchema.fromMap(Map<String, Object?> _value)
+    implements Schema {
+  factory NumberSchema({
+    num? minimum,
+    num? maximum,
+    num? exclusiveMinimum,
+    num? exclusiveMaximum,
+    num? multipleOf,
+  }) =>
+      NumberSchema.fromMap({
+        'type': JsonType.number.typeName,
+        if (minimum != null) 'minimum': minimum,
+        if (maximum != null) 'maximum': maximum,
+        if (exclusiveMinimum != null) 'exclusiveMinimum': exclusiveMinimum,
+        if (exclusiveMaximum != null) 'exclusiveMaximum': exclusiveMaximum,
+        if (multipleOf != null) 'multipleOf': multipleOf,
+      });
+
+  /// The minimum value (inclusive) for this number.
+  num? get minimum => _value['minimum'] as num?;
+
+  /// The maximum value (inclusive) for this number.
+  num? get maximum => _value['maximum'] as num?;
+
+  /// The minimum value (exclusive) for this number.
+  num? get exclusiveMinimum => _value['exclusiveMinimum'] as num?;
+
+  /// The maximum value (exclusive) for this number.
+  num? get exclusiveMaximum => _value['exclusiveMaximum'] as num?;
+
+  /// The value must be a multiple of this number.
+  num? get multipleOf => _value['multipleOf'] as num?;
+}
+
+/// A JSON Schema definition for an [int].
+extension type IntegerSchema.fromMap(Map<String, Object?> _value)
+    implements Schema {
+  factory IntegerSchema({
+    int? minimum,
+    int? maximum,
+    int? exclusiveMinimum,
+    int? exclusiveMaximum,
+    num? multipleOf,
+  }) =>
+      IntegerSchema.fromMap({
+        'type': JsonType.integer.typeName,
+        if (minimum != null) 'minimum': minimum,
+        if (maximum != null) 'maximum': maximum,
+        if (exclusiveMinimum != null) 'exclusiveMinimum': exclusiveMinimum,
+        if (exclusiveMaximum != null) 'exclusiveMaximum': exclusiveMaximum,
+      });
+
+  /// The minimum value (inclusive) for this integer.
+  int? get minimum => _value['minimum'] as int?;
+
+  /// The maximum value (inclusive) for this integer.
+  int? get maximum => _value['maximum'] as int?;
+
+  /// The minimum value (exclusive) for this integer.
+  int? get exclusiveMinimum => _value['exclusiveMinimum'] as int?;
+
+  /// The maximum value (exclusive) for this integer.
+  int? get exclusiveMaximum => _value['exclusiveMaximum'] as int?;
+
+  /// The value must be a multiple of this number.
+  num? get multipleOf => _value['multipleOf'] as num?;
+}
+
+/// A JSON Schema definition for a [bool].
+extension type BooleanSchema.fromMap(Map<String, Object?> _value)
+    implements Schema {
+  factory BooleanSchema() =>
+      BooleanSchema.fromMap({'type': JsonType.bool.typeName});
+}
+
+/// A JSON Schema definition for `null`.
+extension type NullSchema.fromMap(Map<String, Object?> _value)
+    implements Schema {
+  factory NullSchema() => NullSchema.fromMap({'type': JsonType.nil.typeName});
+}
+
+/// A JSON Schema definition for a [List].
+extension type ListSchema.fromMap(Map<String, Object?> _value)
+    implements Schema {
+  factory ListSchema({
+    Schema? items,
+    List<Schema>? prefixItems,
+    bool? unevaluatedItems,
+    int? minItems,
+    int? maxItems,
+    bool? uniqueItems,
+  }) =>
+      ListSchema.fromMap({
+        'type': JsonType.list.typeName,
+        if (items != null) 'items': items,
+        if (prefixItems != null) 'prefixItems': prefixItems,
+        if (unevaluatedItems != null) 'unevaluatedItems': unevaluatedItems,
+        if (minItems != null) 'minItems': minItems,
+        if (maxItems != null) 'maxItems': maxItems,
+        if (uniqueItems != null) 'uniqueItems': uniqueItems,
+      });
+
+  /// The schema for all the items in this list, or all those after
+  /// [prefixItems] (if present).
+  Schema? get items => _value['items'] as Schema?;
+
+  /// The schema for the initial items in this list, if specified.
+  List<Schema>? get prefixItems =>
+      (_value['prefixItems'] as List?)?.cast<Schema>();
+
+  /// Whether or not  additional items in the list are allowed that don't
+  /// match the [items] or [prefixItems] schemas.
+  bool? get unevaluatedItems => _value['unevaluatedItems'] as bool?;
+
+  /// The minimum number of items in this list.
+  int? get minItems => _value['minItems'] as int?;
+
+  /// The maximum number of items in this list.
+  int? get maxItems => _value['maxItems'] as int?;
+
+  /// Whether or not all the items in this list must be unique.
+  bool? get uniqueItems => _value['uniqueItems'] as bool?;
 }

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -182,6 +182,27 @@ extension type Schema.fromMap(Map<String, Object?> _value) {
         if (not != null) 'not': not,
       });
 
+  /// Alias for [StringSchema.new].
+  static final string = StringSchema.new;
+
+  /// Alias for [BooleanSchema.new].
+  static final bool = BooleanSchema.new;
+
+  /// Alias for [NumberSchema.new].
+  static final num = NumberSchema.new;
+
+  /// Alias for [IntegerSchema.new].
+  static final int = IntegerSchema.new;
+
+  /// Alias for [ListSchema.new].
+  static final list = ListSchema.new;
+
+  /// Alias for [ObjectSchema.new].
+  static final object = ObjectSchema.new;
+
+  /// Alias for [NullSchema.new].
+  static final nil = NullSchema.new;
+
   /// The [JsonType] of this schema, if present.
   ///
   /// Use this in switch statements to determine the type of schema and cast to

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -160,7 +160,22 @@ enum JsonType {
 /// **Note:** Only a subset of the json schema spec is supported by these types,
 /// if you need something more complex you can create your own
 /// `Map<String, Object?>` and cast it to [Schema] (or [ObjectSchema]) directly.
-extension type Schema._(Map<String, Object?> _value) {
+extension type Schema.fromMap(Map<String, Object?> _value) {
+  factory Schema.withCombinators({
+    JsonType? type,
+    List<Schema>? allOf,
+    List<Schema>? anyOf,
+    List<Schema>? oneOf,
+    List<Schema>? not,
+  }) =>
+      Schema.fromMap({
+        if (allOf != null) 'allOf': allOf,
+        if (anyOf != null) 'anyOf': anyOf,
+        if (oneOf != null) 'oneOf': oneOf,
+        if (not != null) 'not': not,
+        if (type != null) 'type': type.typeName,
+      });
+
   /// The [JsonType] of this schema, if present.
   ///
   /// Use this in switch statements to determine the type of schema and cast to
@@ -175,16 +190,16 @@ extension type Schema._(Map<String, Object?> _value) {
       .firstWhereOrNull((t) => _value['type'] as String == t.typeName);
 
   /// Schema combinator that requires all sub-schemas to match.
-  SchemaCombinator? get allOf => _value['allOf'] as SchemaCombinator?;
+  List<Schema>? get allOf => (_value['allOf'] as List?)?.cast<Schema>();
 
   /// Schema combinator that requires at least one of the sub-schemas to match.
-  SchemaCombinator? get anyOf => _value['anyOf'] as SchemaCombinator?;
+  List<Schema>? get anyOf => (_value['anyOf'] as List?)?.cast<Schema>();
 
   /// Schema combinator that requires exactly one of the sub-schemas to match.
-  SchemaCombinator? get oneOf => _value['oneOf'] as SchemaCombinator?;
+  List<Schema>? get oneOf => (_value['oneOf'] as List?)?.cast<Schema>();
 
   /// Schema combinator that requires none of the sub-schemas to match.
-  SchemaCombinator? get not => _value['not'] as SchemaCombinator?;
+  List<Schema>? get not => (_value['not'] as List?)?.cast<Schema>();
 }
 
 /// A JSON Schema definition for an object with properties.
@@ -401,15 +416,4 @@ extension type ListSchema.fromMap(Map<String, Object?> _value)
 
   /// Whether or not all the items in this list must be unique.
   bool? get uniqueItems => _value['uniqueItems'] as bool?;
-}
-
-/// A schema combinator such as "allOf", "anyOf", "oneOf", or "not".
-///
-/// https://json-schema.org/understanding-json-schema/reference/combining#schema-composition
-extension type SchemaCombinator.fromList(List<Object?> _value) {
-  factory SchemaCombinator({required List<Schema> subSchemas}) =>
-      SchemaCombinator.fromList(subSchemas);
-
-  /// All the subSchemas in this combinator.
-  List<Schema> get subSchemas => _value.cast<Schema>();
 }

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -132,8 +132,8 @@ enum JsonType {
   object('object'),
   list('array'),
   string('string'),
-  number('number'),
-  integer('integer'),
+  num('number'),
+  int('integer'),
   bool('boolean'),
   nil('null');
 
@@ -289,7 +289,7 @@ extension type NumberSchema.fromMap(Map<String, Object?> _value)
     num? multipleOf,
   }) =>
       NumberSchema.fromMap({
-        'type': JsonType.number.typeName,
+        'type': JsonType.num.typeName,
         if (minimum != null) 'minimum': minimum,
         if (maximum != null) 'maximum': maximum,
         if (exclusiveMinimum != null) 'exclusiveMinimum': exclusiveMinimum,
@@ -324,7 +324,7 @@ extension type IntegerSchema.fromMap(Map<String, Object?> _value)
     num? multipleOf,
   }) =>
       IntegerSchema.fromMap({
-        'type': JsonType.integer.typeName,
+        'type': JsonType.int.typeName,
         if (minimum != null) 'minimum': minimum,
         if (maximum != null) 'maximum': maximum,
         if (exclusiveMinimum != null) 'exclusiveMinimum': exclusiveMinimum,

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -161,7 +161,9 @@ enum JsonType {
 /// if you need something more complex you can create your own
 /// `Map<String, Object?>` and cast it to [Schema] (or [ObjectSchema]) directly.
 extension type Schema.fromMap(Map<String, Object?> _value) {
-  factory Schema.withCombinators({
+  /// A combined schema, see
+  /// https://json-schema.org/understanding-json-schema/reference/combining#schema-composition
+  factory Schema.combined({
     JsonType? type,
     String? title,
     String? description,

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -163,17 +163,21 @@ enum JsonType {
 extension type Schema.fromMap(Map<String, Object?> _value) {
   factory Schema.withCombinators({
     JsonType? type,
+    String? title,
+    String? description,
     List<Schema>? allOf,
     List<Schema>? anyOf,
     List<Schema>? oneOf,
     List<Schema>? not,
   }) =>
       Schema.fromMap({
+        if (type != null) 'type': type.typeName,
+        if (title != null) 'title': title,
+        if (description != null) 'description': description,
         if (allOf != null) 'allOf': allOf,
         if (anyOf != null) 'anyOf': anyOf,
         if (oneOf != null) 'oneOf': oneOf,
         if (not != null) 'not': not,
-        if (type != null) 'type': type.typeName,
       });
 
   /// The [JsonType] of this schema, if present.
@@ -188,6 +192,12 @@ extension type Schema.fromMap(Map<String, Object?> _value) {
   /// combinators ([allOf], [anyOf], [oneOf], or [not]) are used.
   JsonType? get type => JsonType.values
       .firstWhereOrNull((t) => _value['type'] as String == t.typeName);
+
+  /// A title for this schema, should be short.
+  String? get title => _value['title'] as String?;
+
+  /// A description of this schema.
+  String? get description => _value['description'] as String?;
 
   /// Schema combinator that requires all sub-schemas to match.
   List<Schema>? get allOf => (_value['allOf'] as List?)?.cast<Schema>();
@@ -206,6 +216,8 @@ extension type Schema.fromMap(Map<String, Object?> _value) {
 extension type ObjectSchema.fromMap(Map<String, Object?> _value)
     implements Schema {
   factory ObjectSchema({
+    String? title,
+    String? description,
     Map<String, Schema>? properties,
     Map<String, Schema>? patternProperties,
     List<String>? required,
@@ -219,6 +231,8 @@ extension type ObjectSchema.fromMap(Map<String, Object?> _value)
   }) =>
       ObjectSchema.fromMap({
         'type': JsonType.object.typeName,
+        if (title != null) 'title': title,
+        if (description != null) 'description': description,
         if (properties != null) 'properties': properties,
         if (patternProperties != null) 'patternProperties': patternProperties,
         if (required != null) 'required': required,
@@ -272,12 +286,16 @@ extension type ObjectSchema.fromMap(Map<String, Object?> _value)
 extension type const StringSchema.fromMap(Map<String, Object?> _value)
     implements Schema {
   factory StringSchema({
+    String? title,
+    String? description,
     int? minLength,
     int? maxLength,
     String? pattern,
   }) =>
       StringSchema.fromMap({
         'type': JsonType.string.typeName,
+        if (title != null) 'title': title,
+        if (description != null) 'description': description,
         if (minLength != null) 'minLength': minLength,
         if (maxLength != null) 'maxLength': maxLength,
         if (pattern != null) 'pattern': pattern,
@@ -297,6 +315,8 @@ extension type const StringSchema.fromMap(Map<String, Object?> _value)
 extension type NumberSchema.fromMap(Map<String, Object?> _value)
     implements Schema {
   factory NumberSchema({
+    String? title,
+    String? description,
     num? minimum,
     num? maximum,
     num? exclusiveMinimum,
@@ -305,6 +325,8 @@ extension type NumberSchema.fromMap(Map<String, Object?> _value)
   }) =>
       NumberSchema.fromMap({
         'type': JsonType.num.typeName,
+        if (title != null) 'title': title,
+        if (description != null) 'description': description,
         if (minimum != null) 'minimum': minimum,
         if (maximum != null) 'maximum': maximum,
         if (exclusiveMinimum != null) 'exclusiveMinimum': exclusiveMinimum,
@@ -332,6 +354,8 @@ extension type NumberSchema.fromMap(Map<String, Object?> _value)
 extension type IntegerSchema.fromMap(Map<String, Object?> _value)
     implements Schema {
   factory IntegerSchema({
+    String? title,
+    String? description,
     int? minimum,
     int? maximum,
     int? exclusiveMinimum,
@@ -340,10 +364,13 @@ extension type IntegerSchema.fromMap(Map<String, Object?> _value)
   }) =>
       IntegerSchema.fromMap({
         'type': JsonType.int.typeName,
+        if (title != null) 'title': title,
+        if (description != null) 'description': description,
         if (minimum != null) 'minimum': minimum,
         if (maximum != null) 'maximum': maximum,
         if (exclusiveMinimum != null) 'exclusiveMinimum': exclusiveMinimum,
         if (exclusiveMaximum != null) 'exclusiveMaximum': exclusiveMaximum,
+        if (multipleOf != null) 'multipleOf': multipleOf,
       });
 
   /// The minimum value (inclusive) for this integer.
@@ -365,20 +392,37 @@ extension type IntegerSchema.fromMap(Map<String, Object?> _value)
 /// A JSON Schema definition for a [bool].
 extension type BooleanSchema.fromMap(Map<String, Object?> _value)
     implements Schema {
-  factory BooleanSchema() =>
-      BooleanSchema.fromMap({'type': JsonType.bool.typeName});
+  factory BooleanSchema({
+    String? title,
+    String? description,
+  }) =>
+      BooleanSchema.fromMap({
+        'type': JsonType.bool.typeName,
+        if (title != null) 'title': title,
+        if (description != null) 'description': description,
+      });
 }
 
 /// A JSON Schema definition for `null`.
 extension type NullSchema.fromMap(Map<String, Object?> _value)
     implements Schema {
-  factory NullSchema() => NullSchema.fromMap({'type': JsonType.nil.typeName});
+  factory NullSchema({
+    String? title,
+    String? description,
+  }) =>
+      NullSchema.fromMap({
+        'type': JsonType.nil.typeName,
+        if (title != null) 'title': title,
+        if (description != null) 'description': description,
+      });
 }
 
 /// A JSON Schema definition for a [List].
 extension type ListSchema.fromMap(Map<String, Object?> _value)
     implements Schema {
   factory ListSchema({
+    String? title,
+    String? description,
     Schema? items,
     List<Schema>? prefixItems,
     bool? unevaluatedItems,
@@ -388,6 +432,8 @@ extension type ListSchema.fromMap(Map<String, Object?> _value)
   }) =>
       ListSchema.fromMap({
         'type': JsonType.list.typeName,
+        if (title != null) 'title': title,
+        if (description != null) 'description': description,
         if (items != null) 'items': items,
         if (prefixItems != null) 'prefixItems': prefixItems,
         if (unevaluatedItems != null) 'unevaluatedItems': unevaluatedItems,

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -108,7 +108,7 @@ extension type Tool.fromMap(Map<String, Object?> _value) {
   factory Tool({
     required String name,
     String? description,
-    required Schema inputSchema,
+    required ObjectSchema inputSchema,
   }) =>
       Tool.fromMap({
         'name': name,

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -122,8 +122,9 @@ extension type Tool.fromMap(Map<String, Object?> _value) {
   /// A human-readable description of the tool.
   String? get description => _value['description'] as String?;
 
-  /// A JSON [Schema] object defining the expected parameters for the tool.
-  Schema get inputSchema => _value['inputSchema'] as Schema;
+  /// A JSON [ObjectSchema] object defining the expected parameters for the
+  /// tool.
+  ObjectSchema get inputSchema => _value['inputSchema'] as ObjectSchema;
 }
 
 /// The valid types for properties in a JSON-RCP2 schema.

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -183,25 +183,25 @@ extension type Schema.fromMap(Map<String, Object?> _value) {
       });
 
   /// Alias for [StringSchema.new].
-  static final string = StringSchema.new;
+  static const string = StringSchema.new;
 
   /// Alias for [BooleanSchema.new].
-  static final bool = BooleanSchema.new;
+  static const bool = BooleanSchema.new;
 
   /// Alias for [NumberSchema.new].
-  static final num = NumberSchema.new;
+  static const num = NumberSchema.new;
 
   /// Alias for [IntegerSchema.new].
-  static final int = IntegerSchema.new;
+  static const int = IntegerSchema.new;
 
   /// Alias for [ListSchema.new].
-  static final list = ListSchema.new;
+  static const list = ListSchema.new;
 
   /// Alias for [ObjectSchema.new].
-  static final object = ObjectSchema.new;
+  static const object = ObjectSchema.new;
 
   /// Alias for [NullSchema.new].
-  static final nil = NullSchema.new;
+  static const nil = NullSchema.new;
 
   /// The [JsonType] of this schema, if present.
   ///

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -150,7 +150,15 @@ enum JsonType {
 /// check for any schema combinators ([allOf], [anyOf], [oneOf], [not]), as both
 /// may be present.
 ///
-/// If a [type] is provided, it applies to all sub-schemas.
+/// If a [type] is provided, it applies to all sub-schemas, and you can cast all
+/// the sub-schemas directly to the specified type from the parent schema.
+///
+/// See https://json-schema.org/understanding-json-schema/reference for the full
+/// specification.
+///
+/// **Note:** Only a subset of the json schema spec is supported by these types,
+/// if you need something more complex you can create your own
+/// `Map<String, Object?>` and cast it to [Schema] (or [ObjectSchema]) directly.
 extension type Schema._(Map<String, Object?> _value) {
   /// The [JsonType] of this schema, if present.
   ///

--- a/pkgs/dart_mcp/pubspec.yaml
+++ b/pkgs/dart_mcp/pubspec.yaml
@@ -6,6 +6,7 @@ environment:
   sdk: ^3.6.1 # The version of dart in the current flutter stable
 dependencies:
   async: ^2.13.0
+  collection: ^1.19.1
   json_rpc_2: ^3.0.3
   meta: ^1.16.0
   stream_channel: ^2.1.4

--- a/pkgs/dart_mcp/test/client_and_server_test.dart
+++ b/pkgs/dart_mcp/test/client_and_server_test.dart
@@ -228,7 +228,7 @@ final class InitializeProgressTestMCPServer extends TestMCPServer
 
   static final myProgressTool = Tool(
     name: 'progress',
-    inputSchema: InputSchema(),
+    inputSchema: ObjectSchema(),
   );
 }
 

--- a/pkgs/dart_mcp/test/tools_support_test.dart
+++ b/pkgs/dart_mcp/test/tools_support_test.dart
@@ -147,7 +147,8 @@ void main() {
         'minimum': 1,
         'maximum': 10,
         'exclusiveMinimum': 0,
-        'exclusiveMaximum': 11
+        'exclusiveMaximum': 11,
+        'multipleOf': 2,
       });
     });
 

--- a/pkgs/dart_mcp/test/tools_support_test.dart
+++ b/pkgs/dart_mcp/test/tools_support_test.dart
@@ -60,7 +60,7 @@ void main() {
     );
 
     server.registerTool(
-      Tool(name: 'foo', inputSchema: InputSchema()),
+      Tool(name: 'foo', inputSchema: ObjectSchema()),
       (_) => CallToolResult(content: []),
     );
 
@@ -88,7 +88,7 @@ final class TestMCPServerWithTools extends TestMCPServer with ToolsSupport {
 
   static final helloWorld = Tool(
     name: 'hello world',
-    inputSchema: InputSchema(),
+    inputSchema: ObjectSchema(),
   );
 
   static final helloWorldContent = TextContent(

--- a/pkgs/dart_mcp/test/tools_support_test.dart
+++ b/pkgs/dart_mcp/test/tools_support_test.dart
@@ -184,15 +184,41 @@ void main() {
       });
     });
 
-    test('SchemaCombinator', () {
-      final schema = SchemaCombinator(subSchemas: [
-        StringSchema(),
-        IntegerSchema(),
-      ]);
-      expect(schema.subSchemas, [
-        {'type': 'string'},
-        {'type': 'integer'}
-      ]);
+    test('Schema', () {
+      final schema = Schema.withCombinators(
+        allOf: [
+          StringSchema(),
+          IntegerSchema(),
+        ],
+        anyOf: [
+          StringSchema(),
+          IntegerSchema(),
+        ],
+        oneOf: [
+          StringSchema(),
+          IntegerSchema(),
+        ],
+        not: [StringSchema()],
+        type: JsonType.bool,
+      );
+      expect(schema, {
+        'allOf': [
+          {'type': 'string'},
+          {'type': 'integer'}
+        ],
+        'anyOf': [
+          {'type': 'string'},
+          {'type': 'integer'}
+        ],
+        'oneOf': [
+          {'type': 'string'},
+          {'type': 'integer'}
+        ],
+        'not': [
+          {'type': 'string'}
+        ],
+        'type': 'boolean'
+      });
     });
   });
 }

--- a/pkgs/dart_mcp/test/tools_support_test.dart
+++ b/pkgs/dart_mcp/test/tools_support_test.dart
@@ -96,7 +96,7 @@ void main() {
         'required': ['foo'],
         'additionalProperties': false,
         'unevaluatedProperties': true,
-        'propertyNames': {'type': 'string', 'pattern': '^[a-z]+\$'},
+        'propertyNames': {'type': 'string', 'pattern': r'^[a-z]+$'},
         'minProperties': 1,
         'maxProperties': 2
       });
@@ -112,7 +112,7 @@ void main() {
         'type': 'string',
         'minLength': 1,
         'maxLength': 10,
-        'pattern': '^[a-z]+\$'
+        'pattern': r'^[a-z]+$'
       });
     });
 

--- a/pkgs/dart_mcp/test/tools_support_test.dart
+++ b/pkgs/dart_mcp/test/tools_support_test.dart
@@ -72,6 +72,129 @@ void main() {
     // Need to manually close so the stream matchers can complete.
     await environment.shutdown();
   });
+
+  group('Schemas', () {
+    test('ObjectSchema', () {
+      final schema = ObjectSchema(
+        properties: {
+          'foo': StringSchema(),
+          'bar': IntegerSchema(),
+        },
+        required: ['foo'],
+        additionalProperties: false,
+        unevaluatedProperties: true,
+        propertyNames: StringSchema(pattern: r'^[a-z]+$'),
+        minProperties: 1,
+        maxProperties: 2,
+      );
+      expect(schema, {
+        'type': 'object',
+        'properties': {
+          'foo': {'type': 'string'},
+          'bar': {'type': 'integer'}
+        },
+        'required': ['foo'],
+        'additionalProperties': false,
+        'unevaluatedProperties': true,
+        'propertyNames': {'type': 'string', 'pattern': '^[a-z]+\$'},
+        'minProperties': 1,
+        'maxProperties': 2
+      });
+    });
+
+    test('StringSchema', () {
+      final schema = StringSchema(
+        minLength: 1,
+        maxLength: 10,
+        pattern: r'^[a-z]+$',
+      );
+      expect(schema, {
+        'type': 'string',
+        'minLength': 1,
+        'maxLength': 10,
+        'pattern': '^[a-z]+\$'
+      });
+    });
+
+    test('NumberSchema', () {
+      final schema = NumberSchema(
+        minimum: 1,
+        maximum: 10,
+        exclusiveMinimum: 0,
+        exclusiveMaximum: 11,
+        multipleOf: 2,
+      );
+      expect(schema, {
+        'type': 'number',
+        'minimum': 1,
+        'maximum': 10,
+        'exclusiveMinimum': 0,
+        'exclusiveMaximum': 11,
+        'multipleOf': 2
+      });
+    });
+
+    test('IntegerSchema', () {
+      final schema = IntegerSchema(
+        minimum: 1,
+        maximum: 10,
+        exclusiveMinimum: 0,
+        exclusiveMaximum: 11,
+        multipleOf: 2,
+      );
+      expect(schema, {
+        'type': 'integer',
+        'minimum': 1,
+        'maximum': 10,
+        'exclusiveMinimum': 0,
+        'exclusiveMaximum': 11
+      });
+    });
+
+    test('BooleanSchema', () {
+      final schema = BooleanSchema();
+      expect(schema, {'type': 'boolean'});
+    });
+
+    test('NullSchema', () {
+      final schema = NullSchema();
+      expect(schema, {'type': 'null'});
+    });
+
+    test('ListSchema', () {
+      final schema = ListSchema(
+        items: StringSchema(),
+        prefixItems: [IntegerSchema(), BooleanSchema()],
+        unevaluatedItems: false,
+        minItems: 1,
+        maxItems: 10,
+        uniqueItems: true,
+      );
+      expect(schema, {
+        'type': 'array',
+        'items': {'type': 'string'},
+        'prefixItems': [
+          {'type': 'integer'},
+          {'type': 'boolean'}
+        ],
+        'unevaluatedItems': false,
+        'minItems': 1,
+        'maxItems': 10,
+        'uniqueItems': true
+      });
+    });
+
+    test('SchemaCombinator', () {
+      final schema = SchemaCombinator(subSchemas: [
+        StringSchema(),
+        IntegerSchema(),
+      ]);
+      expect(schema.subSchemas, [
+        {'type': 'string'},
+        {'type': 'integer'}
+      ]);
+    });
+  });
 }
 
 final class TestMCPServerWithTools extends TestMCPServer with ToolsSupport {

--- a/pkgs/dart_mcp/test/tools_support_test.dart
+++ b/pkgs/dart_mcp/test/tools_support_test.dart
@@ -76,6 +76,9 @@ void main() {
   group('Schemas', () {
     test('ObjectSchema', () {
       final schema = ObjectSchema(
+        title: 'Foo',
+        description: 'Bar',
+        patternProperties: {'^foo': StringSchema()},
         properties: {
           'foo': StringSchema(),
           'bar': IntegerSchema(),
@@ -89,6 +92,11 @@ void main() {
       );
       expect(schema, {
         'type': 'object',
+        'title': 'Foo',
+        'description': 'Bar',
+        'patternProperties': {
+          '^foo': {'type': 'string'}
+        },
         'properties': {
           'foo': {'type': 'string'},
           'bar': {'type': 'integer'}
@@ -104,12 +112,16 @@ void main() {
 
     test('StringSchema', () {
       final schema = StringSchema(
+        title: 'Foo',
+        description: 'Bar',
         minLength: 1,
         maxLength: 10,
         pattern: r'^[a-z]+$',
       );
       expect(schema, {
         'type': 'string',
+        'title': 'Foo',
+        'description': 'Bar',
         'minLength': 1,
         'maxLength': 10,
         'pattern': r'^[a-z]+$'
@@ -118,6 +130,8 @@ void main() {
 
     test('NumberSchema', () {
       final schema = NumberSchema(
+        title: 'Foo',
+        description: 'Bar',
         minimum: 1,
         maximum: 10,
         exclusiveMinimum: 0,
@@ -126,6 +140,8 @@ void main() {
       );
       expect(schema, {
         'type': 'number',
+        'title': 'Foo',
+        'description': 'Bar',
         'minimum': 1,
         'maximum': 10,
         'exclusiveMinimum': 0,
@@ -136,6 +152,8 @@ void main() {
 
     test('IntegerSchema', () {
       final schema = IntegerSchema(
+        title: 'Foo',
+        description: 'Bar',
         minimum: 1,
         maximum: 10,
         exclusiveMinimum: 0,
@@ -144,6 +162,8 @@ void main() {
       );
       expect(schema, {
         'type': 'integer',
+        'title': 'Foo',
+        'description': 'Bar',
         'minimum': 1,
         'maximum': 10,
         'exclusiveMinimum': 0,
@@ -153,17 +173,33 @@ void main() {
     });
 
     test('BooleanSchema', () {
-      final schema = BooleanSchema();
-      expect(schema, {'type': 'boolean'});
+      final schema = BooleanSchema(
+        title: 'Foo',
+        description: 'Bar',
+      );
+      expect(schema, {
+        'type': 'boolean',
+        'title': 'Foo',
+        'description': 'Bar',
+      });
     });
 
     test('NullSchema', () {
-      final schema = NullSchema();
-      expect(schema, {'type': 'null'});
+      final schema = NullSchema(
+        title: 'Foo',
+        description: 'Bar',
+      );
+      expect(schema, {
+        'type': 'null',
+        'title': 'Foo',
+        'description': 'Bar',
+      });
     });
 
     test('ListSchema', () {
       final schema = ListSchema(
+        title: 'Foo',
+        description: 'Bar',
         items: StringSchema(),
         prefixItems: [IntegerSchema(), BooleanSchema()],
         unevaluatedItems: false,
@@ -173,6 +209,8 @@ void main() {
       );
       expect(schema, {
         'type': 'array',
+        'title': 'Foo',
+        'description': 'Bar',
         'items': {'type': 'string'},
         'prefixItems': [
           {'type': 'integer'},
@@ -187,6 +225,9 @@ void main() {
 
     test('Schema', () {
       final schema = Schema.withCombinators(
+        type: JsonType.bool,
+        title: 'Foo',
+        description: 'Bar',
         allOf: [
           StringSchema(),
           IntegerSchema(),
@@ -200,9 +241,11 @@ void main() {
           IntegerSchema(),
         ],
         not: [StringSchema()],
-        type: JsonType.bool,
       );
       expect(schema, {
+        'type': 'boolean',
+        'title': 'Foo',
+        'description': 'Bar',
         'allOf': [
           {'type': 'string'},
           {'type': 'integer'}
@@ -218,7 +261,6 @@ void main() {
         'not': [
           {'type': 'string'}
         ],
-        'type': 'boolean'
       });
     });
   });

--- a/pkgs/dart_mcp/test/tools_support_test.dart
+++ b/pkgs/dart_mcp/test/tools_support_test.dart
@@ -224,7 +224,7 @@ void main() {
     });
 
     test('Schema', () {
-      final schema = Schema.withCombinators(
+      final schema = Schema.combined(
         type: JsonType.bool,
         title: 'Foo',
         description: 'Bar',

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
@@ -147,9 +147,9 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
   }
 
   static final _connectTool = Tool(
-    inputSchema: InputSchema(
-      properties: const {
-        'uri': {'type': 'string'},
+    inputSchema: ObjectSchema(
+      properties: {
+        'uri': StringSchema(),
       },
       required: const ['uri'],
     ),
@@ -165,7 +165,7 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
     description: 'Takes a screenshot of the active flutter application in its '
         'current state. Requires "${_connectTool.name}" to be successfully '
         'called first.',
-    inputSchema: InputSchema(),
+    inputSchema: ObjectSchema(),
   );
 
   static final _dtdNotConnected = CallToolResult(


### PR DESCRIPTION
Closes https://github.com/dart-lang/ai/issues/29

This isn't a full implementation of the spec but should cover all the common use cases. You can always just bring your own map here and cast it to the `ObjectSchema` type, if needed.