### PR TITLE
Update spec to 2025-03-26

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 0.1.1-wip
+## 0.2.0-wip
 
+- **Breaking**: Fixed paginated result subtypes to use `nextCursor` instead of
+  `cursor` as the key for the next cursor.
 - Save the `ServerCapabilities` object on the `ServerConnection` class to make
   it easier to check the capabilities of the server.
 

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -1,9 +1,16 @@
 ## 0.2.0-wip
 
-- **Breaking**: Fixed paginated result subtypes to use `nextCursor` instead of
-  `cursor` as the key for the next cursor.
+- Support protocol version 2025-03-26.
+  - Adds support for `AudioContent`.
+  - Adds support for `ToolAnnotations`.
+  - Adds support for `ProgressNotification` messages.
 - Save the `ServerCapabilities` object on the `ServerConnection` class to make
   it easier to check the capabilities of the server.
+- **Breaking**: Fixed paginated result subtypes to use `nextCursor` instead of
+  `cursor` as the key for the next cursor.
+- **Breaking**: Change the `ProgressNotification.progress` and
+  `ProgressNotification.total` types to `num` instead of `int` to align with the
+  spec.
 
 ## 0.1.0
 

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -6,11 +6,19 @@
   - Adds support for `ProgressNotification` messages.
 - Save the `ServerCapabilities` object on the `ServerConnection` class to make
   it easier to check the capabilities of the server.
+- Add default version negotiation logic.
+  - Save the negotiated `ProtocolVersion` in a `protocolVersion` field for both
+    `MCPServer` and the `ServerConnection` classes.
+  - Automatically disconnect from servers if version negotiation fails.
 - **Breaking**: Fixed paginated result subtypes to use `nextCursor` instead of
   `cursor` as the key for the next cursor.
 - **Breaking**: Change the `ProgressNotification.progress` and
   `ProgressNotification.total` types to `num` instead of `int` to align with the
   spec.
+- **Breaking**: Change the `protocolVersion` string to a `ProtocolVersion` enum,
+  which has all supported versions and whether or not they are supported.
+- **Breaking**: Change `InitializeRequest` and `InitializeResult` to take a
+  `ProtocolVersion` instead of a string.
 
 ## 0.1.0
 

--- a/pkgs/dart_mcp/README.md
+++ b/pkgs/dart_mcp/README.md
@@ -94,6 +94,29 @@ Both the `MCPServer` and `MCPClient` support these.
 | [Cancellation](https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/utilities/cancellation/) | :x: | https://github.com/dart-lang/ai/issues/37 |
 | [Progress](https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/utilities/progress/) | :heavy_check_mark: |  |
 
