### PR TITLE
[dart_tooling_mcp_server] add Dart CLI tool support

### DIFF
--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
@@ -14,7 +14,8 @@ import 'package:watcher/watcher.dart';
 
 /// Mix this in to any MCPServer to add support for analyzing Dart projects.
 ///
-/// The MCPServer must already have the [ToolsSupport] mixin applied.
+/// The MCPServer must already have the [ToolsSupport] and [LoggingSupport]
+/// mixins applied.
 base mixin DartAnalyzerSupport on ToolsSupport, LoggingSupport {
   /// The analyzed contexts.
   AnalysisContextCollection? _analysisContexts;

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/dart_cli.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/dart_cli.dart
@@ -1,0 +1,159 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dart_mcp/server.dart';
+
+// TODO: migrate the analyze files tool to use this mixin and run the
+// `dart analyze` command instead of the analyzer package.
+
+/// Mix this in to any MCPServer to add support for running Dart CLI commands
+/// like `dart fix` and `dart format`.
+///
+/// The MCPServer must already have the [ToolsSupport] and [LoggingSupport]
+/// mixins applied.
+base mixin DartCliSupport on ToolsSupport, LoggingSupport {
+  @override
+  FutureOr<InitializeResult> initialize(InitializeRequest request) {
+    if (request.capabilities.roots == null) {
+      throw StateError(
+        'This server requires the "roots" capability to be implemented.',
+      );
+    }
+    registerTool(dartFixTool, _runDartFixTool);
+    registerTool(dartFormatTool, _runDartFormatTool);
+    return super.initialize(request);
+  }
+
+  /// Implementation of the [dartFixTool].
+  Future<CallToolResult> _runDartFixTool(CallToolRequest request) async {
+    return _runDartCommandInRoots(request, 'dart fix', ['fix', '--apply']);
+  }
+
+  /// Implementation of the [dartFormatTool].
+  Future<CallToolResult> _runDartFormatTool(CallToolRequest request) async {
+    return _runDartCommandInRoots(request, 'dart format', ['format', '.']);
+  }
+
+  /// Helper to run a dart command in multiple project roots.
+  Future<CallToolResult> _runDartCommandInRoots(
+    CallToolRequest request,
+    String commandName,
+    List<String> commandArgs,
+  ) async {
+    final rootConfigs =
+        (request.arguments?['roots'] as List?)?.cast<Map<String, Object?>>();
+    if (rootConfigs == null) {
+      return CallToolResult(
+        content: [TextContent(text: 'Missing required argument `roots`.')],
+        isError: true,
+      );
+    }
+
+    final outputs = <TextContent>[];
+    for (var rootConfig in rootConfigs) {
+      final rootUriString = rootConfig['root'] as String?;
+      if (rootUriString == null) {
+        // This shouldn't happen based on the schema, but handle defensively.
+        return CallToolResult(
+          content: [
+            TextContent(
+              text: 'Invalid root configuration: missing `root` key.',
+            ),
+          ],
+          isError: true,
+        );
+      }
+
+      final rootUri = Uri.parse(rootUriString);
+      if (rootUri.scheme != 'file') {
+        return CallToolResult(
+          content: [
+            TextContent(
+              text:
+                  'Only file scheme uris are allowed for roots, but got '
+                  '$rootUri',
+            ),
+          ],
+          isError: true,
+        );
+      }
+      final projectRoot = Directory(rootUri.toFilePath());
+
+      final result = await Process.run(
+        'dart',
+        commandArgs,
+        workingDirectory: projectRoot.path,
+        runInShell: true,
+      );
+
+      final output = (result.stdout as String).trim();
+      final errors = (result.stderr as String).trim();
+      if (result.exitCode != 0) {
+        return CallToolResult(
+          content: [
+            TextContent(
+              text: '$commandName failed in ${projectRoot.path}:\n$errors',
+            ),
+          ],
+          isError: true,
+        );
+      }
+      if (output.isNotEmpty) {
+        outputs.add(
+          TextContent(text: '$commandName in ${projectRoot.path}:\n$output'),
+        );
+      }
+    }
+    return CallToolResult(content: outputs);
+  }
+
+  static final dartFixTool = Tool(
+    name: 'dart_fix',
+    description: 'Runs `dart fix --apply` for the given project roots.',
+    inputSchema: ObjectSchema(
+      properties: {
+        'roots': ListSchema(
+          title: 'All projects roots to run dart fix in.',
+          description:
+              'These must match a root returned by a call to "listRoots".',
+          items: ObjectSchema(
+            properties: {
+              'root': StringSchema(
+                title: 'The URI of the project root to run `dart fix` in.',
+              ),
+            },
+            required: ['root'],
+          ),
+        ),
+      },
+      required: ['roots'],
+    ),
+  );
+
+  static final dartFormatTool = Tool(
+    name: 'dart_format',
+    description: 'Runs `dart format .` for the given project roots.',
+    inputSchema: ObjectSchema(
+      properties: {
+        'roots': ListSchema(
+          title: 'All projects roots to run dart format in.',
+          description:
+              'These must match a root returned by a call to "listRoots".',
+          items: ObjectSchema(
+            properties: {
+              'root': StringSchema(
+                title: 'The URI of the project root to run `dart format` in.',
+              ),
+            },
+            required: ['root'],
+          ),
+        ),
+      },
+      required: ['roots'],
+    ),
+  );
+}

--- a/pkgs/dart_tooling_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/server.dart
@@ -8,6 +8,7 @@ import 'package:dart_mcp/server.dart';
 import 'package:stream_channel/stream_channel.dart';
 
 import 'mixins/analyzer.dart';
+import 'mixins/dart_cli.dart';
 import 'mixins/dtd.dart';
 
 /// An MCP server for Dart and Flutter tooling.
@@ -16,6 +17,7 @@ final class DartToolingMCPServer extends MCPServer
         LoggingSupport,
         ToolsSupport,
         DartAnalyzerSupport,
+        DartCliSupport,
         DartToolingDaemonSupport {
   DartToolingMCPServer({required super.channel})
       : super.fromStreamChannel(

--- a/pkgs/dart_tooling_mcp_server/test/dart_tooling_mcp_server_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/dart_tooling_mcp_server_test.dart
@@ -2,8 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:dart_mcp/server.dart';
 import 'package:dart_tooling_mcp_server/src/mixins/analyzer.dart';
+import 'package:dart_tooling_mcp_server/src/mixins/dart_cli.dart';
 import 'package:dart_tooling_mcp_server/src/mixins/dtd.dart';
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
@@ -125,7 +128,8 @@ void main() {
       expect(result.isError, isNot(true));
       expect(result.content, [
         TextContent(
-          text: "Error: The argument type 'String' can't be assigned to the "
+          text:
+              "Error: The argument type 'String' can't be assigned to the "
               "parameter type 'num'. ",
         ),
       ]);
@@ -141,6 +145,89 @@ void main() {
       result = await testHarness.callToolWithRetry(request);
       expect(result.isError, isNot(true));
       expect(result.content, isEmpty);
+    });
+  });
+
+  group('dart cli', () {
+    late Tool dartFixTool;
+    late Tool dartFormatTool;
+
+    setUp(() async {
+      final tools = (await testHarness.mcpServerConnection.listTools()).tools;
+      dartFixTool = tools.singleWhere(
+        (t) => t.name == DartCliSupport.dartFixTool.name,
+      );
+      dartFormatTool = tools.singleWhere(
+        (t) => t.name == DartCliSupport.dartFormatTool.name,
+      );
+    });
+
+    test('can run dart fix', () async {
+      final fixExample = d.dir('fix_example', [
+        d.file('main.dart', 'void main() { print("hello"); }'),
+      ]);
+      await fixExample.create();
+      final fixExampleRoot = rootForPath(fixExample.io.path);
+      testHarness.mcpClient.addRoot(fixExampleRoot);
+      await pumpEventQueue();
+
+      final request = CallToolRequest(
+        name: dartFixTool.name,
+        arguments: {
+          'roots': [
+            {'root': fixExampleRoot.uri},
+          ],
+        },
+      );
+      final result = await testHarness.callToolWithRetry(request);
+      expect(result.isError, isNot(true));
+      expect(
+        (result.content.single as TextContent).text,
+        contains('dart fix in ${fixExample.io.path}'),
+      );
+      expect(
+        (result.content.single as TextContent).text,
+        contains('Applied 1 fix'),
+      );
+
+      // Check that the file was modified
+      final fixedContent =
+          File(d.path('fix_example/main.dart')).readAsStringSync();
+      expect(fixedContent, 'void main() {\n  print("hello");\n}\n');
+    });
+
+    test('can run dart format', () async {
+      final formatExample = d.dir('format_example', [
+        d.file('main.dart', 'void main() {print("hello");}'),
+      ]);
+      await formatExample.create();
+      final formatExampleRoot = rootForPath(formatExample.io.path);
+      testHarness.mcpClient.addRoot(formatExampleRoot);
+      await pumpEventQueue();
+
+      final request = CallToolRequest(
+        name: dartFormatTool.name,
+        arguments: {
+          'roots': [
+            {'root': formatExampleRoot.uri},
+          ],
+        },
+      );
+      final result = await testHarness.callToolWithRetry(request);
+      expect(result.isError, isNot(true));
+      expect(
+        (result.content.single as TextContent).text,
+        contains('dart format in ${formatExample.io.path}'),
+      );
+      expect(
+        (result.content.single as TextContent).text,
+        contains('Formatted 1 file'),
+      );
+
+      // Check that the file was modified
+      final formattedContent =
+          File(d.path('format_example/main.dart')).readAsStringSync();
+      expect(formattedContent, 'void main() {\n  print("hello");\n}\n');
     });
   });
 }

