### PR TITLE
[dart_tooling_mcp_server] Add a tool for getting runtime errors

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "counter_app",
+            "cwd": "pkgs/dart_tooling_mcp_server/test_fixtures/counter_app",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "counter_app (profile mode)",
+            "cwd": "pkgs/dart_tooling_mcp_server/test_fixtures/counter_app",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "counter_app (release mode)",
+            "cwd": "pkgs/dart_tooling_mcp_server/test_fixtures/counter_app",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        }
+    ]
+}

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
@@ -186,7 +186,7 @@ base mixin DartAnalyzerSupport on ToolsSupport, LoggingSupport {
 
   @visibleForTesting
   static final analyzeFilesTool = Tool(
-    name: 'analyzeFiles',
+    name: 'analyze_files',
     description:
         'Analyzes the requested file paths under the specified project roots '
         'and returns the results as a list of messages.',

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:dart_mcp/server.dart';
+import 'package:dds_service_extensions/dds_service_extensions.dart';
 import 'package:dtd/dtd.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';
 import 'package:meta/meta.dart';
@@ -32,12 +33,15 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
   @override
   FutureOr<InitializeResult> initialize(InitializeRequest request) async {
     registerTool(connectTool, _connect);
+    registerTool(getRuntimeErrorsTool, runtimeErrors);
+
     // TODO: these tools should only be registered for Flutter applications, or
     // they should return an error when used against a pure Dart app (or a
     // Flutter app that does not support the operation, e.g. hot reload is not
     // supported in profile mode).
     registerTool(screenshotTool, takeScreenshot);
     registerTool(hotReloadTool, hotReload);
+
     return super.initialize(request);
   }
 
@@ -126,7 +130,8 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
             isError: true,
             content: [
               TextContent(
-                text: 'Unknown error or bad response taking screenshot:\n'
+                text:
+                    'Unknown error or bad response taking screenshot:\n'
                     '${result.json}',
               ),
             ],
@@ -159,9 +164,12 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
         });
         await vmService.streamListen(EventStreams.kService);
         final hotReloadMethodName = await hotReloadMethodNameCompleter.future
