### PR TITLE
Add basic analysis support

### DIFF
--- a/.github/workflows/dart_tooling_mcp_server.yaml
+++ b/.github/workflows/dart_tooling_mcp_server.yaml
@@ -57,4 +57,3 @@ jobs:
         if: ${{ matrix.flutterSdk == 'dev' }}
 
       - run: xvfb-run -s "-screen 0 1024x768x24" dart test
-        env:

--- a/.github/workflows/dart_tooling_mcp_server.yaml
+++ b/.github/workflows/dart_tooling_mcp_server.yaml
@@ -35,6 +35,9 @@ jobs:
       - uses: subosito/flutter-action@v1
         with:
           channel: ${{ matrix.flutterSdk }}
+          cache: true
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+      - run: export DART_SDK="$(which dart)"
 
       # Required to build for linux
       - run: |
@@ -54,3 +57,4 @@ jobs:
         if: ${{ matrix.flutterSdk == 'dev' }}
 
       - run: xvfb-run -s "-screen 0 1024x768x24" dart test
+        env:

--- a/.github/workflows/dart_tooling_mcp_server.yaml
+++ b/.github/workflows/dart_tooling_mcp_server.yaml
@@ -37,7 +37,9 @@ jobs:
           channel: ${{ matrix.flutterSdk }}
           cache: true
           cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-      - run: export DART_SDK="$(which dart)"
+      # Exposes the DART_SDK environment variable to all other actions.
+      # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
+      - run: echo "DART_SDK=$(which dart)" >> "$GITHUB_ENV"
 
       # Required to build for linux
       - run: |

--- a/.github/workflows/dart_tooling_mcp_server.yaml
+++ b/.github/workflows/dart_tooling_mcp_server.yaml
@@ -39,7 +39,7 @@ jobs:
           cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
       # Exposes the DART_SDK environment variable to all other actions.
       # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
