### PR TITLE
[dart_tooling_mcp_server] add `get_widget_tree` tool

### DIFF
--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
@@ -41,6 +41,7 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
     // supported in profile mode).
     registerTool(screenshotTool, takeScreenshot);
     registerTool(hotReloadTool, hotReload);
+    registerTool(getWidgetTreeTool, widgetTree);
 
     return super.initialize(request);
   }
@@ -283,6 +284,65 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
     );
   }
 
+  /// Retrieves the Flutter widget tree from the currently running app.
+  ///
+  /// If more than one debug session is active, then it just uses the first one.
+  ///
+  // TODO: support passing a debug session id when there is more than one debug
+  // session.
+  Future<CallToolResult> widgetTree(CallToolRequest request) async {
+    return _callOnVmService(
+      callback: (vmService) async {
+        final vm = await vmService.getVM();
+        final isolateId = vm.isolates!.first.id;
+        final groupId = 'dart-tooling-mcp-server';
+        const inspectorExtensionPrefix = 'ext.flutter.inspector';
+        try {
+          final result = await vmService.callServiceExtension(
+            '$inspectorExtensionPrefix.getRootWidgetTree',
+            isolateId: isolateId,
+            args: {
+              'groupName': groupId,
+              // TODO: consider making these configurable or using defaults that
+              // are better for the LLM.
+              'isSummaryTree': 'true',
+              'withPreviews': 'true',
+              'fullDetails': 'true',
+            },
+          );
+          final tree = result.json?['result'];
+          if (tree == null) {
+            return CallToolResult(
+              content: [
+                TextContent(
+                  text:
+                      'Could not get Widget tree. '
+                      'Unexpected result: ${result.json}.',
+                ),
+              ],
+            );
+          }
+          return CallToolResult(content: [TextContent(text: tree.toString())]);
+        } catch (e) {
+          return CallToolResult(
+            isError: true,
+            content: [
+              TextContent(
+                text: 'Unknown error or bad response getting widget tree:\n$e',
+              ),
+            ],
+          );
+        } finally {
+          await vmService.callServiceExtension(
+            '$inspectorExtensionPrefix.disposeGroup',
+            isolateId: isolateId,
+            args: {'objectGroup': groupId},
+          );
+        }
+      },
+    );
+  }
+
   /// Calls [callback] on the first active debug session, if available.
   Future<CallToolResult> _callOnVmService({
     required Future<CallToolResult> Function(VmService) callback,
@@ -324,6 +384,16 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
   );
 
   @visibleForTesting
+  static final getRuntimeErrorsTool = Tool(
+    name: 'get_runtime_errors',
+    description:
+        'Retrieves the list of runtime errors that have occurred in the active '
+        'Dart or Flutter application. Requires "${connectTool.name}" to be '
+        'successfully called first.',
+    inputSchema: ObjectSchema(),
+  );
+
+  @visibleForTesting
   static final screenshotTool = Tool(
     name: 'take_screenshot',
     description:
@@ -344,12 +414,11 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
   );
 
   @visibleForTesting
-  static final getRuntimeErrorsTool = Tool(
-    name: 'get_runtime_errors',
+  static final getWidgetTreeTool = Tool(
+    name: 'get_widget_tree',
     description:
-        'Retrieves the list of runtime errors that have occurred in the active '
-        'Dart or Flutter application. Requires "${connectTool.name}" to be '
-        'successfully called first.',
+        'Retrieves the widget tree from the active Flutter application. '
+        'Requires "${connectTool.name}" to be successfully called first.',
     inputSchema: ObjectSchema(),
   );
 

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
@@ -307,7 +307,7 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
               // are better for the LLM.
               'isSummaryTree': 'true',
               'withPreviews': 'true',
-              'fullDetails': 'true',
+              'fullDetails': 'false',
             },
           );
           final tree = result.json?['result'];

--- a/pkgs/dart_tooling_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/dtd_test.dart
@@ -74,5 +74,21 @@ void main() {
         contains('A RenderFlex overflowed by'),
       );
     });
+
+    test('can get the widget tree', () async {
+      final tools = (await testHarness.mcpServerConnection.listTools()).tools;
+      final getWidgetTreeTool = tools.singleWhere(
+        (t) => t.name == DartToolingDaemonSupport.getWidgetTreeTool.name,
+      );
+      final getWidgetTreeResult = await testHarness.callToolWithRetry(
+        CallToolRequest(name: getWidgetTreeTool.name),
+      );
+
+      expect(getWidgetTreeResult.isError, isNot(true));
+      expect(
+        (getWidgetTreeResult.content.first as TextContent).text,
+        contains('MyHomePage'),
+      );
+    });
   });
 }