--- a/pkgs/dart_tooling_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_tooling_mcp_server/test/test_harness.dart
@@ -10,6 +10,7 @@ import 'package:dart_mcp/client.dart';
 import 'package:dart_tooling_mcp_server/src/mixins/dtd.dart';
 import 'package:dart_tooling_mcp_server/src/server.dart';
 import 'package:dtd/dtd.dart';
+import 'package:path/path.dart' as p;
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
@@ -156,22 +157,20 @@ final class AppDebugSession {
     String appPath, {
     required bool isFlutter,
   }) async {
-    final platform = Platform.isLinux
-        ? 'linux'
-        : Platform.isMacOS
+    final platform =
+        Platform.isLinux
+            ? 'linux'
+            : Platform.isMacOS
             ? 'macos'
             : throw StateError(
-                'unsupported platform, only mac and linux are supported',
-              );
-    final process = await TestProcess.start(
-        isFlutter ? 'flutter' : 'dart',
-        [
-          'run',
-          if (!isFlutter) '--enable-vm-service',
-          if (isFlutter) ...['-d', platform],
-          appPath,
-        ],
-        workingDirectory: projectRoot);
+              'unsupported platform, only mac and linux are supported',
+            );
+    final process = await TestProcess.start(isFlutter ? 'flutter' : 'dart', [
+      'run',
+      if (!isFlutter) '--enable-vm-service',
+      if (isFlutter) ...['-d', platform],
+      appPath,
+    ], workingDirectory: projectRoot);
 
     addTearDown(() async {
       if (isFlutter) {
@@ -187,8 +186,9 @@ final class AppDebugSession {
     while (vmServiceUri == null && await stdout.hasNext) {
       final line = await stdout.next;
       if (line.contains('A Dart VM Service')) {
-        vmServiceUri =
-            line.substring(line.indexOf('http:')).replaceFirst('http:', 'ws:');
+        vmServiceUri = line
+            .substring(line.indexOf('http:'))
+            .replaceFirst('http:', 'ws:');
         await stdout.cancel();
       }
     }
@@ -210,12 +210,12 @@ final class AppDebugSession {
 /// A basic MCP client which is started as a part of the harness.
 final class DartToolingMCPClient extends MCPClient with RootsSupport {
   DartToolingMCPClient()
-      : super(
-          ClientImplementation(
-            name: 'test client for the dart tooling mcp server',
-            version: '0.1.0',
-          ),
-        );
+    : super(
+        ClientImplementation(
+          name: 'test client for the dart tooling mcp server',
+          version: '0.1.0',
+        ),
+      );
 }
 
 /// The dart tooling daemon currently expects to get vm service uris through
@@ -345,4 +345,6 @@ Future<ServerConnection> _initializeMCPServer(
 Root rootForPath(String projectPath) =>
     Root(uri: Directory(projectPath).absolute.uri.toString());
 
-const counterAppPath = 'test_fixtures/counter_app';
+final counterAppPath = p.join('test_fixtures', 'counter_app');
+
+final dartCliAppsPath = p.join('test_fixtures', 'dart_cli_app');

--- a/pkgs/dart_tooling_mcp_server/test_fixtures/dart_cli_app/.gitignore
+++ b/pkgs/dart_tooling_mcp_server/test_fixtures/dart_cli_app/.gitignore
@@ -1,0 +1,1 @@
+bin_copy/

--- a/pkgs/dart_tooling_mcp_server/test_fixtures/dart_cli_app/analysis_options.yaml
+++ b/pkgs/dart_tooling_mcp_server/test_fixtures/dart_cli_app/analysis_options.yaml
@@ -5,8 +5,3 @@ include: package:dart_flutter_team_lints/analysis_options.yaml
 linter:
   rules:
     - prefer_final_locals
-
-analyzer: 
-  exclude:
-    # This directory has intentional analysis errors and warnings.
-    - test_fixtures/dart_cli_app/**

--- a/pkgs/dart_tooling_mcp_server/test_fixtures/dart_cli_app/bin/dart_fix.dart
+++ b/pkgs/dart_tooling_mcp_server/test_fixtures/dart_cli_app/bin/dart_fix.dart
@@ -1,0 +1,15 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+void main() {
+  var myObject = MyClass();
+  var myList = <int>[];
+  myList.add(1);
+  print(myObject);
+  print(myList);
+}
+
+class MyClass {
+  MyClass();
+}

--- a/pkgs/dart_tooling_mcp_server/test_fixtures/dart_cli_app/bin/dart_format.dart
+++ b/pkgs/dart_tooling_mcp_server/test_fixtures/dart_cli_app/bin/dart_format.dart
@@ -1,0 +1,5 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+void main() {print("hello");}


### PR DESCRIPTION
This PR adds tool support for the following Dart CLI tools:
- Running `dart fix` over a set of roots
- Running `dart format` over a set of roots

This PR also adds the directory `test_fixtures/dart_cli_app` which contains Dart scripts for use in tests.