-            .timeout(const Duration(milliseconds: 1000), onTimeout: () async {
-          return null;
-        });
+            .timeout(
+              const Duration(milliseconds: 1000),
+              onTimeout: () async {
+                return null;
+              },
+            );
         await vmService.streamCancel(EventStreams.kService);
 
         if (hotReloadMethodName == null) {
@@ -169,7 +177,8 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
             isError: true,
             content: [
               TextContent(
-                text: 'The hot reload service has not been registered yet, '
+                text:
+                    'The hot reload service has not been registered yet, '
                     'please wait a few seconds and try again.',
               ),
             ],
@@ -191,10 +200,94 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
             isError: true,
             content: [
               TextContent(
-                text: 'Hot reload failed:\n'
+                text:
+                    'Hot reload failed:\n'
                     '${result.json}',
               ),
             ],
+          );
+        }
+      },
+    );
+  }
+
+  /// Retrieves runtime errors from the currently running app.
+  ///
+  /// If more than one debug session is active, then it just uses the first one.
+  ///
+  // TODO: support passing a debug session id when there is more than one debug
+  // session.
+  Future<CallToolResult> runtimeErrors(CallToolRequest request) async {
+    return _callOnVmService(
+      callback: (vmService) async {
+        final errors = <String>[];
+        try {
+          await vmService.streamListen(EventStreams.kExtension);
+          await vmService.streamListen(EventStreams.kStderr);
+
+          // We need to listen to streams with history so that we can get errors
+          // that occurred before this tool call.
+          // TODO(https://github.com/dart-lang/ai/issues/57): this can result in
+          // duplicate errors that we need to de-duplicate somehow.
+          final extensionEvents = vmService.onExtensionEventWithHistory.listen((
+            Event e,
+          ) {
+            if (e.extensionKind == 'Flutter.Error') {
+              // TODO(https://github.com/dart-lang/ai/issues/57): consider
+              // pruning this content down to only what is useful for the LLM to
+              // understand the error and its source.
+              errors.add(e.json.toString());
+            }
+          });
+          final stderrEvents = vmService.onStderrEventWithHistory.listen((
+            Event e,
+          ) {
+            final message = decodeBase64(e.bytes!);
+            // TODO(https://github.com/dart-lang/ai/issues/57): consider
+            // pruning this content down to only what is useful for the LLM to
+            // understand the error and its source.
+            errors.add(message);
+          });
+
+          // Await a short delay to allow the error events to come over the open
+          // Streams.
+          await Future<void>.delayed(const Duration(seconds: 1));
+
+          await vmService.streamCancel(EventStreams.kExtension);
+          await vmService.streamCancel(EventStreams.kStderr);
+          await extensionEvents.cancel();
+          await stderrEvents.cancel();
+
+          if (errors.isEmpty) {
+            return CallToolResult(
+              content: [TextContent(text: 'No runtime errors found.')],
+            );
+          }
+          return CallToolResult(
+            content: [
+              TextContent(
+                text:
+                    'Found ${errors.length} '
+                    'error${errors.length == 1 ? '' : 's'}:\n',
+              ),
+              ...errors.map((e) => TextContent(text: e.toString())),
+            ],
+          );
+        } on RPCError catch (e) {
+          return CallToolResult(
+            isError: true,
+            content: [
+              TextContent(
+                text:
+                    'Failed to get runtime errors: ${e.message} '
+                    '(Code: ${e.code})',
+              ),
+            ],
+          );
+        } catch (e) {
+          return CallToolResult(
+            isError: true,
+            content: [TextContent(text: 'An unexpected error occurred: $e')],
           );
         }
       },
@@ -218,8 +311,9 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
     if (debugSessions.isEmpty) return _noActiveDebugSession;
 
     // TODO: Consider holding on to this connection.
-    final vmService =
-        await vmServiceConnectUri(debugSessions.first.vmServiceUri);
+    final vmService = await vmServiceConnectUri(
+      debugSessions.first.vmServiceUri,
+    );
     try {
       return await callback(vmService);
     } finally {
@@ -233,7 +327,7 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
       properties: {'uri': StringSchema()},
       required: const ['uri'],
     ),
-    name: 'connectDartToolingDaemon',
+    name: 'connect_dart_tooling_daemon',
     description:
         'Connects to the Dart Tooling Daemon. You should ask the user for the '
         'dart tooling daemon URI, and suggest the "Copy DTD Uri to clipboard" '
@@ -242,8 +336,9 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
 
   @visibleForTesting
   static final screenshotTool = Tool(
-    name: 'takeScreenshot',
-    description: 'Takes a screenshot of the active flutter application in its '
+    name: 'take_screenshot',
+    description:
+        'Takes a screenshot of the active Flutter application in its '
         'current state. Requires "${connectTool.name}" to be successfully '
         'called first.',
     inputSchema: ObjectSchema(),
@@ -251,10 +346,21 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
 
   @visibleForTesting
   static final hotReloadTool = Tool(
-    name: 'hotReload',
-    description: 'Performs a hot reload of the active Flutter application. '
+    name: 'hot_reload',
+    description:
+        'Performs a hot reload of the active Flutter application. '
         'This is to apply the latest code changes to the running application. '
         'Requires "${connectTool.name}" to be successfully called first.',
+    inputSchema: ObjectSchema(),
+  );
+
+  @visibleForTesting
+  static final getRuntimeErrorsTool = Tool(
+    name: 'get_runtime_errors',
+    description:
+        'Retrieves the list of runtime errors that have occurred in the active '
+        'Dart or Flutter application. Requires "${connectTool.name}" to be '
+        'successfully called first.',
     inputSchema: ObjectSchema(),
   );
 
@@ -262,7 +368,8 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
     isError: true,
     content: [
       TextContent(
-        text: 'The dart tooling daemon is not connected, you need to call '
+        text:
+            'The dart tooling daemon is not connected, you need to call '
             '"${connectTool.name}" first.',
       ),
     ],
@@ -272,7 +379,8 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
     isError: true,
     content: [
       TextContent(
-        text: 'The dart tooling daemon is already connected, you cannot call '
+        text:
+            'The dart tooling daemon is already connected, you cannot call '
             '"${connectTool.name}" again.',
       ),
     ],
@@ -289,7 +397,8 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
     isError: true,
     content: [
       TextContent(
-        text: 'The dart tooling daemon is not ready yet, please wait a few '
+        text:
+            'The dart tooling daemon is not ready yet, please wait a few '
             'seconds and try again.',
       ),
     ],
@@ -350,11 +459,10 @@ extension type GetDebugSessionsResponse.fromJson(Map<String, Object?> _value)
 
   factory GetDebugSessionsResponse({
     required List<DebugSession> debugSessions,
-  }) =>
-      GetDebugSessionsResponse.fromJson({
-        'debugSessions': debugSessions,
-        'type': type,
-      });
+  }) => GetDebugSessionsResponse.fromJson({
+    'debugSessions': debugSessions,
+    'type': type,
+  });
 }
 
 /// An individual debug session.