### PR DESCRIPTION
This PR adds a tool that gets the widget tree for a running Flutter app. In its current form, this tool calls the `ext.flutter.inspector.getRootWidgetTree` service extensions with the following parameters:
```
'groupName': groupId,
'isSummaryTree': 'true',
'withPreviews': 'true',
'fullDetails': 'true',
```
This will return Widgets that were added to the tree from the user's code (it will not contain implementation widgets). @elliette what do you think of these default values? 

Example response:
```
{description: [root], type: _ElementDiagnosticableTreeNode, style: dense, hasChildren: true, allowWrap: false, summaryTree: true, valueId: inspector-83, locationId: 0, creationLocation: {file: file:///Users/kenzieschmoll/develop/flutter/packages/flutter/lib/src/widgets/binding.dart, line: 1331, column: 24, name: RootWidget}, children: [{description: MyApp, type: _ElementDiagnosticableTreeNode, style: dense, hasChildren: true, allowWrap: false, summaryTree: true, valueId: inspector-84, locationId: 1, creationLocation: {file: file:///Users/kenzieschmoll/develop/dart-lang/ai/pkgs/dart_tooling_mcp_server/test_fixtures/counter_app/lib/main.dart, line: 8, column: 16, name: MyApp}, createdByLocalProject: true, children: [{description: MaterialApp, type: _ElementDiagnosticableTreeNode, style: dense, hasChildren: true, allowWrap: false, summaryTree: true, valueId: inspector-85, locationId: 2, creationLocation: {file: file:///Users/kenzieschmoll/develop/dart-lang/ai/pkgs/dart_tooling_mcp_server/test_fixtures/counter_app/lib/main.dart, line: 16, column: 12, name: MaterialApp}, createdByLocalProject: true, children: [{description: MyHomePage, type: _ElementDiagnosticableTreeNode, style: dense, hasChildren: true, allowWrap: false, summaryTree: true, valueId: inspector-86, locationId: 3, creationLocation: {file: file:///Users/kenzieschmoll/develop/dart-lang/ai/pkgs/dart_tooling_mcp_server/test_fixtures/counter_app/lib/main.dart, line: 21, column: 19, name: MyHomePage}, createdByLocalProject: true, children: [{description: Scaffold, type: _ElementDiagnosticableTreeNode, style: dense, hasChildren: true, allowWrap: false, summaryTree: true, valueId: inspector-87, locationId: 4, creationLocation: {file: file:///Users/kenzieschmoll/develop/dart-lang/ai/pkgs/dart_tooling_mcp_server/test_fixtures/counter_app/lib/main.dart, line: 46, column: 12, name: Scaffold}, createdByLocalProject: true, children: [{description: Center, type: _ElementDiagnosticableTreeNode, style: dense, hasChildren: true, allowWrap: false, summaryTree: true, valueId: inspector-88, locationId: 5, creationLocation: {file: file:///Users/kenzieschmoll/develop/dart-lang/ai/pkgs/dart_tooling_mcp_server/test_fixtures/counter_app/lib/main.dart, line: 51, column: 13, name: Center}, createdByLocalProject: true, children: [{description: Column, type: _ElementDiagnosticableTreeNode, style: dense, hasChildren: true, allowWrap: false, summaryTree: true, valueId: inspector-89, locationId: 6, creationLocation: {file: file:///Users/kenzieschmoll/develop/dart-lang/ai/pkgs/dart_tooling_mcp_server/test_fixtures/counter_app/lib/main.dart, line: 52, column: 16, name: Column}, createdByLocalProject: true, children: [{description: Row, type: _ElementDiagnosticableTreeNode, style: dense, hasChildren: true, allowWrap: false, summaryTree: true, valueId: inspector-47, locationId: 7, creationLocation: {file: file:///Users/kenzieschmoll/develop/dart-lang/ai/pkgs/dart_tooling_mcp_server/test_fixtures/counter_app/lib/main.dart, line: 55, column: 19, name: Row}, createdByLocalProject: true, children: [{description: Text, type: _ElementDiagnosticableTreeNode, style: dense, hasChildren: true, allowWrap: false, summaryTree: true, valueId: inspector-90, locationId: 8, creationLocation: {file: file:///Users/kenzieschmoll/develop/dart-lang/ai/pkgs/dart_tooling_mcp_server/test_fixtures/counter_app/lib/main.dart, line: 57, column: 17, name: Text}, createdByLocalProject: true, textPreview: You have pushed the button this many times:, children: [], widgetRuntimeType: Text, stateful: false}, {description: Text, type: _ElementDiagnosticableTreeNode, style: dense, hasChildren: true, allowWrap: false, summaryTree: true, valueId: inspector-91, locationId: 9, creationLocation: {file: file:///Users/kenzieschmoll/develop/dart-lang/ai/pkgs/dart_tooling_mcp_server/test_fixtures/counter_app/lib/main.dart, line: 58, column: 17, name: Text}, createdByLocalProject: true, textPreview: And this Row should create an overflow error because it contains way more text than could ever fit on a single Row on both a mobile app or the default size of a desktop app., children: [], widgetRuntimeType: Text, stateful: false}], widgetRuntimeType: Row, stateful: false}, {description: Text, type: _ElementDiagnosticableTreeNode, style: dense, hasChildren: true, allowWrap: false, summaryTree: true, valueId: inspector-92, locationId: 10, creationLocation: {file: file:///Users/kenzieschmoll/develop/dart-lang/ai/pkgs/dart_tooling_mcp_server/test_fixtures/counter_app/lib/main.dart, line: 65, column: 13, name: Text}, createdByLocalProject: true, textPreview: 0, children: [], widgetRuntimeType: Text, stateful: false}], widgetRuntimeType: Column, stateful: false}], widgetRuntimeType: Center, stateful: false}, {description: AppBar, type: _ElementDiagnosticableTreeNode, style: dense, hasChildren: true, allowWrap: false, summaryTree: true, valueId: inspector-93, locationId: 11, creationLocation: {file: file:///Users/kenzieschmoll/develop/dart-lang/ai/pkgs/dart_tooling_mcp_server/test_fixtures/counter_app/lib/main.dart, line: 47, column: 15, name: AppBar}, createdByLocalProject: true, children: [{description: Text, type: _ElementDiagnosticableTreeNode, style: dense, hasChildren: true, allowWrap: false, summaryTree: true, valueId: inspector-94, locationId: 12, creationLocation: {file: file:///Users/kenzieschmoll/develop/dart-lang/ai/pkgs/dart_tooling_mcp_server/test_fixtures/counter_app/lib/main.dart, line: 49, column: 16, name: Text}, createdByLocalProject: true, textPreview: Flutter Demo Home Page, children: [], widgetRuntimeType: Text, stateful: false}], widgetRuntimeType: AppBar, stateful: true}, {description: FloatingActionButton, type: _ElementDiagnosticableTreeNode, style: dense, hasChildren: true, allowWrap: false, summaryTree: true, valueId: inspector-95, locationId: 13, creationLocation: {file: file:///Users/kenzieschmoll/develop/dart-lang/ai/pkgs/dart_tooling_mcp_server/test_fixtures/counter_app/lib/main.dart, line: 72, column: 29, name: FloatingActionButton}, createdByLocalProject: true, children: [{description: Icon, type: _ElementDiagnosticableTreeNode, style: dense, hasChildren: true, allowWrap: false, summaryTree: true, valueId: inspector-96, locationId: 14, creationLocation: {file: file:///Users/kenzieschmoll/develop/dart-lang/ai/pkgs/dart_tooling_mcp_server/test_fixtures/counter_app/lib/main.dart, line: 75, column: 22, name: Icon}, createdByLocalProject: true, children: [], widgetRuntimeType: Icon, stateful: false}], widgetRuntimeType: FloatingActionButton, stateful: false}], widgetRuntimeType: Scaffold, stateful: true}], widgetRuntimeType: MyHomePage, stateful: true}], widgetRuntimeType: MaterialApp, stateful: true}], widgetRuntimeType: MyApp, stateful: false}], widgetRuntimeType: RootWidget, stateful: false}
```

See https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/widgets/service_extensions.dart/#L126 for other Widget Inspector service extensions we may be interested in exposing. It is possible that `getDetailsSubtree` could be a better candidate for a getting a smaller portion of the widget tree (for example getting the subtree of a widget referenced in a Flutter error). 