-      - run: echo "DART_SDK=$(which dart)" >> "$GITHUB_ENV"
+      - run: echo "DART_SDK=$(which dart | xargs dirname | xargs dirname)" >> "$GITHUB_ENV"
 
       # Required to build for linux
       - run: |

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -57,6 +57,12 @@ base class MCPClient {
     List<String> arguments,
   ) async {
     var process = await Process.start(command, arguments);
+    process.stderr
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen((line) {
+      stderr.writeln('[StdErr from server $command]: $line');
+    });
     var channel = StreamChannel.withCloseGuarantee(
       process.stdout,
       process.stdin,

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -24,7 +24,7 @@ part 'tools_support.dart';
 abstract base class MCPServer extends MCPBase {
   /// Completes when this server has finished initialization and gotten the
   /// final ack from the client.
-  FutureOr<void> get initialized => _initialized.future;
+  Future<void> get initialized => _initialized.future;
   final Completer<void> _initialized = Completer<void>();
 
   /// Whether this server is still active and has completed initialization.

--- a/pkgs/dart_tooling_mcp_server/bin/main.dart
+++ b/pkgs/dart_tooling_mcp_server/bin/main.dart
@@ -2,10 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io' as io;
 
 import 'package:async/async.dart';
+import 'package:dart_mcp/server.dart';
 import 'package:dart_tooling_mcp_server/dart_tooling_mcp_server.dart';
 import 'package:stream_channel/stream_channel.dart';
 
@@ -18,16 +20,35 @@ void main(List<String> args) async {
     io.exit(1);
   }
 
-  await DartToolingMCPServer.connect(
-    StreamChannel.withCloseGuarantee(io.stdin, io.stdout)
-        .transform(StreamChannelTransformer.fromCodec(utf8))
-        .transformStream(const LineSplitter())
-        .transformSink(
-      StreamSinkTransformer.fromHandlers(
-        handleData: (data, sink) {
-          sink.add('$data\n');
-        },
+  DartToolingMCPServer? server;
+  await runZonedGuarded(() async {
+    server = await DartToolingMCPServer.connect(
+      StreamChannel.withCloseGuarantee(io.stdin, io.stdout)
+          .transform(StreamChannelTransformer.fromCodec(utf8))
+          .transformStream(const LineSplitter())
+          .transformSink(
+        StreamSinkTransformer.fromHandlers(
+          handleData: (data, sink) {
+            sink.add('$data\n');
+          },
+        ),
       ),
-    ),
-  );
+    );
+  }, (e, s) {
+    if (server != null) {
+      // Log unhandled errors to the client, if we managed to connect.
+      server!.log(LoggingLevel.error, '$e\n$s');
+    } else {
+      // Otherwise log to stderr.
+      io.stderr
+        ..writeln(e)
+        ..writeln(s);
+    }
+  }, zoneSpecification: ZoneSpecification(print: (_, __, ___, value) {
+    if (server != null) {
+      // Don't allow `print` since this breaks stdio communication, but if we
+      // have a server we do log messages to the client.
+      server!.log(LoggingLevel.info, value);
+    }
+  }));
 }

--- a/pkgs/dart_tooling_mcp_server/bin/main.dart
+++ b/pkgs/dart_tooling_mcp_server/bin/main.dart
@@ -36,8 +36,10 @@ void main(List<String> args) async {
     );
   }, (e, s) {
     if (server != null) {
-      // Log unhandled errors to the client, if we managed to connect.
-      server!.log(LoggingLevel.error, '$e\n$s');
+      try {
+        // Log unhandled errors to the client, if we managed to connect.
+        server!.log(LoggingLevel.error, '$e\n$s');
+      } catch (_) {}
     } else {
       // Otherwise log to stderr.
       io.stderr
@@ -46,9 +48,11 @@ void main(List<String> args) async {
     }
   }, zoneSpecification: ZoneSpecification(print: (_, __, ___, value) {
     if (server != null) {
-      // Don't allow `print` since this breaks stdio communication, but if we
-      // have a server we do log messages to the client.
-      server!.log(LoggingLevel.info, value);
+      try {
+        // Don't allow `print` since this breaks stdio communication, but if we
+        // have a server we do log messages to the client.
+        server!.log(LoggingLevel.info, value);
+      } catch (_) {}
     }
   }));
 }

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
@@ -8,6 +8,7 @@ import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:dart_mcp/server.dart';
 import 'package:meta/meta.dart';
+import 'package:path/path.dart' as p;
 
 /// Mix this in to any MCPServer to add support for analyzing Dart projects.
 ///
@@ -55,7 +56,7 @@ base mixin DartAnalyzerSupport on ToolsSupport {
     _analysisContexts = AnalysisContextCollection(includedPaths: paths);
   }
 
-  /// Implementation of the [_analyzeFilesTool], analyzes the requested files
+  /// Implementation of the [analyzeFilesTool], analyzes the requested files
   /// under the requested project roots.
   Future<CallToolResult> _analyzeFiles(CallToolRequest request) async {
     var contexts = _analysisContexts;
@@ -91,8 +92,9 @@ base mixin DartAnalyzerSupport on ToolsSupport {
       }
 
       for (var path in paths) {
-        var errorsResult = await context.currentSession
-            .getErrors(rootUri.resolve(path).toFilePath());
+        var normalized = p.normalize(
+            p.isAbsolute(path) ? path : p.join(rootUri.toFilePath(), path));
+        var errorsResult = await context.currentSession.getErrors(normalized);
         if (errorsResult is! ErrorsResult) {
           return CallToolResult(content: [
             TextContent(text: 'Error computing analyzer errors $errorsResult'),

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
@@ -1,0 +1,136 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:dart_mcp/server.dart';
+
+/// Mix this in to any MCPServer to add support for analyzing Dart projects.
+///
+/// The MCPServer must already have the [ToolsSupport] mixin applied.
+base mixin DartAnalyzerSupport on ToolsSupport {
+  /// The analyzed contexts.
+  AnalysisContextCollection? _analysisContexts;
+
+  @override
+  FutureOr<InitializeResult> initialize(InitializeRequest request) {
+    if (request.capabilities.roots == null) {
+      throw StateError(
+          'This server requires the "roots" capability to be implemented.');
+    }
+    registerTool(_analyzeFilesTool, _analyzeFiles);
+    initialized.then(_listenForRoots);
+    return super.initialize(request);
+  }
+
+  /// Lists the roots, and listens for changes to them.
+  ///
+  /// Whenever new roots are found, creates a new [AnalysisContextCollection].
+  void _listenForRoots([void _]) async {
+    rootsListChanged!.listen((event) async {
+      unawaited(_analysisContexts?.dispose());
+      _analysisContexts = null;
+      _createAnalysisContext(await listRoots(ListRootsRequest()));
+    });
+    _createAnalysisContext(await listRoots(ListRootsRequest()));
+  }
+
+  /// Creates an analysis context from a list of roots.
+  //
+  // TODO: Watch the file system for changes to files.
+  void _createAnalysisContext(ListRootsResult result) async {
+    final paths = <String>[];
+    for (var root in result.roots) {
+      var uri = Uri.parse(root.uri);
+      if (uri.scheme != 'file') {
+        throw ArgumentError.value(
+            root.uri, 'uri', 'Only file scheme uris are allowed for roots');
+      }
+      paths.add(uri.toFilePath());
+    }
+    _analysisContexts = AnalysisContextCollection(includedPaths: paths);
+  }
+
+  /// Implementation of the [_analyzeFilesTool], analyzes the requested files
+  /// under the requested project roots.
+  Future<CallToolResult> _analyzeFiles(CallToolRequest request) async {
+    var contexts = _analysisContexts;
+    if (contexts == null) {
+      return CallToolResult(content: [
+        TextContent(
+            text: 'Analysis not yet ready, please wait a few seconds and try '
+                'again.')
+      ], isError: true);
+    }
+
+    var messages = <TextContent>[];
+    final rootConfigs =
+        (request.arguments!['roots'] as List).cast<Map<String, Object?>>();
+    for (var rootConfig in rootConfigs) {
+      var rootUri = Uri.parse(rootConfig['root'] as String);
+      if (rootUri.scheme != 'file') {
+        return CallToolResult(content: [
+          TextContent(
+              text: 'Only file scheme uris are allowed for roots, but got '
+                  '$rootUri')
+        ], isError: true);
+      }
+      var context = contexts.contextFor(rootUri.toFilePath());
+      var paths = (rootConfig['paths'] as List?)?.cast<String>();
+      if (paths == null) {
+        return CallToolResult(content: [
+          TextContent(
+              text:
+                  'Missing required argument `paths`, which should be the list '
+                  'of relative paths to analyze.')
+        ], isError: true);
+      }
+
+      for (var path in paths) {
+        var errorsResult = await context.currentSession
+            .getErrors(rootUri.resolve(path).toFilePath());
+        if (errorsResult is! ErrorsResult) {
+          return CallToolResult(content: [
+            TextContent(text: 'Error computing analyzer errors $errorsResult'),
+          ]);
+        }
+        for (var error in errorsResult.errors) {
+          messages.add(TextContent(text: 'Error: ${error.message}'));
+          if (error.correctionMessage case var correctionMessage?) {
+            messages.add(TextContent(text: correctionMessage));
+          }
+        }
+      }
+    }
+
+    return CallToolResult(content: messages);
+  }
+
+  static final _analyzeFilesTool = Tool(
+      name: 'analyze files',
+      description:
+          'Analyzes the requested file paths under the specified project roots '
+          'and returns the results as a list of messages.',
+      inputSchema: ObjectSchema(properties: {
+        'roots': ListSchema(
+            title: 'All projects roots to analyze',
+            description:
+                'These must match a root returned by a call to "listRoots".',
+            items: ObjectSchema(
+              properties: {
+                'root': StringSchema(
+                    title: 'The URI of the project root to analyze.'),
+                'paths': ListSchema(
+                    title: 'Relative or absolute paths to analyze under the '
+                        '"root", must correspond to files and not directories.',
+                    items: StringSchema()),
+              },
+              required: ['root'],
+            )),
+      }, required: [
+        'roots'
+      ]));
+}

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:dart_mcp/server.dart';
+import 'package:meta/meta.dart';
 
 /// Mix this in to any MCPServer to add support for analyzing Dart projects.
 ///
@@ -21,7 +22,7 @@ base mixin DartAnalyzerSupport on ToolsSupport {
       throw StateError(
           'This server requires the "roots" capability to be implemented.');
     }
-    registerTool(_analyzeFilesTool, _analyzeFiles);
+    registerTool(analyzeFilesTool, _analyzeFiles);
     initialized.then(_listenForRoots);
     return super.initialize(request);
   }
@@ -109,7 +110,8 @@ base mixin DartAnalyzerSupport on ToolsSupport {
     return CallToolResult(content: messages);
   }
 
-  static final _analyzeFilesTool = Tool(
+  @visibleForTesting
+  static final analyzeFilesTool = Tool(
       name: 'analyze files',
       description:
           'Analyzes the requested file paths under the specified project roots '

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:dart_mcp/server.dart';
 import 'package:dtd/dtd.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';
+import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service_io.dart';
 
 /// Mix this in to any MCPServer to add support for connecting to the Dart
@@ -29,8 +30,8 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
 
   @override
   FutureOr<InitializeResult> initialize(InitializeRequest request) async {
-    registerTool(_connectTool, _connect);
-    registerTool(_screenshotTool, takeScreenshot);
+    registerTool(connectTool, _connect);
+    registerTool(screenshotTool, takeScreenshot);
     return super.initialize(request);
   }
 
@@ -146,7 +147,8 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
     }
   }
 
-  static final _connectTool = Tool(
+  @visibleForTesting
+  static final connectTool = Tool(
     inputSchema: ObjectSchema(
       properties: {
         'uri': StringSchema(),
@@ -160,10 +162,11 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
         'command. Do not just make up a random URI to pass.',
   );
 
-  static final _screenshotTool = Tool(
+  @visibleForTesting
+  static final screenshotTool = Tool(
     name: 'take_screenshot',
     description: 'Takes a screenshot of the active flutter application in its '
-        'current state. Requires "${_connectTool.name}" to be successfully '
+        'current state. Requires "${connectTool.name}" to be successfully '
         'called first.',
     inputSchema: ObjectSchema(),
   );
@@ -173,7 +176,7 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
     content: [
       TextContent(
         text: 'The dart tooling daemon is not connected, you need to call '
-            '"${_connectTool.name}" first.',
+            '"${connectTool.name}" first.',
       ),
     ],
   );
@@ -183,7 +186,7 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
     content: [
       TextContent(
         text: 'The dart tooling daemon is already connected, you cannot call '
-            '"${_connectTool.name}" again.',
+            '"${connectTool.name}" again.',
       ),
     ],
   );

--- a/pkgs/dart_tooling_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/server.dart
@@ -7,11 +7,16 @@ import 'dart:async';
 import 'package:dart_mcp/server.dart';
 import 'package:stream_channel/stream_channel.dart';
 
+import 'mixins/analyzer.dart';
 import 'mixins/dtd.dart';
 
 /// An MCP server for Dart and Flutter tooling.
 final class DartToolingMCPServer extends MCPServer
-    with ToolsSupport, DartToolingDaemonSupport {
+    with
+        LoggingSupport,
+        ToolsSupport,
+        DartAnalyzerSupport,
+        DartToolingDaemonSupport {
   DartToolingMCPServer({required super.channel})
       : super.fromStreamChannel(
           implementation: ServerImplementation(

--- a/pkgs/dart_tooling_mcp_server/pubspec.yaml
+++ b/pkgs/dart_tooling_mcp_server/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   test_descriptor: ^2.0.2
   test_process: ^2.1.1
   vm_service: ^15.0.0
+  watcher: ^1.1.1
 executables:
   dart_tooling_mcp_server: main
 dev_dependencies:

--- a/pkgs/dart_tooling_mcp_server/pubspec.yaml
+++ b/pkgs/dart_tooling_mcp_server/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   dtd: ^2.4.0
   json_rpc_2: ^3.0.3
   meta: ^1.16.0
+  path: ^1.9.1
   stream_channel: ^2.1.4
   test_descriptor: ^2.0.2
   test_process: ^2.1.1

--- a/pkgs/dart_tooling_mcp_server/pubspec.yaml
+++ b/pkgs/dart_tooling_mcp_server/pubspec.yaml
@@ -5,6 +5,7 @@ version: 0.1.0-wip
 environment:
   sdk: ^3.6.1 # The version of dart in the current flutter stable
 dependencies:
+  analyzer: ^7.3.0
   async: ^2.13.0
   dart_mcp:
     path: ../dart_mcp

--- a/pkgs/dart_tooling_mcp_server/pubspec.yaml
+++ b/pkgs/dart_tooling_mcp_server/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   devtools_shared: ^11.2.0
   dtd: ^2.4.0
   json_rpc_2: ^3.0.3
+  meta: ^1.16.0
   stream_channel: ^2.1.4
   test_descriptor: ^2.0.2
   test_process: ^2.1.1

--- a/pkgs/dart_tooling_mcp_server/test/dart_tooling_mcp_server_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/dart_tooling_mcp_server_test.dart
@@ -68,8 +68,8 @@ void main() {
       final example =
           d.dir('example', [d.file('main.dart', 'void main() => 1 + "2";')]);
       await example.create();
-      final exampeRoot = Root(uri: example.io.absolute.uri.toString());
-      testHarness.mcpClient.addRoot(exampeRoot);
+      final exampleRoot = Root(uri: example.io.absolute.uri.toString());
+      testHarness.mcpClient.addRoot(exampleRoot);
 
       // Allow the notification to propagate, and the server to ask for the new
       // list of roots.
@@ -80,7 +80,7 @@ void main() {
         arguments: {
           'roots': [
             {
-              'root': exampeRoot.uri,
+              'root': exampleRoot.uri,
               'paths': ['main.dart']
             }
           ]

--- a/pkgs/dart_tooling_mcp_server/test/dart_tooling_mcp_server_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/dart_tooling_mcp_server_test.dart
@@ -3,6 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:dart_mcp/server.dart';
+import 'package:dart_tooling_mcp_server/src/mixins/analyzer.dart';
+import 'package:dart_tooling_mcp_server/src/mixins/dtd.dart';
 import 'package:test/test.dart';
 
 import 'test_harness.dart';
@@ -20,7 +22,7 @@ void main() {
   test('can take a screenshot', () async {
     final tools = (await testHarness.mcpServerConnection.listTools()).tools;
     final screenshotTool = tools.singleWhere(
-      (t) => t.name == 'take_screenshot',
+      (t) => t.name == DartToolingDaemonSupport.screenshotTool.name,
     );
     final screenshotResult = await testHarness.callToolWithRetry(
       CallToolRequest(name: screenshotTool.name),
@@ -33,5 +35,25 @@ void main() {
         'type': ImageContent.expectedType
       },
     );
+  });
+
+  test('can analyze a project', () async {
+    final tools = (await testHarness.mcpServerConnection.listTools()).tools;
+    final analyzeTool = tools.singleWhere(
+        (t) => t.name == DartAnalyzerSupport.analyzeFilesTool.name);
+    final request = CallToolRequest(
+      name: analyzeTool.name,
+      arguments: {
+        'roots': [
+          {
+            'root': Uri.base.resolve(counterAppPath).toString(),
+            'paths': ['lib/main.dart']
+          }
+        ]
+      },
+    );
+    final result = await testHarness.callToolWithRetry(request);
+    expect(result.isError, false);
+    expect(result.content, isEmpty);
   });
 }

--- a/pkgs/dart_tooling_mcp_server/test/dart_tooling_mcp_server_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/dart_tooling_mcp_server_test.dart
@@ -53,7 +53,7 @@ void main() {
       },
     );
     final result = await testHarness.callToolWithRetry(request);
-    expect(result.isError, false);
+    expect(result.isError, isNot(true));
     expect(result.content, isEmpty);
   });
 }

--- a/pkgs/dart_tooling_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_tooling_mcp_server/test/test_harness.dart
@@ -73,6 +73,9 @@ class TestHarness {
     final mcpClient = DartToolingMCPClient();
     addTearDown(mcpClient.shutdown);
     final connection = await _initializeMCPServer(mcpClient, debugMode);
+    connection.onLog.listen((log) {
+      printOnFailure('MCP Server Log: $log');
+    });
 
     final fakeEditorExtension = await FakeEditorExtension.connect(
       flutterProcess,
@@ -94,6 +97,7 @@ class TestHarness {
     final result = await callToolWithRetry(
       CallToolRequest(name: connectTool.name, arguments: {'uri': dtdUri}),
     );
+
     expect(result.isError, isNot(true), reason: result.content.join('\n'));
   }
 
@@ -127,7 +131,7 @@ final class DartToolingMCPClient extends MCPClient with RootsSupport {
           ),
         ) {
     addRoot(Root(
-        uri: Uri.base.resolve(counterAppPath).toString(),
+        uri: Directory(counterAppPath).absolute.uri.toString(),
         name: 'counter app test fixture'));
   }
 }

--- a/pkgs/dart_tooling_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_tooling_mcp_server/test/test_harness.dart
@@ -89,8 +89,7 @@ class TestHarness {
     final tools = (await mcpServerConnection.listTools()).tools;
 
     final connectTool = tools.singleWhere(
-      (t) => t.name == 'connectDartToolingDaemon',
-    );
+        (t) => t.name == DartToolingDaemonSupport.connectTool.name);
 
     final result = await callToolWithRetry(
       CallToolRequest(name: connectTool.name, arguments: {'uri': dtdUri}),
@@ -119,14 +118,18 @@ class TestHarness {
   }
 }
 
-final class DartToolingMCPClient extends MCPClient {
+final class DartToolingMCPClient extends MCPClient with RootsSupport {
   DartToolingMCPClient()
       : super(
           ClientImplementation(
             name: 'test client for the dart tooling mcp server',
             version: '0.1.0',
           ),
-        );
+        ) {
+    addRoot(Root(
+        uri: Uri.base.resolve(counterAppPath).toString(),
+        name: 'counter app test fixture'));
+  }
 }
 
 /// The dart tooling daemon currently expects to get vm service uris through


### PR DESCRIPTION
Requires clients to implement "Roots", and creates one analysis context per root.

Then, requests to analyze groups of files can be issued via the "analyze files" command, which requires a root for each group of files.

We also run a file watcher, which is a bit right now because we could be a second or so behind if using a polling watcher. We might want to try and do some sort of "file overlay" situation for other scenarios, passing the file contents to analyze directly.

This is currently based on the input schema branch - I will wait to merge until that is merged and then change the target branch here.