### PR TITLE
[dart_tooling_mcp_server] add tool for getting the selected widget

### DIFF
--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
@@ -433,9 +433,7 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
           final widget = result.json?['result'];
           if (widget == null) {
             return CallToolResult(
-              content: [
-                TextContent(text: 'No Widget selected.'),
-              ],
+              content: [TextContent(text: 'No Widget selected.')],
             );
           }
           return CallToolResult(

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
@@ -439,7 +439,7 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
             );
           }
           return CallToolResult(
-            content: [TextContent(text: widget.toString())],
+            content: [TextContent(text: jsonEncode(widget))],
           );
         } catch (e) {
           return CallToolResult(

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
@@ -434,7 +434,7 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
           if (widget == null) {
             return CallToolResult(
               content: [
-                TextContent(text: 'No Widget selected: ${result.json}'),
+                TextContent(text: 'No Widget selected.'),
               ],
             );
           }

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:dart_mcp/server.dart';
 import 'package:dds_service_extensions/dds_service_extensions.dart';
@@ -39,10 +40,24 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
   @visibleForTesting
   static bool debugAwaitVmServiceDisposal = false;
 
+  /// The id for the object group used when calling Flutter Widget
+  /// Inspector service extensions from DTD tools.
+  @visibleForTesting
+  static const inspectorObjectGroup = 'dart-tooling-mcp-server';
+
+  /// The prefix for Flutter Widget Inspector service extensions.
+  ///
+  /// See https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/widgets/service_extensions.dart#L126
+  /// for full list of available Flutter Widget Inspector service extensions.
+  static const _inspectorServiceExtensionPrefix = 'ext.flutter.inspector';
+
   /// Called when the DTD connection is lost, resets all associated state.
   Future<void> _resetDtd() async {
     _dtd = null;
     _getDebugSessionsReady = false;
+
+    // TODO: determine whether we need to dispose the [inspectorObjectGroup] on
+    // the Flutter Widget Inspector for each VM service instance.
 
     final future = Future.wait(
       activeVmServices.values.map((vmService) => vmService.dispose()),
@@ -94,6 +109,7 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
     registerTool(screenshotTool, takeScreenshot);
     registerTool(hotReloadTool, hotReload);
     registerTool(getWidgetTreeTool, widgetTree);
+    registerTool(getSelectedWidgetTool, selectedWidget);
 
     return super.initialize(request);
   }
@@ -357,14 +373,12 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
       callback: (vmService) async {
         final vm = await vmService.getVM();
         final isolateId = vm.isolates!.first.id;
-        final groupId = 'dart-tooling-mcp-server';
-        const inspectorExtensionPrefix = 'ext.flutter.inspector';
         try {
           final result = await vmService.callServiceExtension(
-            '$inspectorExtensionPrefix.getRootWidgetTree',
+            '$_inspectorServiceExtensionPrefix.getRootWidgetTree',
             isolateId: isolateId,
             args: {
-              'groupName': groupId,
+              'groupName': inspectorObjectGroup,
               // TODO: consider making these configurable or using defaults that
               // are better for the LLM.
               'isSummaryTree': 'true',
@@ -384,7 +398,7 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
               ],
             );
           }
-          return CallToolResult(content: [TextContent(text: tree.toString())]);
+          return CallToolResult(content: [TextContent(text: jsonEncode(tree))]);
         } catch (e) {
           return CallToolResult(
             isError: true,
@@ -394,11 +408,43 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
               ),
             ],
           );
-        } finally {
-          await vmService.callServiceExtension(
-            '$inspectorExtensionPrefix.disposeGroup',
+        }
+      },
+    );
+  }
+
+  /// Retrieves the selected widget from the currently running app.
+  ///
+  /// If more than one debug session is active, then it just uses the first one.
+  // TODO: support passing a debug session id when there is more than one debug
+  // session.
+  Future<CallToolResult> selectedWidget(CallToolRequest request) async {
+    return _callOnVmService(
+      callback: (vmService) async {
+        final vm = await vmService.getVM();
+        final isolateId = vm.isolates!.first.id;
+        try {
+          final result = await vmService.callServiceExtension(
+            '$_inspectorServiceExtensionPrefix.getSelectedSummaryWidget',
             isolateId: isolateId,
-            args: {'objectGroup': groupId},
+            args: {'objectGroup': inspectorObjectGroup},
+          );
+
+          final widget = result.json?['result'];
+          if (widget == null) {
+            return CallToolResult(
+              content: [
+                TextContent(text: 'No Widget selected: ${result.json}'),
+              ],
+            );
+          }
+          return CallToolResult(
+            content: [TextContent(text: widget.toString())],
+          );
+        } catch (e) {
+          return CallToolResult(
+            isError: true,
+            content: [TextContent(text: 'Failed to get selected widget: $e')],
           );
         }
       },
@@ -473,6 +519,15 @@ base mixin DartToolingDaemonSupport on ToolsSupport {
     name: 'get_widget_tree',
     description:
         'Retrieves the widget tree from the active Flutter application. '
+        'Requires "${connectTool.name}" to be successfully called first.',
+    inputSchema: ObjectSchema(),
+  );
+
+  @visibleForTesting
+  static final getSelectedWidgetTool = Tool(
+    name: 'get_selected_widget',
+    description:
+        'Retrieves the selected widget from the active Flutter application. '
         'Requires "${connectTool.name}" to be successfully called first.',
     inputSchema: ObjectSchema(),
   );

--- a/pkgs/dart_tooling_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/dtd_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:dart_mcp/server.dart';
 import 'package:dart_tooling_mcp_server/src/mixins/dtd.dart';
 import 'package:test/test.dart';
@@ -13,155 +15,238 @@ void main() {
   late TestHarness testHarness;
 
   group('dart tooling daemon tools', () {
-    // TODO: Use setUpAll, currently this fails due to an apparent TestProcess
-    // issue.
-    setUp(() async {
-      testHarness = await TestHarness.start();
-      await testHarness.connectToDtd();
-    });
+    group('[compiled server]', () {
+      // TODO: Use setUpAll, currently this fails due to an apparent TestProcess
+      // issue.
+      setUp(() async {
+        testHarness = await TestHarness.start();
+        await testHarness.connectToDtd();
+      });
 
-    test('can take a screenshot', () async {
-      await testHarness.startDebugSession(
-        counterAppPath,
-        'lib/main.dart',
-        isFlutter: true,
-      );
-      final tools = (await testHarness.mcpServerConnection.listTools()).tools;
-      final screenshotTool = tools.singleWhere(
-        (t) => t.name == DartToolingDaemonSupport.screenshotTool.name,
-      );
-      final screenshotResult = await testHarness.callToolWithRetry(
-        CallToolRequest(name: screenshotTool.name),
-      );
-      expect(screenshotResult.content.single, {
-        'data': anything,
-        'mimeType': 'image/png',
-        'type': ImageContent.expectedType,
+      test('can take a screenshot', () async {
+        await testHarness.startDebugSession(
+          counterAppPath,
+          'lib/main.dart',
+          isFlutter: true,
+        );
+        final tools = (await testHarness.mcpServerConnection.listTools()).tools;
+        final screenshotTool = tools.singleWhere(
+          (t) => t.name == DartToolingDaemonSupport.screenshotTool.name,
+        );
+        final screenshotResult = await testHarness.callToolWithRetry(
+          CallToolRequest(name: screenshotTool.name),
+        );
+        expect(screenshotResult.content.single, {
+          'data': anything,
+          'mimeType': 'image/png',
+          'type': ImageContent.expectedType,
+        });
+      });
+
+      test('can perform a hot reload', () async {
+        await testHarness.startDebugSession(
+          counterAppPath,
+          'lib/main.dart',
+          isFlutter: true,
+        );
+        final tools = (await testHarness.mcpServerConnection.listTools()).tools;
+        final hotReloadTool = tools.singleWhere(
+          (t) => t.name == DartToolingDaemonSupport.hotReloadTool.name,
+        );
+        final hotReloadResult = await testHarness.callToolWithRetry(
+          CallToolRequest(name: hotReloadTool.name),
+        );
+
+        expect(hotReloadResult.isError, isNot(true));
+        expect(hotReloadResult.content, [
+          TextContent(text: 'Hot reload succeeded.'),
+        ]);
+      });
+
+      test('can get runtime errors', () async {
+        await testHarness.startDebugSession(
+          counterAppPath,
+          'lib/main.dart',
+          isFlutter: true,
+          args: ['--dart-define=include_layout_error=true'],
+        );
+        final tools = (await testHarness.mcpServerConnection.listTools()).tools;
+        final runtimeErrorsTool = tools.singleWhere(
+          (t) => t.name == DartToolingDaemonSupport.getRuntimeErrorsTool.name,
+        );
+        final runtimeErrorsResult = await testHarness.callToolWithRetry(
+          CallToolRequest(name: runtimeErrorsTool.name),
+        );
+
+        expect(runtimeErrorsResult.isError, isNot(true));
+        final errorCountRegex = RegExp(r'Found \d+ errors?:');
+        expect(
+          (runtimeErrorsResult.content.first as TextContent).text,
+          contains(errorCountRegex),
+        );
+        expect(
+          (runtimeErrorsResult.content[1] as TextContent).text,
+          contains('A RenderFlex overflowed by'),
+        );
+      });
+
+      test('can get the widget tree', () async {
+        await testHarness.startDebugSession(
+          counterAppPath,
+          'lib/main.dart',
+          isFlutter: true,
+        );
+        final tools = (await testHarness.mcpServerConnection.listTools()).tools;
+        final getWidgetTreeTool = tools.singleWhere(
+          (t) => t.name == DartToolingDaemonSupport.getWidgetTreeTool.name,
+        );
+        final getWidgetTreeResult = await testHarness.callToolWithRetry(
+          CallToolRequest(name: getWidgetTreeTool.name),
+        );
+
+        expect(getWidgetTreeResult.isError, isNot(true));
+        expect(
+          (getWidgetTreeResult.content.first as TextContent).text,
+          contains('MyHomePage'),
+        );
       });
     });
 
-    test('can perform a hot reload', () async {
-      await testHarness.startDebugSession(
-        counterAppPath,
-        'lib/main.dart',
-        isFlutter: true,
-      );
-      final tools = (await testHarness.mcpServerConnection.listTools()).tools;
-      final hotReloadTool = tools.singleWhere(
-        (t) => t.name == DartToolingDaemonSupport.hotReloadTool.name,
-      );
-      final hotReloadResult = await testHarness.callToolWithRetry(
-        CallToolRequest(name: hotReloadTool.name),
-      );
+    group('[in process]', () {
+      setUp(() async {
+        DartToolingDaemonSupport.debugAwaitVmServiceDisposal = true;
+        addTearDown(
+          () => DartToolingDaemonSupport.debugAwaitVmServiceDisposal = false,
+        );
 
-      expect(hotReloadResult.isError, isNot(true));
-      expect(hotReloadResult.content, [
-        TextContent(text: 'Hot reload succeeded.'),
-      ]);
-    });
+        testHarness = await TestHarness.start(inProcess: true);
+        await testHarness.connectToDtd();
+      });
 
-    test('can get runtime errors', () async {
-      await testHarness.startDebugSession(
-        counterAppPath,
-        'lib/main.dart',
-        isFlutter: true,
-        args: ['--dart-define=include_layout_error=true'],
-      );
-      final tools = (await testHarness.mcpServerConnection.listTools()).tools;
-      final runtimeErrorsTool = tools.singleWhere(
-        (t) => t.name == DartToolingDaemonSupport.getRuntimeErrorsTool.name,
-      );
-      final runtimeErrorsResult = await testHarness.callToolWithRetry(
-        CallToolRequest(name: runtimeErrorsTool.name),
-      );
+      group('$VmService management', () {
+        test('persists vm services', () async {
+          final server = testHarness.serverConnectionPair.server!;
+          expect(server.activeVmServices, isEmpty);
 
-      expect(runtimeErrorsResult.isError, isNot(true));
-      final errorCountRegex = RegExp(r'Found \d+ errors?:');
-      expect(
-        (runtimeErrorsResult.content.first as TextContent).text,
-        contains(errorCountRegex),
-      );
-      expect(
-        (runtimeErrorsResult.content[1] as TextContent).text,
-        contains('A RenderFlex overflowed by'),
-      );
-    });
+          await testHarness.startDebugSession(
+            counterAppPath,
+            'lib/main.dart',
+            isFlutter: true,
+          );
+          await server.updateActiveVmServices();
+          expect(server.activeVmServices.length, 1);
 
-    test('can get the widget tree', () async {
-      await testHarness.startDebugSession(
-        counterAppPath,
-        'lib/main.dart',
-        isFlutter: true,
-      );
-      final tools = (await testHarness.mcpServerConnection.listTools()).tools;
-      final getWidgetTreeTool = tools.singleWhere(
-        (t) => t.name == DartToolingDaemonSupport.getWidgetTreeTool.name,
-      );
-      final getWidgetTreeResult = await testHarness.callToolWithRetry(
-        CallToolRequest(name: getWidgetTreeTool.name),
-      );
+          // Re-uses existing VM Service when available.
+          final originalVmService = server.activeVmServices.values.single;
+          await server.updateActiveVmServices();
+          expect(server.activeVmServices.length, 1);
+          expect(originalVmService, server.activeVmServices.values.single);
 
-      expect(getWidgetTreeResult.isError, isNot(true));
-      expect(
-        (getWidgetTreeResult.content.first as TextContent).text,
-        contains('MyHomePage'),
-      );
-    });
-  });
+          await testHarness.startDebugSession(
+            counterAppPath,
+            'lib/main.dart',
+            isFlutter: true,
+          );
+          await server.updateActiveVmServices();
+          expect(server.activeVmServices.length, 2);
+        });
 
-  group('$VmService management', () {
-    setUp(() async {
-      DartToolingDaemonSupport.debugAwaitVmServiceDisposal = true;
-      addTearDown(
-        () => DartToolingDaemonSupport.debugAwaitVmServiceDisposal = false,
-      );
+        test('automatically removes vm services upon shutdown', () async {
+          final server = testHarness.serverConnectionPair.server!;
+          expect(server.activeVmServices, isEmpty);
 
-      testHarness = await TestHarness.start(inProcess: true);
-      await testHarness.connectToDtd();
-    });
+          final debugSession = await testHarness.startDebugSession(
+            counterAppPath,
+            'lib/main.dart',
+            isFlutter: true,
+          );
+          await server.updateActiveVmServices();
+          expect(server.activeVmServices.length, 1);
 
-    test('persists vm services', () async {
-      final server = testHarness.serverConnectionPair.server!;
-      expect(server.activeVmServices, isEmpty);
+          await testHarness.stopDebugSession(debugSession);
+          await server.updateActiveVmServices();
+          expect(server.activeVmServices, isEmpty);
+        });
+      });
 
-      await testHarness.startDebugSession(
-        counterAppPath,
-        'lib/main.dart',
-        isFlutter: true,
-      );
-      await server.updateActiveVmServices();
-      expect(server.activeVmServices.length, 1);
+      group('get selected widget', () {
+        test('when a selected widget exists', () async {
+          final server = testHarness.serverConnectionPair.server!;
+          final tools =
+              (await testHarness.mcpServerConnection.listTools()).tools;
 
-      // Re-uses existing VM Service when available.
-      final originalVmService = server.activeVmServices.values.single;
-      await server.updateActiveVmServices();
-      expect(server.activeVmServices.length, 1);
-      expect(originalVmService, server.activeVmServices.values.single);
+          await testHarness.startDebugSession(
+            counterAppPath,
+            'lib/main.dart',
+            isFlutter: true,
+          );
+          await server.updateActiveVmServices();
 
-      await testHarness.startDebugSession(
-        counterAppPath,
-        'lib/main.dart',
-        isFlutter: true,
-      );
-      await server.updateActiveVmServices();
-      expect(server.activeVmServices.length, 2);
-    });
+          final getWidgetTreeTool = tools.singleWhere(
+            (t) => t.name == DartToolingDaemonSupport.getWidgetTreeTool.name,
+          );
+          final getWidgetTreeResult = await testHarness.callToolWithRetry(
+            CallToolRequest(name: getWidgetTreeTool.name),
+          );
 
-    test('automatically removes vm services upon shutdown', () async {
-      final server = testHarness.serverConnectionPair.server!;
-      expect(server.activeVmServices, isEmpty);
+          // Select the first child of the [root] widget.
+          final widgetTree =
+              jsonDecode(
+                    (getWidgetTreeResult.content.first as TextContent).text,
+                  )
+                  as Map<String, Object?>;
+          final children = widgetTree['children'] as List<Object?>;
+          final firstWidgetId =
+              (children.first as Map<String, Object?>)['valueId'];
+          final appVmService = server.activeVmServices.values.first;
+          final vm = await appVmService.getVM();
+          await appVmService.callServiceExtension(
+            'ext.flutter.inspector.setSelectionById',
+            isolateId: vm.isolates!.first.id,
+            args: {
+              'objectGroup': DartToolingDaemonSupport.inspectorObjectGroup,
+              'arg': firstWidgetId,
+            },
+          );
 
-      final debugSession = await testHarness.startDebugSession(
-        counterAppPath,
-        'lib/main.dart',
-        isFlutter: true,
-      );
-      await server.updateActiveVmServices();
-      expect(server.activeVmServices.length, 1);
+          // Confirm we can get the selected widget from the MCP tool.
+          final getSelectedWidgetTool = tools.singleWhere(
+            (t) =>
+                t.name == DartToolingDaemonSupport.getSelectedWidgetTool.name,
+          );
+          final getSelectedWidgetResult = await testHarness.callToolWithRetry(
+            CallToolRequest(name: getSelectedWidgetTool.name),
+          );
+          expect(getSelectedWidgetResult.isError, isNot(true));
+          expect(
+            (getSelectedWidgetResult.content.first as TextContent).text,
+            contains('MyApp'),
+          );
+        });
 
-      await testHarness.stopDebugSession(debugSession);
-      await server.updateActiveVmServices();
-      expect(server.activeVmServices, isEmpty);
+        test('when there is no selected widget', () async {
+          await testHarness.startDebugSession(
+            counterAppPath,
+            'lib/main.dart',
+            isFlutter: true,
+          );
+          final tools =
+              (await testHarness.mcpServerConnection.listTools()).tools;
+          final getSelectedWidgetTool = tools.singleWhere(
+            (t) =>
+                t.name == DartToolingDaemonSupport.getSelectedWidgetTool.name,
+          );
+          final getSelectedWidgetResult = await testHarness.callToolWithRetry(
+            CallToolRequest(name: getSelectedWidgetTool.name),
+          );
+
+          expect(getSelectedWidgetResult.isError, isNot(true));
+          expect(
+            (getSelectedWidgetResult.content.first as TextContent).text,
+            contains('No Widget selected.'),
+          );
+        });
+      });
     });
   });
 }


### PR DESCRIPTION
This PR adds a tool that gets the selected widget from the Widget Inspector for a running Flutter app. In its current form, this tool calls the `ext.flutter.inspector.getSelectedSummaryWidget` service extension. I opted to use `getSelectedSummaryWidget` instead of `getSelectedWidget` because this tool will likely be useful in the context of the user's code.