### PR TITLE
[dart_tooling_mcp_server] Persist VmService objects

### DIFF
--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
@@ -95,9 +95,9 @@ base mixin DartAnalyzerSupport on ToolsSupport, LoggingSupport {
       _watchSubscriptions.add(
         watcher.events.listen((event) {
           try {
-          _analysisContexts
-              ?.contextFor(event.path)
-              .changeFile(p.normalize(event.path));
+            _analysisContexts
+                ?.contextFor(event.path)
+                .changeFile(p.normalize(event.path));
           } catch (_) {
             // Fail gracefully.
             // TODO(https://github.com/dart-lang/ai/issues/65): remove this

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
@@ -94,9 +94,15 @@ base mixin DartAnalyzerSupport on ToolsSupport, LoggingSupport {
       final watcher = DirectoryWatcher(rootPath);
       _watchSubscriptions.add(
         watcher.events.listen((event) {
+          try {
           _analysisContexts
               ?.contextFor(event.path)
               .changeFile(p.normalize(event.path));
+          } catch (_) {
+            // Fail gracefully.
+            // TODO(https://github.com/dart-lang/ai/issues/65): remove this
+            // catch if possible.
+          }
         }),
       );
     }

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/dart_cli.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/dart_cli.dart
@@ -44,6 +44,9 @@ base mixin DartCliSupport on ToolsSupport, LoggingSupport {
   }
 
   /// Helper to run a dart command in multiple project roots.
+  /// 
+  /// [defaultPaths] may be specified if one or more path arguments are required
+  /// for the dart command (e.g. `dart format <default paths>`).
   Future<CallToolResult> _runDartCommandInRoots(
     CallToolRequest request,
     String commandName,

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/dart_cli.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/dart_cli.dart
@@ -44,7 +44,7 @@ base mixin DartCliSupport on ToolsSupport, LoggingSupport {
   }
 
   /// Helper to run a dart command in multiple project roots.
-  /// 
+  ///
   /// [defaultPaths] may be specified if one or more path arguments are required
   /// for the dart command (e.g. `dart format <default paths>`).
   Future<CallToolResult> _runDartCommandInRoots(

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
@@ -56,6 +56,9 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
     final response = await dtd.getDebugSessions();
     final debugSessions = response.debugSessions;
     for (final debugSession in debugSessions) {
+      if (activeVmServices.containsKey(debugSession.vmServiceUri)) {
+        continue;
+      }
       final vmService = await vmServiceConnectUri(debugSession.vmServiceUri);
       activeVmServices[debugSession.vmServiceUri] = vmService;
       unawaited(

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
@@ -24,10 +24,47 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
   /// ready to be invoked.
   bool _getDebugSessionsReady = false;
 
+  /// A Map of [VmService] objects by their associated VM Service URI
+  /// (represented as a String).
+  ///
+  /// [VmService] objects are automatically removed from the Map when the
+  /// [VmService] shuts down.
+  final activeVmServices = <String, VmService>{};
+
   /// Called when the DTD connection is lost, resets all associated state.
-  void _resetDtd() {
+  Future<void> _resetDtd() async {
     _dtd = null;
     _getDebugSessionsReady = false;
+    await Future.wait(
+      activeVmServices.values.map((vmService) => vmService.dispose()),
+    );
+    activeVmServices.clear();
+  }
+
+  Future<void> updateActiveVmServices() async {
+    final dtd = _dtd;
+    if (dtd == null) return;
+
+    // TODO: in the future, get the active VM service URIs from DTD directly
+    // instead of from the `Editor.getDebugSessions` service method.
+    if (!_getDebugSessionsReady) {
+      // Give it a chance to get ready.
+      await Future<void>.delayed(const Duration(seconds: 1));
+      if (!_getDebugSessionsReady) return;
+    }
+
+    final response = await dtd.getDebugSessions();
+    final debugSessions = response.debugSessions;
+    for (final debugSession in debugSessions) {
+      final vmService = await vmServiceConnectUri(debugSession.vmServiceUri);
+      activeVmServices[debugSession.vmServiceUri] = vmService;
+      unawaited(
+        vmService.onDone.then((_) {
+          activeVmServices.remove(debugSession.vmServiceUri);
+          vmService.dispose();
+        }),
+      );
+    }
   }
 
   @override
@@ -43,6 +80,12 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
     registerTool(hotReloadTool, hotReload);
 
     return super.initialize(request);
+  }
+
+  @override
+  Future<void> shutdown() async {
+    await _resetDtd();
+    await super.shutdown();
   }
 
   /// Connects to the Dart Tooling Daemon.
@@ -64,7 +107,7 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
       _dtd = await DartToolingDaemon.connect(
         Uri.parse(request.arguments!['uri'] as String),
       );
-      unawaited(_dtd!.done.then((_) => _resetDtd()));
+      unawaited(_dtd!.done.then((_) async => await _resetDtd()));
 
       _listenForServices();
       return CallToolResult(
@@ -150,62 +193,66 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
   Future<CallToolResult> hotReload(CallToolRequest request) async {
     return _callOnVmService(
       callback: (vmService) async {
-        final vm = await vmService.getVM();
+        StreamSubscription<Event>? serviceStreamSubscription;
+        try {
+          final hotReloadMethodNameCompleter = Completer<String?>();
+          serviceStreamSubscription = vmService
+              .onEvent(EventStreams.kService)
+              .listen((Event e) {
+                if (e.kind == EventKind.kServiceRegistered) {
+                  final serviceName = e.service!;
+                  if (serviceName == 'reloadSources') {
+                    // This may look something like 's0.reloadSources'.
+                    hotReloadMethodNameCompleter.complete(e.method);
+                  }
+                }
+              });
 
-        final hotReloadMethodNameCompleter = Completer<String?>();
-        vmService.onEvent(EventStreams.kService).listen((Event e) {
-          if (e.kind == EventKind.kServiceRegistered) {
-            final serviceName = e.service!;
-            if (serviceName == 'reloadSources') {
-              // This may look something like 's0.reloadSources'.
-              hotReloadMethodNameCompleter.complete(e.method);
-            }
-          }
-        });
-        await vmService.streamListen(EventStreams.kService);
-        final hotReloadMethodName = await hotReloadMethodNameCompleter.future
-            .timeout(
-              const Duration(milliseconds: 1000),
-              onTimeout: () async {
-                return null;
-              },
+          await vmService.streamListen(EventStreams.kService);
+
+          final hotReloadMethodName = await hotReloadMethodNameCompleter.future
+              .timeout(
+                const Duration(milliseconds: 1000),
+                onTimeout: () async {
+                  return null;
+                },
+              );
+          if (hotReloadMethodName == null) {
+            return CallToolResult(
+              isError: true,
+              content: [
+                TextContent(
+                  text:
+                      'The hot reload service has not been registered yet. '
+                      'Please wait a few seconds and try again.',
+                ),
+              ],
             );
-        await vmService.streamCancel(EventStreams.kService);
+          }
 
-        if (hotReloadMethodName == null) {
-          return CallToolResult(
-            isError: true,
-            content: [
-              TextContent(
-                text:
-                    'The hot reload service has not been registered yet, '
-                    'please wait a few seconds and try again.',
-              ),
-            ],
+          final vm = await vmService.getVM();
+          final result = await vmService.callMethod(
+            hotReloadMethodName,
+            isolateId: vm.isolates!.first.id,
           );
-        }
-
-        final result = await vmService.callMethod(
-          hotReloadMethodName,
-          isolateId: vm.isolates!.first.id,
-        );
-        final resultType = result.json?['type'];
-        if (resultType == 'Success' ||
-            (resultType == 'ReloadReport' && result.json?['success'] == true)) {
-          return CallToolResult(
-            content: [TextContent(text: 'Hot reload succeeded.')],
-          );
-        } else {
-          return CallToolResult(
-            isError: true,
-            content: [
-              TextContent(
-                text:
-                    'Hot reload failed:\n'
-                    '${result.json}',
-              ),
-            ],
-          );
+          final resultType = result.json?['type'];
+          if (resultType == 'Success' ||
+              (resultType == 'ReloadReport' &&
+                  result.json?['success'] == true)) {
+            return CallToolResult(
+              content: [TextContent(text: 'Hot reload succeeded.')],
+            );
+          } else {
+            return CallToolResult(
+              isError: true,
+              content: [
+                TextContent(text: 'Hot reload failed:\n${result.json}'),
+              ],
+            );
+          }
+        } finally {
+          await serviceStreamSubscription?.cancel();
+          await vmService.streamCancel(EventStreams.kService);
         }
       },
     );
@@ -295,19 +342,12 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
       if (!_getDebugSessionsReady) return _dtdNotReady;
     }
 
-    final response = await dtd.getDebugSessions();
-    final debugSessions = response.debugSessions;
-    if (debugSessions.isEmpty) return _noActiveDebugSession;
+    await updateActiveVmServices();
+    if (activeVmServices.isEmpty) return _noActiveDebugSession;
 
-    // TODO: Consider holding on to this connection.
-    final vmService = await vmServiceConnectUri(
-      debugSessions.first.vmServiceUri,
-    );
-    try {
-      return await callback(vmService);
-    } finally {
-      unawaited(vmService.dispose());
-    }
+    // TODO: support selecting a VM Service if more than one are available.
+    final vmService = activeVmServices.values.first;
+    return await callback(vmService);
   }
 
   @visibleForTesting

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
@@ -32,13 +32,23 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
   @visibleForTesting
   final activeVmServices = <String, VmService>{};
 
+  /// Whether to await the disposal of all [VmService] objects in
+  /// [activeVmServices] upon server shutdown or loss of DTD connection.
+  ///
+  /// Defaults to false but can be flipped to true for testing purposes.
+  @visibleForTesting
+  static bool debugAwaitVmServiceDisposal = false;
+
   /// Called when the DTD connection is lost, resets all associated state.
   Future<void> _resetDtd() async {
     _dtd = null;
     _getDebugSessionsReady = false;
-    await Future.wait(
+
+    final future = Future.wait(
       activeVmServices.values.map((vmService) => vmService.dispose()),
     );
+    debugAwaitVmServiceDisposal ? await future : unawaited(future);
+
     activeVmServices.clear();
   }
 

--- a/pkgs/dart_tooling_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/dtd_test.dart
@@ -138,13 +138,13 @@ void main() {
       expect(server.activeVmServices.length, 1);
       expect(originalVmService, server.activeVmServices.values.single);
 
-      // await testHarness.startDebugSession(
-      //   counterAppPath,
-      //   'lib/main.dart',
-      //   isFlutter: true,
-      // );
-      // await server.updateActiveVmServices();
-      // expect(server.activeVmServices.length, 2);
+      await testHarness.startDebugSession(
+        counterAppPath,
+        'lib/main.dart',
+        isFlutter: true,
+      );
+      await server.updateActiveVmServices();
+      expect(server.activeVmServices.length, 2);
     });
 
     test('automatically removes vm services upon shutdown', () async {

--- a/pkgs/dart_tooling_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/dtd_test.dart
@@ -5,26 +5,27 @@
 import 'package:dart_mcp/server.dart';
 import 'package:dart_tooling_mcp_server/src/mixins/dtd.dart';
 import 'package:test/test.dart';
+import 'package:vm_service/vm_service.dart';
 
 import '../test_harness.dart';
 
 void main() {
   late TestHarness testHarness;
 
-  // TODO: Use setUpAll, currently this fails due to an apparent TestProcess
-  // issue.
-  setUp(() async {
-    testHarness = await TestHarness.start();
-    await testHarness.connectToDtd();
-    await testHarness.startDebugSession(
-      counterAppPath,
-      'lib/main.dart',
-      isFlutter: true,
-    );
-  });
-
   group('dart tooling daemon tools', () {
+    // TODO: Use setUpAll, currently this fails due to an apparent TestProcess
+    // issue.
+    setUp(() async {
+      testHarness = await TestHarness.start(inProcess: true);
+      await testHarness.connectToDtd();
+    });
+
     test('can take a screenshot', () async {
+      await testHarness.startDebugSession(
+        counterAppPath,
+        'lib/main.dart',
+        isFlutter: true,
+      );
       final tools = (await testHarness.mcpServerConnection.listTools()).tools;
       final screenshotTool = tools.singleWhere(
         (t) => t.name == DartToolingDaemonSupport.screenshotTool.name,
@@ -40,6 +41,11 @@ void main() {
     });
 
     test('can perform a hot reload', () async {
+      await testHarness.startDebugSession(
+        counterAppPath,
+        'lib/main.dart',
+        isFlutter: true,
+      );
       final tools = (await testHarness.mcpServerConnection.listTools()).tools;
       final hotReloadTool = tools.singleWhere(
         (t) => t.name == DartToolingDaemonSupport.hotReloadTool.name,
@@ -55,6 +61,12 @@ void main() {
     });
 
     test('can get runtime errors', () async {
+      await testHarness.startDebugSession(
+        counterAppPath,
+        'lib/main.dart',
+        isFlutter: true,
+        args: ['--dart-define=include_layout_error=true'],
+      );
       final tools = (await testHarness.mcpServerConnection.listTools()).tools;
       final runtimeErrorsTool = tools.singleWhere(
         (t) => t.name == DartToolingDaemonSupport.getRuntimeErrorsTool.name,
@@ -73,6 +85,57 @@ void main() {
         (runtimeErrorsResult.content[1] as TextContent).text,
         contains('A RenderFlex overflowed by'),
       );
+    });
+  });
+
+  group('$VmService management', () {
+    setUp(() async {
+      testHarness = await TestHarness.start(inProcess: true);
+      await testHarness.connectToDtd();
+    });
+
+    test('persists vm services', () async {
+      final server = testHarness.serverConnectionPair.server!;
+      expect(server.activeVmServices, isEmpty);
+
+      await testHarness.startDebugSession(
+        counterAppPath,
+        'lib/main.dart',
+        isFlutter: true,
+      );
+      await server.updateActiveVmServices();
+      expect(server.activeVmServices.length, 1);
+
+      // Re-uses existing VM Service when available.
+      final originalVmService = server.activeVmServices.values.single;
+      await server.updateActiveVmServices();
+      expect(server.activeVmServices.length, 1);
+      expect(originalVmService, server.activeVmServices.values.single);
+
+      // await testHarness.startDebugSession(
+      //   counterAppPath,
+      //   'lib/main.dart',
+      //   isFlutter: true,
+      // );
+      // await server.updateActiveVmServices();
+      // expect(server.activeVmServices.length, 2);
+    });
+
+    test('automatically removes vm services upon shutdown', () async {
+      final server = testHarness.serverConnectionPair.server!;
+      expect(server.activeVmServices, isEmpty);
+
+      final debugSession = await testHarness.startDebugSession(
+        counterAppPath,
+        'lib/main.dart',
+        isFlutter: true,
+      );
+      await server.updateActiveVmServices();
+      expect(server.activeVmServices.length, 1);
+
+      await testHarness.stopDebugSession(debugSession);
+      await server.updateActiveVmServices();
+      expect(server.activeVmServices, isEmpty);
     });
   });
 }

--- a/pkgs/dart_tooling_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/dtd_test.dart
@@ -16,7 +16,7 @@ void main() {
     // TODO: Use setUpAll, currently this fails due to an apparent TestProcess
     // issue.
     setUp(() async {
-      testHarness = await TestHarness.start(inProcess: true);
+      testHarness = await TestHarness.start();
       await testHarness.connectToDtd();
     });
 
@@ -88,6 +88,11 @@ void main() {
     });
 
     test('can get the widget tree', () async {
+      await testHarness.startDebugSession(
+        counterAppPath,
+        'lib/main.dart',
+        isFlutter: true,
+      );
       final tools = (await testHarness.mcpServerConnection.listTools()).tools;
       final getWidgetTreeTool = tools.singleWhere(
         (t) => t.name == DartToolingDaemonSupport.getWidgetTreeTool.name,

--- a/pkgs/dart_tooling_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/dtd_test.dart
@@ -111,6 +111,11 @@ void main() {
 
   group('$VmService management', () {
     setUp(() async {
+      DartToolingDaemonSupport.debugAwaitVmServiceDisposal = true;
+      addTearDown(
+        () => DartToolingDaemonSupport.debugAwaitVmServiceDisposal = false,
+      );
+
       testHarness = await TestHarness.start(inProcess: true);
       await testHarness.connectToDtd();
     });

--- a/pkgs/dart_tooling_mcp_server/test_fixtures/counter_app/lib/main.dart
+++ b/pkgs/dart_tooling_mcp_server/test_fixtures/counter_app/lib/main.dart
@@ -35,6 +35,10 @@ class MyHomePage extends StatefulWidget {
 class _MyHomePageState extends State<MyHomePage> {
   int _counter = 0;
 
+  static const includeLayoutError = bool.fromEnvironment(
+    'include_layout_error',
+  );
+
   void _incrementCounter() {
     setState(() {
       _counter++;
@@ -55,11 +59,13 @@ class _MyHomePageState extends State<MyHomePage> {
             const Row(
               children: [
                 Text('You have pushed the button this many times:'),
-                Text(
-                  'And this Row should create an overflow error because it '
-                  'contains way more text than could ever fit on a single Row '
-                  'on both a mobile app or the default size of a desktop app.',
-                ),
+                if (includeLayoutError)
+                  Text(
+                    'And this Row should create an overflow error because it '
+                    'contains way more text than could ever fit on a single '
+                    'Row on both a mobile app or the default size of a desktop '
+                    'app.',
+                  ),
               ],
             ),
             Text(


### PR DESCRIPTION
This PR:
- persists active VM service objects so that we do not need to recreate them for each DTD tool call
- cleans up a stream subscription disposal for the hot reload command (review with hide whitespace diffs)