+## Transport Mechanisms
+
+This table describes the supported
+[transport mechanisms](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports).
+
+At its core this package is just build on streams, so any transport mechanism
+can be used, but some are supported out of the box.
+
+| Transport | Support | Notes |
+| --- | --- | --- |
+| [Stdio](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#stdio) | :heavy_check_mark: |  |
+| [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) | :x: | Unsupported at this time, may come in the future. |
+
+## Batching Requests
+
+Both the client and server support processing batch requests, but do not support
+creating batch requests at this time.
+
+## Authorization
+
+Authorization is not supported at this time, this package is primarily targeted
+at local MCP server usage for now.
+
 ## Server Capabilities
 
 This table describes the state of implementation for the

--- a/pkgs/dart_mcp/README.md
+++ b/pkgs/dart_mcp/README.md
@@ -114,7 +114,7 @@ creating batch requests at this time.
 
 ## Authorization
 
-Authorization is not supported at this time, this package is primarily targeted
+Authorization is not supported at this time. This package is primarily targeted
 at local MCP server usage for now.
 
 ## Server Capabilities

--- a/pkgs/dart_mcp/README.md
+++ b/pkgs/dart_mcp/README.md
@@ -99,8 +99,8 @@ Both the `MCPServer` and `MCPClient` support these.
 This table describes the supported
 [transport mechanisms](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports).
 
-At its core this package is just build on streams, so any transport mechanism
-can be used, but some are supported out of the box.
+At its core this package is just built on streams, so any transport mechanism
+can be used, but some are directly supported out of the box.
 
 | Transport | Support | Notes |
 | --- | --- | --- |

--- a/pkgs/dart_mcp/example/client.dart
+++ b/pkgs/dart_mcp/example/client.dart
@@ -18,15 +18,15 @@ void main() async {
   print('initializing server');
   final initializeResult = await server.initialize(
     InitializeRequest(
-      protocolVersion: protocolVersion,
+      protocolVersion: ProtocolVersion.latest,
       capabilities: client.capabilities,
       clientInfo: client.implementation,
     ),
   );
   print('initialized: $initializeResult');
-  if (initializeResult.protocolVersion != protocolVersion) {
+  if (initializeResult.protocolVersion != ProtocolVersion.latest) {
     throw StateError(
-      'Protocol version mismatch, expected $protocolVersion, '
+      'Protocol version mismatch, expected ${ProtocolVersion.latest}, '
       'got ${initializeResult.protocolVersion}',
     );
   }

--- a/pkgs/dart_mcp/example/client.dart
+++ b/pkgs/dart_mcp/example/client.dart
@@ -18,15 +18,15 @@ void main() async {
   print('initializing server');
   final initializeResult = await server.initialize(
     InitializeRequest(
-      protocolVersion: ProtocolVersion.latest,
+      protocolVersion: ProtocolVersion.latestSupported,
       capabilities: client.capabilities,
       clientInfo: client.implementation,
     ),
   );
   print('initialized: $initializeResult');
-  if (initializeResult.protocolVersion != ProtocolVersion.latest) {
+  if (initializeResult.protocolVersion != ProtocolVersion.latestSupported) {
     throw StateError(
-      'Protocol version mismatch, expected ${ProtocolVersion.latest}, '
+      'Protocol version mismatch, expected ${ProtocolVersion.latestSupported}, '
       'got ${initializeResult.protocolVersion}',
     );
   }

--- a/pkgs/dart_mcp/example/dash_client.dart
+++ b/pkgs/dart_mcp/example/dash_client.dart
@@ -224,14 +224,14 @@ final class DashClient extends MCPClient with RootsSupport {
     for (var connection in serverConnections) {
       final result = await connection.initialize(
         InitializeRequest(
-          protocolVersion: protocolVersion,
+          protocolVersion: ProtocolVersion.latest,
           capabilities: capabilities,
           clientInfo: implementation,
         ),
       );
-      if (result.protocolVersion != protocolVersion) {
+      if (result.protocolVersion != ProtocolVersion.latest) {
         print(
-          'Protocol version mismatch, expected $protocolVersion, '
+          'Protocol version mismatch, expected ${ProtocolVersion.latest}, '
           'got ${result.protocolVersion}, disconnecting from server',
         );
         await connection.shutdown();
@@ -385,7 +385,7 @@ final class DashChatBotServer extends MCPServer with ToolsSupport {
 
 final systemInstructions = gemini.Content.system('''
 You are a developer assistant for Dart and Flutter apps. Your persona is a cute
-blue humingbird named Dash, and you are also the mascot for the Dart and Flutter
+blue hummingbird named Dash, and you are also the mascot for the Dart and Flutter
 brands. Your personality is extremely cheery and bright, and your tone is always
 positive.
 

--- a/pkgs/dart_mcp/example/dash_client.dart
+++ b/pkgs/dart_mcp/example/dash_client.dart
@@ -224,15 +224,16 @@ final class DashClient extends MCPClient with RootsSupport {
     for (var connection in serverConnections) {
       final result = await connection.initialize(
         InitializeRequest(
-          protocolVersion: ProtocolVersion.latest,
+          protocolVersion: ProtocolVersion.latestSupported,
           capabilities: capabilities,
           clientInfo: implementation,
         ),
       );
-      if (result.protocolVersion != ProtocolVersion.latest) {
+      if (result.protocolVersion != ProtocolVersion.latestSupported) {
         print(
-          'Protocol version mismatch, expected ${ProtocolVersion.latest}, '
-          'got ${result.protocolVersion}, disconnecting from server',
+          'Protocol version mismatch, expected '
+          '${ProtocolVersion.latestSupported}, got ${result.protocolVersion}, '
+          'disconnecting from server',
         );
         await connection.shutdown();
         serverConnections.remove(connection);

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -185,7 +185,7 @@ extension type PaginatedRequest._fromMap(Map<String, Object?> _value)
 /// constructor.
 extension type PaginatedResult._fromMap(Map<String, Object?> _value)
     implements Result {
-  Cursor? get cursor => _value['cursor'] as Cursor?;
+  Cursor? get nextCursor => _value['nextCursor'] as Cursor?;
 }
 
 /// Could be either [TextContent], [ImageContent] or [EmbeddedResource].

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -41,7 +41,7 @@ enum ProtocolVersion {
   /// Whether or not this API is compatible with the current version.
   ///
   /// **Note**: There may be extra fields included.
-  bool get isSupported => this >= oldestSupported;
+  bool get isSupported => this >= oldestSupported && this <= latestSupported;
 
   bool operator <(ProtocolVersion other) => index < other.index;
   bool operator <=(ProtocolVersion other) => index <= other.index;

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -17,15 +17,37 @@ part 'roots.dart';
 part 'sampling.dart';
 part 'tools.dart';
 
-/// The latest supported protocol version, the API exposed here reflects this
-/// version but it is backwards compatible with all the versions in
-/// [supportedVersions].
-const protocolVersion = '2025-03-26';
+/// Enum of the known protocol versions.
+enum ProtocolVersion {
+  v2024_11_05('2024-11-05'),
+  v2025_03_26('2025-03-26');
 
-/// The supported protocol versions.
-///
-/// The APIs in this package are
-const supportedVersions = ['2025-03-26', '2024-11-05'];
+  const ProtocolVersion(this.versionString);
+
+  /// Returns the [ProtocolVersion] based on the [version] string, or `null` if
+  /// it was not recognized.
+  static ProtocolVersion? tryParse(String version) =>
+      values.firstWhereOrNull((v) => v.versionString == version);
+
+  /// The oldest version supported by the current API.
+  static const oldestSupportedVersion = ProtocolVersion.v2024_11_05;
+
+  /// The most recent version supported by the current API.
+  static const latest = ProtocolVersion.v2025_03_26;
+
+  /// The version string used over the wire to identify this version.
+  final String versionString;
+
+  /// Whether or not this API is compatible with the current version.
+  ///
+  /// **Note**: There may be extra fields included.
+  bool get isSupported => this >= oldestSupportedVersion;
+
+  bool operator <(ProtocolVersion other) => index < other.index;
+  bool operator <=(ProtocolVersion other) => index <= other.index;
+  bool operator >(ProtocolVersion other) => index > other.index;
+  bool operator >=(ProtocolVersion other) => index >= other.index;
+}
 
 /// A progress token, used to associate progress notifications with the original
 /// request.
@@ -301,7 +323,7 @@ extension type ImageContent.fromMap(Map<String, Object?> _value)
 
 /// Audio provided to or from an LLM.
 ///
-/// Only supported since version `2025-03-26`.
+/// Only supported since version [ProtocolVersion.v2025_03_26].
 extension type AudioContent.fromMap(Map<String, Object?> _value)
     implements Content, Annotated {
   static const expectedType = 'audio';

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -30,10 +30,10 @@ enum ProtocolVersion {
       values.firstWhereOrNull((v) => v.versionString == version);
 
   /// The oldest version supported by the current API.
-  static const oldestSupportedVersion = ProtocolVersion.v2024_11_05;
+  static const oldestSupported = ProtocolVersion.v2024_11_05;
 
   /// The most recent version supported by the current API.
-  static const latest = ProtocolVersion.v2025_03_26;
+  static const latestSupported = ProtocolVersion.v2025_03_26;
 
   /// The version string used over the wire to identify this version.
   final String versionString;
@@ -41,7 +41,7 @@ enum ProtocolVersion {
   /// Whether or not this API is compatible with the current version.
   ///
   /// **Note**: There may be extra fields included.
-  bool get isSupported => this >= oldestSupportedVersion;
+  bool get isSupported => this >= oldestSupported;
 
   bool operator <(ProtocolVersion other) => index < other.index;
   bool operator <=(ProtocolVersion other) => index <= other.index;
@@ -316,8 +316,9 @@ extension type ImageContent.fromMap(Map<String, Object?> _value)
   /// The base64 encoded image data.
   String get data => _value['data'] as String;
 
-  /// The MIME type of the image. Different providers may support different
-  /// image types.
+  /// The MIME type of the image.
+  ///
+  /// Different providers may support different image types.
   String get mimeType => _value['mimeType'] as String;
 }
 
@@ -345,11 +346,12 @@ extension type AudioContent.fromMap(Map<String, Object?> _value)
     return type;
   }
 
-  /// The base64 encoded image data.
+  /// The base64 encoded audio data.
   String get data => _value['data'] as String;
 
-  /// The MIME type of the audio. Different providers may support different
-  /// audio types.
+  /// The MIME type of the audio.
+  ///
+  /// Different providers may support different audio types.
   String get mimeType => _value['mimeType'] as String;
 }
 

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -17,8 +17,15 @@ part 'roots.dart';
 part 'sampling.dart';
 part 'tools.dart';
 
-/// The current protocol version
-const protocolVersion = '2024-11-05';
+/// The latest supported protocol version, the API exposed here reflects this
+/// version but it is backwards compatible with all the versions in
+/// [supportedVersions].
+const protocolVersion = '2025-03-26';
+
+/// The supported protocol versions.
+///
+/// The APIs in this package are
+const supportedVersions = ['2025-03-26', '2024-11-05'];
 
 /// A progress token, used to associate progress notifications with the original
 /// request.
@@ -136,14 +143,16 @@ extension type ProgressNotification.fromMap(Map<String, Object?> _value)
 
   factory ProgressNotification({
     required ProgressToken progressToken,
-    required int progress,
-    int? total,
+    required num progress,
+    num? total,
     Meta? meta,
+    String? message,
   }) => ProgressNotification.fromMap({
     'progressToken': progressToken,
     'progress': progress,
     if (total != null) 'total': total,
     if (meta != null) '_meta': meta,
+    if (message != null) 'message': message,
   });
 
   /// The progress token which was given in the initial request, used to
@@ -154,11 +163,14 @@ extension type ProgressNotification.fromMap(Map<String, Object?> _value)
   ///
   /// This should increase every time progress is made, even if the total is
   /// unknown.
-  int get progress => _value['progress'] as int;
+  num get progress => _value['progress'] as num;
 
   /// Total number of items to process (or total progress required), if
   /// known.
-  int? get total => _value['total'] as int?;
+  num? get total => _value['total'] as num?;
+
+  /// An optional message describing the current progress.
+  String? get message => _value['message'] as String?;
 }
 
 /// A "mixin"-like extension type for any request that contains a [Cursor] at
@@ -188,7 +200,8 @@ extension type PaginatedResult._fromMap(Map<String, Object?> _value)
   Cursor? get nextCursor => _value['nextCursor'] as Cursor?;
 }
 
-/// Could be either [TextContent], [ImageContent] or [EmbeddedResource].
+/// Could be either [TextContent], [ImageContent], [AudioContent] or
+/// [EmbeddedResource].
 ///
 /// Use [isText], [isImage] and [isEmbeddedResource] before casting to the more
 /// specific types, or switch on the [type] and then cast.
@@ -201,11 +214,26 @@ extension type Content._(Map<String, Object?> _value) {
     return Content._(value);
   }
 
+  /// Alias for [TextContent.new].
+  static const text = TextContent.new;
+
+  /// Alias for [ImageContent.new].
+  static const image = ImageContent.new;
+
+  /// Alias for [AudioContent.new].
+  static const audio = AudioContent.new;
+
+  /// Alias for [EmbeddedResource.new].
+  static const embeddedResource = EmbeddedResource.new;
+
   /// Whether or not this is a [TextContent].
   bool get isText => _value['type'] == TextContent.expectedType;
 
-  /// Whether or not this is a [ImageContent].
+  /// Whether or not this is an [ImageContent].
   bool get isImage => _value['type'] == ImageContent.expectedType;
+
+  /// Whether or not this is an [AudioContent].
+  bool get isAudio => _value['type'] == AudioContent.expectedType;
 
   /// Whether or not this is an [EmbeddedResource].
   bool get isEmbeddedResource =>
@@ -214,12 +242,12 @@ extension type Content._(Map<String, Object?> _value) {
   /// The type of content.
   ///
   /// You can use this in a switch to handle the various types (see the static
-  /// `expectedType` getters), or you can use [isText], [isImage], and
+  /// `expectedType` getters), or you can use [isText], [isImage], [isAudio] and
   /// [isEmbeddedResource] to determine the type and then do the cast.
   String get type => _value['type'] as String;
 }
 
-/// Text provided to an LLM.
+/// Text provided to or from an LLM.
 extension type TextContent.fromMap(Map<String, Object?> _value)
     implements Content, Annotated {
   static const expectedType = 'text';
@@ -241,7 +269,7 @@ extension type TextContent.fromMap(Map<String, Object?> _value)
   String get text => _value['text'] as String;
 }
 
-/// An image provided to an LLM.
+/// An image provided to or from an LLM.
 extension type ImageContent.fromMap(Map<String, Object?> _value)
     implements Content, Annotated {
   static const expectedType = 'image';
@@ -263,11 +291,43 @@ extension type ImageContent.fromMap(Map<String, Object?> _value)
     return type;
   }
 
-  /// If the [type] is `image`, this is the base64 encoded image data.
+  /// The base64 encoded image data.
   String get data => _value['data'] as String;
 
-  /// If the [type] is `image`, the MIME type of the image. Different providers
-  /// may support different image types.
+  /// The MIME type of the image. Different providers may support different
+  /// image types.
+  String get mimeType => _value['mimeType'] as String;
+}
+
+/// Audio provided to or from an LLM.
+///
+/// Only supported since version `2025-03-26`.
+extension type AudioContent.fromMap(Map<String, Object?> _value)
+    implements Content, Annotated {
+  static const expectedType = 'audio';
+
+  factory AudioContent({
+    required String data,
+    required String mimeType,
+    Annotations? annotations,
+  }) => AudioContent.fromMap({
+    'data': data,
+    'mimeType': mimeType,
+    'type': expectedType,
+    if (annotations != null) 'annotations': annotations,
+  });
+
+  String get type {
+    final type = _value['type'] as String;
+    assert(type == expectedType);
+    return type;
+  }
+
+  /// The base64 encoded image data.
+  String get data => _value['data'] as String;
+
+  /// The MIME type of the audio. Different providers may support different
+  /// audio types.
   String get mimeType => _value['mimeType'] as String;
 }
 

--- a/pkgs/dart_mcp/lib/src/api/completions.dart
+++ b/pkgs/dart_mcp/lib/src/api/completions.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+/// Note that all features here are only supported since version `2025-03-26`.
 part of 'api.dart';
 
 /// A request from the client to the server, to ask for completion options.

--- a/pkgs/dart_mcp/lib/src/api/completions.dart
+++ b/pkgs/dart_mcp/lib/src/api/completions.dart
@@ -2,7 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// Note that all features here are only supported since version `2025-03-26`.
+/// Note that all features here are only supported since version
+/// [ProtocolVersion.v2025_03_26].
 part of 'api.dart';
 
 /// A request from the client to the server, to ask for completion options.

--- a/pkgs/dart_mcp/lib/src/api/initialization.dart
+++ b/pkgs/dart_mcp/lib/src/api/initialization.dart
@@ -62,6 +62,15 @@ extension type InitializeResult.fromMap(Map<String, Object?> _value)
   ProtocolVersion? get protocolVersion =>
       ProtocolVersion.tryParse(_value['protocolVersion'] as String);
 
+  /// Sets the protocol version, by default this is set for you, but you can
+  /// override it to a specific version if desired.
+  ///
+  /// While this API is typed as nullable, `null` is not an allowed value.
+  set protocolVersion(ProtocolVersion? value) {
+    assert(value != null);
+    _value['protocolVersion'] = value!.versionString;
+  }
+
   ServerCapabilities get capabilities =>
       _value['capabilities'] as ServerCapabilities;
 

--- a/pkgs/dart_mcp/lib/src/api/initialization.dart
+++ b/pkgs/dart_mcp/lib/src/api/initialization.dart
@@ -11,12 +11,12 @@ extension type InitializeRequest._fromMap(Map<String, Object?> _value)
   static const methodName = 'initialize';
 
   factory InitializeRequest({
-    required String protocolVersion,
+    required ProtocolVersion protocolVersion,
     required ClientCapabilities capabilities,
     required ClientImplementation clientInfo,
     MetaWithProgressToken? meta,
   }) => InitializeRequest._fromMap({
-    'protocolVersion': protocolVersion,
+    'protocolVersion': protocolVersion.versionString,
     'capabilities': capabilities,
     'clientInfo': clientInfo,
     if (meta != null) '_meta': meta,
@@ -25,9 +25,14 @@ extension type InitializeRequest._fromMap(Map<String, Object?> _value)
   /// The latest version of the Model Context Protocol that the client supports.
   ///
   /// The client MAY decide to support older versions as well.
-  String get protocolVersion => _value['protocolVersion'] as String;
+  ///
+  /// May be `null` if the version is not recognized.
+  ProtocolVersion? get protocolVersion =>
+      ProtocolVersion.tryParse(_value['protocolVersion'] as String);
+
   ClientCapabilities get capabilities =>
       _value['capabilities'] as ClientCapabilities;
+
   ClientImplementation get clientInfo =>
       _value['clientInfo'] as ClientImplementation;
 }
@@ -37,12 +42,12 @@ extension type InitializeRequest._fromMap(Map<String, Object?> _value)
 extension type InitializeResult.fromMap(Map<String, Object?> _value)
     implements Result {
   factory InitializeResult({
-    required String protocolVersion,
+    required ProtocolVersion protocolVersion,
     required ServerCapabilities serverCapabilities,
     required ServerImplementation serverInfo,
     required String instructions,
   }) => InitializeResult.fromMap({
-    'protocolVersion': protocolVersion,
+    'protocolVersion': protocolVersion.versionString,
     'capabilities': serverCapabilities,
     'serverInfo': serverInfo,
     'instructions': instructions,
@@ -52,7 +57,10 @@ extension type InitializeResult.fromMap(Map<String, Object?> _value)
   ///
   /// This may not match the version that the client requested. If the client
   /// cannot support this version, it MUST disconnect.
-  String get protocolVersion => _value['protocolVersion'] as String;
+  ///
+  /// May be `null` if the version is not recognized.
+  ProtocolVersion? get protocolVersion =>
+      ProtocolVersion.tryParse(_value['protocolVersion'] as String);
 
   ServerCapabilities get capabilities =>
       _value['capabilities'] as ServerCapabilities;

--- a/pkgs/dart_mcp/lib/src/api/prompts.dart
+++ b/pkgs/dart_mcp/lib/src/api/prompts.dart
@@ -22,11 +22,11 @@ extension type ListPromptsResult.fromMap(Map<String, Object?> _value)
     implements PaginatedResult {
   factory ListPromptsResult({
     required List<Prompt> prompts,
-    Cursor? cursor,
+    Cursor? nextCursor,
     Meta? meta,
   }) => ListPromptsResult.fromMap({
     'prompts': prompts,
-    if (cursor != null) 'cursor': cursor,
+    if (nextCursor != null) 'nextCursor': nextCursor,
     if (meta != null) '_meta': meta,
   });
 

--- a/pkgs/dart_mcp/lib/src/api/resources.dart
+++ b/pkgs/dart_mcp/lib/src/api/resources.dart
@@ -21,11 +21,11 @@ extension type ListResourcesResult.fromMap(Map<String, Object?> _value)
     implements PaginatedResult {
   factory ListResourcesResult({
     required List<Resource> resources,
-    Cursor? cursor,
+    Cursor? nextCursor,
     Meta? meta,
   }) => ListResourcesResult.fromMap({
     'resources': resources,
-    if (cursor != null) 'cursor': cursor,
+    if (nextCursor != null) 'nextCursor': nextCursor,
     if (meta != null) '_meta': meta,
   });
 
@@ -53,11 +53,11 @@ extension type ListResourceTemplatesResult.fromMap(Map<String, Object?> _value)
     implements PaginatedResult {
   factory ListResourceTemplatesResult({
     required List<ResourceTemplate> resourceTemplates,
-    Cursor? cursor,
+    Cursor? nextCursor,
     Meta? meta,
   }) => ListResourceTemplatesResult.fromMap({
     'resourceTemplates': resourceTemplates,
-    if (cursor != null) 'cursor': cursor,
+    if (nextCursor != null) 'nextCursor': nextCursor,
     if (meta != null) '_meta': meta,
   });
 

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -106,8 +106,7 @@ extension type Tool.fromMap(Map<String, Object?> _value) {
     required String name,
     String? description,
     required ObjectSchema inputSchema,
-
-    /// Only supported since version [ProtocolVersion.v2025_03_26].
+    // Only supported since version `ProtocolVersion.v2025_03_26`.
     ToolAnnotations? annotations,
   }) => Tool.fromMap({
     'name': name,

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -21,11 +21,11 @@ extension type ListToolsResult.fromMap(Map<String, Object?> _value)
     implements PaginatedResult {
   factory ListToolsResult({
     required List<Tool> tools,
-    Cursor? cursor,
+    Cursor? nextCursor,
     Meta? meta,
   }) => ListToolsResult.fromMap({
     'tools': tools,
-    if (cursor != null) 'cursor': cursor,
+    if (nextCursor != null) 'nextCursor': nextCursor,
     if (meta != null) '_meta': meta,
   });
 

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -106,11 +106,22 @@ extension type Tool.fromMap(Map<String, Object?> _value) {
     required String name,
     String? description,
     required ObjectSchema inputSchema,
+
+    /// Only supported since version `2025-03-26`.
+    ToolAnnotations? annotations,
   }) => Tool.fromMap({
     'name': name,
     if (description != null) 'description': description,
     'inputSchema': inputSchema,
+    if (annotations != null) 'annotations': annotations,
   });
+
+  /// Optional additional tool information.
+  ///
+  /// Only supported since version `2025-03-26`.
+  ToolAnnotations? get toolAnnotations =>
+      (_value['annotations'] as Map?)?.cast<String, Object?>()
+          as ToolAnnotations?;
 
   /// The name of the tool.
   String get name => _value['name'] as String;
@@ -121,6 +132,55 @@ extension type Tool.fromMap(Map<String, Object?> _value) {
   /// A JSON [ObjectSchema] object defining the expected parameters for the
   /// tool.
   ObjectSchema get inputSchema => _value['inputSchema'] as ObjectSchema;
+}
+
+/// Additional properties describing a Tool to clients.
+///
+/// NOTE: all properties in ToolAnnotations are **hints**. They are not
+/// guaranteed to provide a faithful description of tool behavior (including
+/// descriptive properties like `title`).
+///
+/// Clients should never make tool use decisions based on ToolAnnotations
+/// received from untrusted servers.
+extension type ToolAnnotations.fromMap(Map<String, Object?> _value) {
+  factory ToolAnnotations({
+    bool? destructiveHint,
+    bool? idempotentHint,
+    bool? openWorldHint,
+    bool? readOnlyHint,
+    String? title,
+  }) => ToolAnnotations.fromMap({
+    if (destructiveHint != null) 'destructiveHint': destructiveHint,
+    if (idempotentHint != null) 'idempotentHint': idempotentHint,
+    if (openWorldHint != null) 'openWorldHint': openWorldHint,
+    if (readOnlyHint != null) 'readOnlyHint': readOnlyHint,
+    if (title != null) 'title': title,
+  });
+
+  /// If true, the tool may perform destructive updates to its environment.
+  ///
+  /// If false, the tool performs only additive updates.
+  ///
+  /// (This property is meaningful only when `readOnlyHint == false`)
+  bool? get destructiveHint => _value['destructiveHint'] as bool?;
+
+  /// If true, calling the tool repeatedly with the same arguments will have no
+  /// additional effect on the its environment.
+  ///
+  /// (This property is meaningful only when `readOnlyHint == false`)
+  bool? get idempotentHint => _value['idempotentHint'] as bool?;
+
+  /// If true, this tool may interact with an "open world" of external entities.
+  ///
+  /// If false, the tool's domain of interaction is closed. For example, the
+  /// world of a web search tool is open, whereas that of a memory tool is not.
+  bool? get openWorldHint => _value['openWorldHint'] as bool?;
+
+  /// If true, the tool does not modify its environment.
+  bool? get readOnlyHint => _value['readOnlyHint'] as bool?;
+
+  /// A human-readable title for the tool.
+  String? get title => _value['title'] as String?;
 }
 
 /// The valid types for properties in a JSON-RCP2 schema.

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -107,7 +107,7 @@ extension type Tool.fromMap(Map<String, Object?> _value) {
     String? description,
     required ObjectSchema inputSchema,
 
-    /// Only supported since version `2025-03-26`.
+    /// Only supported since version [ProtocolVersion.v2025_03_26].
     ToolAnnotations? annotations,
   }) => Tool.fromMap({
     'name': name,
@@ -118,7 +118,7 @@ extension type Tool.fromMap(Map<String, Object?> _value) {
 
   /// Optional additional tool information.
   ///
-  /// Only supported since version `2025-03-26`.
+  /// Only supported since version [ProtocolVersion.v2025_03_26].
   ToolAnnotations? get toolAnnotations =>
       (_value['annotations'] as Map?)?.cast<String, Object?>()
           as ToolAnnotations?;

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -76,7 +76,9 @@ base class MCPClient {
             },
           ),
         );
-    return connectServer(channel);
+    final connection = connectServer(channel);
+    unawaited(connection.done.then((_) => process.kill()));
+    return connection;
   }
 
   /// Returns a connection for an MCP server using a [channel], which is already
@@ -171,6 +173,10 @@ base class ServerConnection extends MCPBase {
   final _logController =
       StreamController<LoggingMessageNotification>.broadcast();
 
+  /// Completes when [shutdown] is called.
+  Future<void> get done => _done.future;
+  final Completer<void> _done = Completer<void>();
+
   /// A 1:1 connection from a client to a server using [channel].
   ///
   /// If the client supports "roots", then it should provide an implementation
@@ -235,6 +241,7 @@ base class ServerConnection extends MCPBase {
       _resourceUpdatedController.close(),
       _logController.close(),
     ]);
+    _done.complete();
   }
 
   /// Called after a successful call to [initialize].

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -107,6 +107,12 @@ base class MCPClient {
 
 /// An active server connection.
 base class ServerConnection extends MCPBase {
+  /// The version of the protocol that was negotiated during intialization.
+  ///
+  /// Some APIs may error if you attempt to use them without first checking the
+  /// protocol version.
+  late ProtocolVersion protocolVersion;
+
   /// The [ServerImplementation] returned from the [initialize] request.
   ///
   /// Only assigned after [initialize] has successfully completed.
@@ -246,6 +252,10 @@ base class ServerConnection extends MCPBase {
     );
     serverInfo = response.serverInfo;
     serverCapabilities = response.capabilities;
+    final serverVersion = response.protocolVersion;
+    if (serverVersion?.isSupported != true) {
+      await shutdown();
+    }
     return response;
   }
 
@@ -296,6 +306,8 @@ base class ServerConnection extends MCPBase {
   /// Clients should debounce their calls to this API to avoid overloading the
   /// server.
   ///
+  /// You should check the [protocolVersion] before using this API, it must be
+  /// >= [ProtocolVersion.v2025_03_26].
   // TODO: Implement automatic debouncing.
   Future<CompleteResult> requestCompletions(CompleteRequest request) =>
       sendRequest(CompleteRequest.methodName, request);

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -87,7 +87,7 @@ abstract base class MCPServer extends MCPBase {
     // terminate the connection.
     final clientProtocolVersion = request.protocolVersion;
     if (clientProtocolVersion == null || !clientProtocolVersion.isSupported) {
-      protocolVersion = ProtocolVersion.latest;
+      protocolVersion = ProtocolVersion.latestSupported;
     } else {
       protocolVersion = clientProtocolVersion;
     }

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -38,6 +38,11 @@ abstract base class MCPServer extends MCPBase {
   /// These may be used in system prompts.
   final String instructions;
 
+  /// The negotiated protocol version.
+  ///
+  /// Only assigned after `initialize` has been called.
+  late ProtocolVersion protocolVersion;
+
   /// The capabilities of the client.
   ///
   /// Only assigned after `initialize` has been called.
@@ -77,6 +82,16 @@ abstract base class MCPServer extends MCPBase {
   /// Mixins should register their methods in this method, as well as editing
   /// the [InitializeResult.capabilities] as needed.
   FutureOr<InitializeResult> initialize(InitializeRequest request) {
+    // If we don't support or understand the version, set it to the latest one
+    // that we do support. If the client doesn't support that version they will
+    // terminate the connection.
+    final clientProtocolVersion = request.protocolVersion;
+    if (clientProtocolVersion == null || !clientProtocolVersion.isSupported) {
+      protocolVersion = ProtocolVersion.latest;
+    } else {
+      protocolVersion = clientProtocolVersion;
+    }
+
     clientCapabilities = request.capabilities;
     if (clientCapabilities.roots?.listChanged == true) {
       _rootsListChangedController =

--- a/pkgs/dart_mcp/pubspec.yaml
+++ b/pkgs/dart_mcp/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dart_mcp
 description: A package for making MCP servers and clients.
 repository: https://github.com/dart-lang/ai/tree/main/pkgs/dart_mcp
-version: 0.1.1-wip
+version: 0.2.0-wip
 environment:
   sdk: ^3.7.0
 dependencies:

--- a/pkgs/dart_mcp/test/api_test.dart
+++ b/pkgs/dart_mcp/test/api_test.dart
@@ -8,42 +8,54 @@ import 'package:test/test.dart';
 void main() {
   test('protocol versions can be compared', () {
     expect(
-      ProtocolVersion.latest > ProtocolVersion.oldestSupportedVersion,
+      ProtocolVersion.latestSupported > ProtocolVersion.oldestSupported,
       true,
     );
     expect(
-      ProtocolVersion.latest >= ProtocolVersion.oldestSupportedVersion,
+      ProtocolVersion.latestSupported >= ProtocolVersion.oldestSupported,
       true,
     );
     expect(
-      ProtocolVersion.latest < ProtocolVersion.oldestSupportedVersion,
+      ProtocolVersion.latestSupported < ProtocolVersion.oldestSupported,
       false,
     );
     expect(
-      ProtocolVersion.latest <= ProtocolVersion.oldestSupportedVersion,
+      ProtocolVersion.latestSupported <= ProtocolVersion.oldestSupported,
       false,
     );
 
     expect(
-      ProtocolVersion.oldestSupportedVersion > ProtocolVersion.latest,
+      ProtocolVersion.oldestSupported > ProtocolVersion.latestSupported,
       false,
     );
     expect(
-      ProtocolVersion.oldestSupportedVersion >= ProtocolVersion.latest,
+      ProtocolVersion.oldestSupported >= ProtocolVersion.latestSupported,
       false,
     );
     expect(
-      ProtocolVersion.oldestSupportedVersion < ProtocolVersion.latest,
+      ProtocolVersion.oldestSupported < ProtocolVersion.latestSupported,
       true,
     );
     expect(
-      ProtocolVersion.oldestSupportedVersion <= ProtocolVersion.latest,
+      ProtocolVersion.oldestSupported <= ProtocolVersion.latestSupported,
       true,
     );
 
-    expect(ProtocolVersion.latest <= ProtocolVersion.latest, true);
-    expect(ProtocolVersion.latest >= ProtocolVersion.latest, true);
-    expect(ProtocolVersion.latest < ProtocolVersion.latest, false);
-    expect(ProtocolVersion.latest > ProtocolVersion.latest, false);
+    expect(
+      ProtocolVersion.latestSupported <= ProtocolVersion.latestSupported,
+      true,
+    );
+    expect(
+      ProtocolVersion.latestSupported >= ProtocolVersion.latestSupported,
+      true,
+    );
+    expect(
+      ProtocolVersion.latestSupported < ProtocolVersion.latestSupported,
+      false,
+    );
+    expect(
+      ProtocolVersion.latestSupported > ProtocolVersion.latestSupported,
+      false,
+    );
   });
 }

--- a/pkgs/dart_mcp/test/api_test.dart
+++ b/pkgs/dart_mcp/test/api_test.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dart_mcp/client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('protocol versions can be compared', () {
+    expect(
+      ProtocolVersion.latest > ProtocolVersion.oldestSupportedVersion,
+      true,
+    );
+    expect(
+      ProtocolVersion.latest >= ProtocolVersion.oldestSupportedVersion,
+      true,
+    );
+    expect(
+      ProtocolVersion.latest < ProtocolVersion.oldestSupportedVersion,
+      false,
+    );
+    expect(
+      ProtocolVersion.latest <= ProtocolVersion.oldestSupportedVersion,
+      false,
+    );
+
+    expect(
+      ProtocolVersion.oldestSupportedVersion > ProtocolVersion.latest,
+      false,
+    );
+    expect(
+      ProtocolVersion.oldestSupportedVersion >= ProtocolVersion.latest,
+      false,
+    );
+    expect(
+      ProtocolVersion.oldestSupportedVersion < ProtocolVersion.latest,
+      true,
+    );
+    expect(
+      ProtocolVersion.oldestSupportedVersion <= ProtocolVersion.latest,
+      true,
+    );
+
+    expect(ProtocolVersion.latest <= ProtocolVersion.latest, true);
+    expect(ProtocolVersion.latest >= ProtocolVersion.latest, true);
+    expect(ProtocolVersion.latest < ProtocolVersion.latest, false);
+    expect(ProtocolVersion.latest > ProtocolVersion.latest, false);
+  });
+}

--- a/pkgs/dart_mcp/test/client_and_server_test.dart
+++ b/pkgs/dart_mcp/test/client_and_server_test.dart
@@ -246,6 +246,47 @@ void main() {
         expect(environment.serverConnection.isActive, false);
       },
     );
+
+    test('protocol versions can be compared', () {
+      expect(
+        ProtocolVersion.latest > ProtocolVersion.oldestSupportedVersion,
+        true,
+      );
+      expect(
+        ProtocolVersion.latest >= ProtocolVersion.oldestSupportedVersion,
+        true,
+      );
+      expect(
+        ProtocolVersion.latest < ProtocolVersion.oldestSupportedVersion,
+        false,
+      );
+      expect(
+        ProtocolVersion.latest <= ProtocolVersion.oldestSupportedVersion,
+        false,
+      );
+
+      expect(
+        ProtocolVersion.oldestSupportedVersion > ProtocolVersion.latest,
+        false,
+      );
+      expect(
+        ProtocolVersion.oldestSupportedVersion >= ProtocolVersion.latest,
+        false,
+      );
+      expect(
+        ProtocolVersion.oldestSupportedVersion < ProtocolVersion.latest,
+        true,
+      );
+      expect(
+        ProtocolVersion.oldestSupportedVersion <= ProtocolVersion.latest,
+        true,
+      );
+
+      expect(ProtocolVersion.latest <= ProtocolVersion.latest, true);
+      expect(ProtocolVersion.latest >= ProtocolVersion.latest, true);
+      expect(ProtocolVersion.latest < ProtocolVersion.latest, false);
+      expect(ProtocolVersion.latest > ProtocolVersion.latest, false);
+    });
   });
 }
 

--- a/pkgs/dart_mcp/test/client_and_server_test.dart
+++ b/pkgs/dart_mcp/test/client_and_server_test.dart
@@ -246,47 +246,6 @@ void main() {
         expect(environment.serverConnection.isActive, false);
       },
     );
-
-    test('protocol versions can be compared', () {
-      expect(
-        ProtocolVersion.latest > ProtocolVersion.oldestSupportedVersion,
-        true,
-      );
-      expect(
-        ProtocolVersion.latest >= ProtocolVersion.oldestSupportedVersion,
-        true,
-      );
-      expect(
-        ProtocolVersion.latest < ProtocolVersion.oldestSupportedVersion,
-        false,
-      );
-      expect(
-        ProtocolVersion.latest <= ProtocolVersion.oldestSupportedVersion,
-        false,
-      );
-
-      expect(
-        ProtocolVersion.oldestSupportedVersion > ProtocolVersion.latest,
-        false,
-      );
-      expect(
-        ProtocolVersion.oldestSupportedVersion >= ProtocolVersion.latest,
-        false,
-      );
-      expect(
-        ProtocolVersion.oldestSupportedVersion < ProtocolVersion.latest,
-        true,
-      );
-      expect(
-        ProtocolVersion.oldestSupportedVersion <= ProtocolVersion.latest,
-        true,
-      );
-
-      expect(ProtocolVersion.latest <= ProtocolVersion.latest, true);
-      expect(ProtocolVersion.latest >= ProtocolVersion.latest, true);
-      expect(ProtocolVersion.latest < ProtocolVersion.latest, false);
-      expect(ProtocolVersion.latest > ProtocolVersion.latest, false);
-    });
   });
 }
 

--- a/pkgs/dart_mcp/test/client_and_server_test.dart
+++ b/pkgs/dart_mcp/test/client_and_server_test.dart
@@ -23,7 +23,7 @@ void main() {
 
     expect(initializeResult.capabilities, isEmpty);
     expect(initializeResult.instructions, environment.server.instructions);
-    expect(initializeResult.protocolVersion, protocolVersion);
+    expect(initializeResult.protocolVersion, ProtocolVersion.latest);
 
     expect(
       environment.serverConnection.listTools(ListToolsRequest()),

--- a/pkgs/dart_mcp/test/client_and_server_test.dart
+++ b/pkgs/dart_mcp/test/client_and_server_test.dart
@@ -23,7 +23,7 @@ void main() {
 
     expect(initializeResult.capabilities, isEmpty);
     expect(initializeResult.instructions, environment.server.instructions);
-    expect(initializeResult.protocolVersion, ProtocolVersion.latest);
+    expect(initializeResult.protocolVersion, ProtocolVersion.latestSupported);
 
     expect(
       environment.serverConnection.listTools(ListToolsRequest()),
@@ -214,10 +214,7 @@ void main() {
       );
 
       final initializeResult = await environment.initializeServer();
-      expect(
-        initializeResult.protocolVersion,
-        ProtocolVersion.oldestSupportedVersion,
-      );
+      expect(initializeResult.protocolVersion, ProtocolVersion.oldestSupported);
     });
 
     test('server can accept a lower version', () async {
@@ -226,12 +223,9 @@ void main() {
         (c) => TestMCPServer(channel: c),
       );
       final initializeResult = await environment.initializeServer(
-        protocolVersion: ProtocolVersion.oldestSupportedVersion,
+        protocolVersion: ProtocolVersion.oldestSupported,
       );
-      expect(
-        initializeResult.protocolVersion,
-        ProtocolVersion.oldestSupportedVersion,
-      );
+      expect(initializeResult.protocolVersion, ProtocolVersion.oldestSupported);
     });
 
     test(
@@ -292,7 +286,7 @@ final class TestOldMcpServer extends TestMCPServer {
   @override
   Future<InitializeResult> initialize(InitializeRequest request) async {
     return (await super.initialize(request))
-      ..protocolVersion = ProtocolVersion.oldestSupportedVersion;
+      ..protocolVersion = ProtocolVersion.oldestSupported;
   }
 }
 

--- a/pkgs/dart_mcp/test/test_utils.dart
+++ b/pkgs/dart_mcp/test/test_utils.dart
@@ -50,7 +50,7 @@ class TestEnvironment<Client extends MCPClient, Server extends MCPServer> {
   Future<InitializeResult> initializeServer() async {
     final initializeResult = await serverConnection.initialize(
       InitializeRequest(
-        protocolVersion: protocolVersion,
+        protocolVersion: ProtocolVersion.latest,
         capabilities: client.capabilities,
         clientInfo: client.implementation,
       ),

--- a/pkgs/dart_mcp/test/test_utils.dart
+++ b/pkgs/dart_mcp/test/test_utils.dart
@@ -48,7 +48,7 @@ class TestEnvironment<Client extends MCPClient, Server extends MCPServer> {
   /// notification, then returns the original [InitializeResult] for tests
   /// to inspect if desired.
   Future<InitializeResult> initializeServer({
-    ProtocolVersion protocolVersion = ProtocolVersion.latest,
+    ProtocolVersion protocolVersion = ProtocolVersion.latestSupported,
   }) async {
     final initializeResult = await serverConnection.initialize(
       InitializeRequest(

--- a/pkgs/dart_mcp/test/test_utils.dart
+++ b/pkgs/dart_mcp/test/test_utils.dart
@@ -47,16 +47,22 @@ class TestEnvironment<Client extends MCPClient, Server extends MCPServer> {
   /// Initializes the server and waits for it to receive the initialization
   /// notification, then returns the original [InitializeResult] for tests
   /// to inspect if desired.
-  Future<InitializeResult> initializeServer() async {
+  Future<InitializeResult> initializeServer({
+    ProtocolVersion protocolVersion = ProtocolVersion.latest,
+  }) async {
     final initializeResult = await serverConnection.initialize(
       InitializeRequest(
-        protocolVersion: ProtocolVersion.latest,
+        protocolVersion: protocolVersion,
         capabilities: client.capabilities,
         clientInfo: client.implementation,
       ),
     );
-    serverConnection.notifyInitialized(InitializedNotification());
-    await server.initialized;
+
+    /// Only notify initialized if we got a supported protocol version
+    if (initializeResult.protocolVersion?.isSupported == true) {
+      serverConnection.notifyInitialized(InitializedNotification());
+      await server.initialized;
+    }
     return initializeResult;
   }
 

--- a/pkgs/dart_mcp/test/tools_support_test.dart
+++ b/pkgs/dart_mcp/test/tools_support_test.dart
@@ -253,8 +253,16 @@ final class TestMCPServerWithTools extends TestMCPServer with ToolsSupport {
   }
 
   static final helloWorld = Tool(
-    name: 'hello world',
+    name: 'hello_world',
+    description: 'Says hello world!',
     inputSchema: ObjectSchema(),
+    annotations: ToolAnnotations(
+      destructiveHint: false,
+      idempotentHint: false,
+      readOnlyHint: true,
+      openWorldHint: false,
+      title: 'Hello World',
+    ),
   );
 
   static final helloWorldContent = TextContent(

--- a/pkgs/dart_tooling_mcp_server/pubspec.yaml
+++ b/pkgs/dart_tooling_mcp_server/pubspec.yaml
@@ -7,8 +7,7 @@ environment:
 dependencies:
   analyzer: ^7.3.0
   async: ^2.13.0
-  dart_mcp:
-    path: ../dart_mcp
+  dart_mcp: ^2.0.0
   dds_service_extensions: ^2.0.1
   devtools_shared: ^11.2.0
   dtd: ^2.4.0
@@ -25,3 +24,7 @@ executables:
 dev_dependencies:
   dart_flutter_team_lints: ^3.2.1
   test: ^1.25.15
+
+dependency_overrides:
+  dart_mcp:
+    path: ../dart_mcp

--- a/pkgs/dart_tooling_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_tooling_mcp_server/test/test_harness.dart
@@ -361,12 +361,12 @@ Future<ServerConnectionPair> _initializeMCPServer(
 
   final initializeResult = await connection.initialize(
     InitializeRequest(
-      protocolVersion: ProtocolVersion.latest,
+      protocolVersion: ProtocolVersion.latestSupported,
       capabilities: client.capabilities,
       clientInfo: client.implementation,
     ),
   );
-  expect(initializeResult.protocolVersion, ProtocolVersion.latest);
+  expect(initializeResult.protocolVersion, ProtocolVersion.latestSupported);
   connection.notifyInitialized(InitializedNotification());
   return (serverConnection: connection, server: server);
 }

--- a/pkgs/dart_tooling_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_tooling_mcp_server/test/test_harness.dart
@@ -337,12 +337,12 @@ Future<ServerConnection> _initializeMCPServer(
 
   final initializeResult = await connection.initialize(
     InitializeRequest(
-      protocolVersion: protocolVersion,
+      protocolVersion: ProtocolVersion.latest,
       capabilities: client.capabilities,
       clientInfo: client.implementation,
     ),
   );
-  expect(initializeResult.protocolVersion, protocolVersion);
+  expect(initializeResult.protocolVersion, ProtocolVersion.latest);
   connection.notifyInitialized(InitializedNotification());
   return connection;
 }


### PR DESCRIPTION
I had already implemented one portion of this by accident apparently (completions support).

Adds version negotiation and a few other small breaking changes since I wanted to make a breaking change anyways to convert the protocol version to an enum.