@@ -375,12 +483,11 @@ extension type DebugSession.fromJson(Map<String, Object?> _value)
     required String name,
     required String projectRootPath,
     required String vmServiceUri,
-  }) =>
-      DebugSession.fromJson({
-        'debuggerType': debuggerType,
-        'id': id,
-        'name': name,
-        'projectRootPath': projectRootPath,
-        'vmServiceUri': vmServiceUri,
-      });
+  }) => DebugSession.fromJson({
+    'debuggerType': debuggerType,
+    'id': id,
+    'name': name,
+    'projectRootPath': projectRootPath,
+    'vmServiceUri': vmServiceUri,
+  });
 }

--- a/pkgs/dart_tooling_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/server.dart
@@ -20,15 +20,15 @@ final class DartToolingMCPServer extends MCPServer
         DartCliSupport,
         DartToolingDaemonSupport {
   DartToolingMCPServer({required super.channel})
-      : super.fromStreamChannel(
-          implementation: ServerImplementation(
-            name: 'dart and flutter tooling',
-            version: '0.1.0-wip',
-          ),
-          instructions:
-              'This server helps to connect Dart and Flutter developers to '
-              'their development tools and running applications.',
-        );
+    : super.fromStreamChannel(
+        implementation: ServerImplementation(
+          name: 'dart and flutter tooling',
+          version: '0.1.0-wip',
+        ),
+        instructions:
+            'This server helps to connect Dart and Flutter developers to '
+            'their development tools and running applications.',
+      );
 
   static Future<DartToolingMCPServer> connect(
     StreamChannel<String> mcpChannel,

--- a/pkgs/dart_tooling_mcp_server/pubspec.yaml
+++ b/pkgs/dart_tooling_mcp_server/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   async: ^2.13.0
   dart_mcp:
     path: ../dart_mcp
+  dds_service_extensions: ^2.0.1
   devtools_shared: ^11.2.0
   dtd: ^2.4.0
   json_rpc_2: ^3.0.3

--- a/pkgs/dart_tooling_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/dtd_test.dart
@@ -64,9 +64,10 @@ void main() {
       );
 
       expect(runtimeErrorsResult.isError, isNot(true));
+      final errorCountRegex = RegExp(r'Found \d+ errors?:');
       expect(
         (runtimeErrorsResult.content.first as TextContent).text,
-        contains('Found 1 error:'),
+        contains(errorCountRegex),
       );
       expect(
         (runtimeErrorsResult.content[1] as TextContent).text,

--- a/pkgs/dart_tooling_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/dtd_test.dart
@@ -15,18 +15,16 @@ void main() {
   // issue.
   setUp(() async {
     testHarness = await TestHarness.start();
+    await testHarness.connectToDtd();
+    await testHarness.startDebugSession(
+      counterAppPath,
+      'lib/main.dart',
+      isFlutter: true,
+    );
   });
 
   group('dart tooling daemon tools', () {
     test('can take a screenshot', () async {
-      await testHarness.connectToDtd();
-
-      await testHarness.startDebugSession(
-        counterAppPath,
-        'lib/main.dart',
-        isFlutter: true,
-      );
-
       final tools = (await testHarness.mcpServerConnection.listTools()).tools;
       final screenshotTool = tools.singleWhere(
         (t) => t.name == DartToolingDaemonSupport.screenshotTool.name,
@@ -42,14 +40,6 @@ void main() {
     });
 
     test('can perform a hot reload', () async {
-      await testHarness.connectToDtd();
-
-      await testHarness.startDebugSession(
-        counterAppPath,
-        'lib/main.dart',
-        isFlutter: true,
-      );
-
       final tools = (await testHarness.mcpServerConnection.listTools()).tools;
       final hotReloadTool = tools.singleWhere(
         (t) => t.name == DartToolingDaemonSupport.hotReloadTool.name,
@@ -62,6 +52,26 @@ void main() {
       expect(hotReloadResult.content, [
         TextContent(text: 'Hot reload succeeded.'),
       ]);
+    });
+
+    test('can get runtime errors', () async {
+      final tools = (await testHarness.mcpServerConnection.listTools()).tools;
+      final runtimeErrorsTool = tools.singleWhere(
+        (t) => t.name == DartToolingDaemonSupport.getRuntimeErrorsTool.name,
+      );
+      final runtimeErrorsResult = await testHarness.callToolWithRetry(
+        CallToolRequest(name: runtimeErrorsTool.name),
+      );
+
+      expect(runtimeErrorsResult.isError, isNot(true));
+      expect(
+        (runtimeErrorsResult.content.first as TextContent).text,
+        contains('Found 1 error:'),
+      );
+      expect(
+        (runtimeErrorsResult.content[1] as TextContent).text,
+        contains('A RenderFlex overflowed by'),
+      );
     });
   });
 }

--- a/pkgs/dart_tooling_mcp_server/test_fixtures/counter_app/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/pkgs/dart_tooling_mcp_server/test_fixtures/counter_app/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -54,6 +55,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/pkgs/dart_tooling_mcp_server/test_fixtures/counter_app/lib/main.dart
+++ b/pkgs/dart_tooling_mcp_server/test_fixtures/counter_app/lib/main.dart
@@ -52,7 +52,16 @@ class _MyHomePageState extends State<MyHomePage> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            const Text('You have pushed the button this many times:'),
+            const Row(
+              children: [
+                Text('You have pushed the button this many times:'),
+                Text(
+                  'And this Row should create an overflow error because it '
+                  'contains way more text than could ever fit on a single Row '
+                  'on both a mobile app or the default size of a desktop app.',
+                ),
+              ],
+            ),
             Text(
               '$_counter',
               style: Theme.of(context).textTheme.headlineMedium,


### PR DESCRIPTION
This PR:

- Adds a new tool `get_runtime_errors` to `DartToolingDaemonSupport` for retrieving runtime errors from an app. This method pulls `Flutter.Error` events from the VM service `kExtension` stream as well as any messages to the `kStderr` stream.
- Adds an overflow error to the Flutter test fixture app
- Adds a VS Code launch configuration for easily launching the Flutter test Fixture app
- Makes all tool names use a consistent case (`snake_case`). 

This PR contains some formatting changes. Filed https://github.com/dart-lang/ai/issues/58 to track using a consistent formatting version in this repo.