### PR TITLE
Update analyze tool to use LSP, simplify tool

### DIFF
--- a/pkgs/dart_mcp/example/dash_client.dart
+++ b/pkgs/dart_mcp/example/dash_client.dart
@@ -39,7 +39,7 @@ final argParser =
         abbr: 's',
         help: 'A command to run to start an MCP server',
       )
-      ..addOption(
+      ..addFlag(
         'verbose',
         abbr: 'v',
         help: 'Enables verbose logging for logs from servers.',

--- a/pkgs/dart_tooling_mcp_server/lib/src/lsp/wire_format.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/lsp/wire_format.dart
@@ -1,0 +1,105 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:async/async.dart';
+import 'package:stream_channel/stream_channel.dart';
+
+StreamChannel<String> lspChannel(
+  Stream<List<int>> stream,
+  StreamSink<List<int>> sink,
+) {
+  final parser = _Parser(stream);
+  final outSink = StreamSinkTransformer.fromHandlers(
+    handleData: _serialize,
+    handleDone: (sink) {
+      sink.close();
+      parser.close();
+    },
+  ).bind(sink);
+  return StreamChannel.withGuarantees(parser.stream, outSink);
+}
+
+void _serialize(String data, EventSink<List<int>> sink) {
+  final message = utf8.encode(data);
+  final header = 'Content-Length: ${message.length}\r\n\r\n';
+  sink.add(ascii.encode(header));
+  for (var chunk in _chunks(message, 1024)) {
+    sink.add(chunk);
+  }
+}
+
+class _Parser {
+  final _streamCtl = StreamController<String>();
+  Stream<String> get stream => _streamCtl.stream;
+
+  final _buffer = <int>[];
+  bool _headerMode = true;
+  int _contentLength = -1;
+
+  late final StreamSubscription _subscription;
+
+  _Parser(Stream<List<int>> stream) {
+    _subscription = stream
+        .expand((bytes) => bytes)
+        .listen(_handleByte, onDone: _streamCtl.close);
+  }
+
+  Future<void> close() => _subscription.cancel();
+
+  void _handleByte(int byte) {
+    _buffer.add(byte);
+    if (_headerMode && _headerComplete) {
+      _contentLength = _parseContentLength();
+      _buffer.clear();
+      _headerMode = false;
+    } else if (!_headerMode && _messageComplete) {
+      _streamCtl.add(utf8.decode(_buffer));
+      _buffer.clear();
+      _headerMode = true;
+    }
+  }
+
+  /// Whether the entire message is in [_buffer].
+  bool get _messageComplete => _buffer.length >= _contentLength;
+
+  /// Decodes [_buffer] into a String and looks for the 'Content-Length' header.
+  int _parseContentLength() {
+    final asString = ascii.decode(_buffer);
+    final headers = asString.split('\r\n');
+    final lengthHeader = headers.firstWhere(
+      (h) => h.startsWith('Content-Length'),
+    );
+    final length = lengthHeader.split(':').last.trim();
+    return int.parse(length);
+  }
+
+  /// Whether [_buffer] ends in '\r\n\r\n'.
+  bool get _headerComplete {
+    final l = _buffer.length;
+    return l > 4 &&
+        _buffer[l - 1] == 10 &&
+        _buffer[l - 2] == 13 &&
+        _buffer[l - 3] == 10 &&
+        _buffer[l - 4] == 13;
+  }
+}
+
+Iterable<List<T>> _chunks<T>(List<T> data, int chunkSize) sync* {
+  if (data.length <= chunkSize) {
+    yield data;
+    return;
+  }
+  var low = 0;
+  while (low < data.length) {
+    if (data.length > low + chunkSize) {
+      yield data.sublist(low, low + chunkSize);
+    } else {
+      yield data.sublist(low);
+    }
+    low += chunkSize;
+  }
+}

--- a/pkgs/dart_tooling_mcp_server/pubspec.yaml
+++ b/pkgs/dart_tooling_mcp_server/pubspec.yaml
@@ -33,5 +33,3 @@ dev_dependencies:
 dependency_overrides:
   dart_mcp:
     path: ../dart_mcp
-  json_rpc_2:
-    path: ../../tools/pkgs/json_rpc_2

--- a/pkgs/dart_tooling_mcp_server/pubspec.yaml
+++ b/pkgs/dart_tooling_mcp_server/pubspec.yaml
@@ -11,14 +11,19 @@ dependencies:
   dds_service_extensions: ^2.0.1
   devtools_shared: ^11.2.0
   dtd: ^2.4.0
-  json_rpc_2: ^3.0.3
+  json_rpc_2: ^4.0.0
+  # TODO: Get this another way.
+  language_server_protocol:
+    git:
+      url: https://github.com/dart-lang/sdk.git
+      path:
+        third_party/pkg/language_server_protocol
   meta: ^1.16.0
   path: ^1.9.1
   stream_channel: ^2.1.4
   test_descriptor: ^2.0.2
   test_process: ^2.1.1
   vm_service: ^15.0.0
-  watcher: ^1.1.1
 executables:
   dart_tooling_mcp_server: main
 dev_dependencies:
@@ -28,3 +33,5 @@ dev_dependencies:
 dependency_overrides:
   dart_mcp:
     path: ../dart_mcp
+  json_rpc_2:
+    path: ../../tools/pkgs/json_rpc_2

--- a/pkgs/dart_tooling_mcp_server/pubspec.yaml
+++ b/pkgs/dart_tooling_mcp_server/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   dds_service_extensions: ^2.0.1
   devtools_shared: ^11.2.0
   dtd: ^2.4.0
-  json_rpc_2: ^4.0.0
+  json_rpc_2: ^3.0.3
   # TODO: Get this another way.
   language_server_protocol:
     git:

--- a/pkgs/dart_tooling_mcp_server/pubspec.yaml
+++ b/pkgs/dart_tooling_mcp_server/pubspec.yaml
@@ -5,7 +5,6 @@ version: 0.1.0-wip
 environment:
   sdk: ^3.7.0 # The version of dart in the current flutter stable
 dependencies:
-  analyzer: ^7.3.0
   async: ^2.13.0
   dart_mcp: ^2.0.0
   dds_service_extensions: ^2.0.1

--- a/pkgs/dart_tooling_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_tooling_mcp_server/test/test_harness.dart
@@ -254,18 +254,18 @@ class FakeEditorExtension {
   int get nextId => ++_nextId;
   int _nextId = 0;
 
-  FakeEditorExtension(this.dtd, this.dtdProcess, this.dtdUri) {
-    _registerService();
-  }
+  FakeEditorExtension._(this.dtd, this.dtdProcess, this.dtdUri);
 
   static Future<FakeEditorExtension> connect() async {
     final dtdProcess = await TestProcess.start('dart', ['tooling-daemon']);
     final dtdUri = await _getDTDUri(dtdProcess);
     final dtd = await DartToolingDaemon.connect(Uri.parse(dtdUri));
-    return FakeEditorExtension(dtd, dtdProcess, dtdUri);
+    final extension = FakeEditorExtension._(dtd, dtdProcess, dtdUri);
+    await extension._registerService();
+    return extension;
   }
 
-  void _registerService() async {
+  Future<void> _registerService() async {
     await dtd.registerService('Editor', 'getDebugSessions', (request) async {
       return GetDebugSessionsResponse(
         debugSessions: [

--- a/pkgs/dart_tooling_mcp_server/test/tools/analyzer_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/analyzer_test.dart
@@ -18,83 +18,83 @@ void main() {
     testHarness = await TestHarness.start();
   });
 
-  group('analyzer tools', () {
-    late Tool analyzeTool;
+  // group('analyzer tools', () {
+  //   late Tool analyzeTool;
 
-    setUp(() async {
-      final tools = (await testHarness.mcpServerConnection.listTools()).tools;
-      analyzeTool = tools.singleWhere(
-        (t) => t.name == DartAnalyzerSupport.analyzeFilesTool.name,
-      );
-    });
+  //   setUp(() async {
+  //     final tools = (await testHarness.mcpServerConnection.listTools()).tools;
+  //     analyzeTool = tools.singleWhere(
+  //       (t) => t.name == DartAnalyzerSupport.analyzeFilesTool.name,
+  //     );
+  //   });
 
-    test('can analyze a project', () async {
-      final counterAppRoot = rootForPath(counterAppPath);
-      testHarness.mcpClient.addRoot(counterAppRoot);
-      // Allow the notification to propagate, and the server to ask for the new
-      // list of roots.
-      await pumpEventQueue();
+  //   test('can analyze a project', () async {
+  //     final counterAppRoot = rootForPath(counterAppPath);
+  //     testHarness.mcpClient.addRoot(counterAppRoot);
+  //     // Allow the notification to propagate, and the server to ask for the new
+  //     // list of roots.
+  //     await pumpEventQueue();
 
-      final request = CallToolRequest(
-        name: analyzeTool.name,
-        arguments: {
-          'roots': [
-            {
-              'root': counterAppRoot.uri,
-              'paths': ['lib/main.dart'],
-            },
-          ],
-        },
-      );
-      final result = await testHarness.callToolWithRetry(request);
-      expect(result.isError, isNot(true));
-      expect(result.content, isEmpty);
-    });
+  //     final request = CallToolRequest(
+  //       name: analyzeTool.name,
+  //       arguments: {
+  //         'roots': [
+  //           {
+  //             'root': counterAppRoot.uri,
+  //             'paths': ['lib/main.dart'],
+  //           },
+  //         ],
+  //       },
+  //     );
+  //     final result = await testHarness.callToolWithRetry(request);
+  //     expect(result.isError, isNot(true));
+  //     expect(result.content, isEmpty);
+  //   });
 
-    test('can handle project changes', () async {
-      final example = d.dir('example', [
-        d.file('main.dart', 'void main() => 1 + "2";'),
-      ]);
-      await example.create();
-      final exampleRoot = rootForPath(example.io.path);
-      testHarness.mcpClient.addRoot(exampleRoot);
+  //   test('can handle project changes', () async {
+  //     final example = d.dir('example', [
+  //       d.file('main.dart', 'void main() => 1 + "2";'),
+  //     ]);
+  //     await example.create();
+  //     final exampleRoot = rootForPath(example.io.path);
+  //     testHarness.mcpClient.addRoot(exampleRoot);
 
-      // Allow the notification to propagate, and the server to ask for the new
-      // list of roots.
-      await pumpEventQueue();
+  //     // Allow the notification to propagate, and the server to ask for the new
+  //     // list of roots.
+  //     await pumpEventQueue();
 
-      final request = CallToolRequest(
-        name: analyzeTool.name,
-        arguments: {
-          'roots': [
-            {
-              'root': exampleRoot.uri,
-              'paths': ['main.dart'],
-            },
-          ],
-        },
-      );
-      var result = await testHarness.callToolWithRetry(request);
-      expect(result.isError, isNot(true));
-      expect(result.content, [
-        TextContent(
-          text:
-              "Error: The argument type 'String' can't be assigned to the "
-              "parameter type 'num'. ",
-        ),
-      ]);
+  //     final request = CallToolRequest(
+  //       name: analyzeTool.name,
+  //       arguments: {
+  //         'roots': [
+  //           {
+  //             'root': exampleRoot.uri,
+  //             'paths': ['main.dart'],
+  //           },
+  //         ],
+  //       },
+  //     );
+  //     var result = await testHarness.callToolWithRetry(request);
+  //     expect(result.isError, isNot(true));
+  //     expect(result.content, [
+  //       TextContent(
+  //         text:
+  //             "Error: The argument type 'String' can't be assigned to the "
+  //             "parameter type 'num'. ",
+  //       ),
+  //     ]);
 
-      // Change the file to fix the error
-      await d.dir('example', [
-        d.file('main.dart', 'void main() => 1 + 2;'),
-      ]).create();
-      // Wait for the file watcher to pick up the change, the default delay for
-      // a polling watcher is one second.
-      await Future<void>.delayed(const Duration(seconds: 1));
+  //     // Change the file to fix the error
+  //     await d.dir('example', [
+  //       d.file('main.dart', 'void main() => 1 + 2;'),
+  //     ]).create();
+  //     // Wait for the file watcher to pick up the change, the default delay for
+  //     // a polling watcher is one second.
+  //     await Future<void>.delayed(const Duration(seconds: 1));
 
-      result = await testHarness.callToolWithRetry(request);
-      expect(result.isError, isNot(true));
-      expect(result.content, isEmpty);
-    });
-  });
+  //     result = await testHarness.callToolWithRetry(request);
+  //     expect(result.isError, isNot(true));
+  //     expect(result.content, isEmpty);
+  //   });
+  // });
 }

--- a/pkgs/dart_tooling_mcp_server/test/tools/analyzer_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/analyzer_test.dart
@@ -18,83 +18,72 @@ void main() {
     testHarness = await TestHarness.start();
   });
 
-  // group('analyzer tools', () {
-  //   late Tool analyzeTool;
+  group('analyzer tools', () {
+    late Tool analyzeTool;
 
-  //   setUp(() async {
-  //     final tools = (await testHarness.mcpServerConnection.listTools()).tools;
-  //     analyzeTool = tools.singleWhere(
-  //       (t) => t.name == DartAnalyzerSupport.analyzeFilesTool.name,
-  //     );
-  //   });
+    setUp(() async {
+      final tools = (await testHarness.mcpServerConnection.listTools()).tools;
+      analyzeTool = tools.singleWhere(
+        (t) => t.name == DartAnalyzerSupport.analyzeFilesTool.name,
+      );
+    });
 
-  //   test('can analyze a project', () async {
-  //     final counterAppRoot = rootForPath(counterAppPath);
-  //     testHarness.mcpClient.addRoot(counterAppRoot);
-  //     // Allow the notification to propagate, and the server to ask for the new
-  //     // list of roots.
-  //     await pumpEventQueue();
+    test('can analyze a project', () async {
+      final counterAppRoot = rootForPath(counterAppPath);
+      testHarness.mcpClient.addRoot(counterAppRoot);
+      // Allow the notification to propagate, and the server to ask for the new
+      // list of roots.
+      await pumpEventQueue();
 
-  //     final request = CallToolRequest(
-  //       name: analyzeTool.name,
-  //       arguments: {
-  //         'roots': [
-  //           {
-  //             'root': counterAppRoot.uri,
-  //             'paths': ['lib/main.dart'],
-  //           },
-  //         ],
-  //       },
-  //     );
-  //     final result = await testHarness.callToolWithRetry(request);
-  //     expect(result.isError, isNot(true));
-  //     expect(result.content, isEmpty);
-  //   });
+      final request = CallToolRequest(name: analyzeTool.name);
+      final result = await testHarness.callToolWithRetry(request);
+      expect(result.isError, isNot(true));
+      expect(
+        result.content.single,
+        isA<TextContent>().having((t) => t.text, 'text', 'No errors'),
+      );
+    });
 
-  //   test('can handle project changes', () async {
-  //     final example = d.dir('example', [
-  //       d.file('main.dart', 'void main() => 1 + "2";'),
-  //     ]);
-  //     await example.create();
-  //     final exampleRoot = rootForPath(example.io.path);
-  //     testHarness.mcpClient.addRoot(exampleRoot);
+    test('can handle project changes', () async {
+      final example = d.dir('example', [
+        d.file('main.dart', 'void main() => 1 + "2";'),
+      ]);
+      await example.create();
+      final exampleRoot = rootForPath(example.io.path);
+      testHarness.mcpClient.addRoot(exampleRoot);
 
-  //     // Allow the notification to propagate, and the server to ask for the new
-  //     // list of roots.
-  //     await pumpEventQueue();
+      // Allow the notification to propagate, and the server to ask for the new
+      // list of roots.
+      await pumpEventQueue();
 
-  //     final request = CallToolRequest(
-  //       name: analyzeTool.name,
-  //       arguments: {
-  //         'roots': [
-  //           {
-  //             'root': exampleRoot.uri,
-  //             'paths': ['main.dart'],
-  //           },
-  //         ],
-  //       },
-  //     );
-  //     var result = await testHarness.callToolWithRetry(request);
-  //     expect(result.isError, isNot(true));
-  //     expect(result.content, [
-  //       TextContent(
-  //         text:
-  //             "Error: The argument type 'String' can't be assigned to the "
-  //             "parameter type 'num'. ",
-  //       ),
-  //     ]);
+      final request = CallToolRequest(name: analyzeTool.name);
+      var result = await testHarness.callToolWithRetry(request);
+      expect(result.isError, isNot(true));
+      expect(result.content, [
+        isA<TextContent>().having(
+          (t) => t.text,
+          'text',
+          contains(
+            "The argument type 'String' can't be assigned to the parameter "
+            "type 'num'.",
+          ),
+        ),
+      ]);
 
-  //     // Change the file to fix the error
-  //     await d.dir('example', [
-  //       d.file('main.dart', 'void main() => 1 + 2;'),
-  //     ]).create();
-  //     // Wait for the file watcher to pick up the change, the default delay for
-  //     // a polling watcher is one second.
-  //     await Future<void>.delayed(const Duration(seconds: 1));
+      // Change the file to fix the error
+      await d.dir('example', [
+        d.file('main.dart', 'void main() => 1 + 2;'),
+      ]).create();
+      // Wait for the file watcher to pick up the change, the default delay for
+      // a polling watcher is one second.
+      await Future<void>.delayed(const Duration(seconds: 1));
 
-  //     result = await testHarness.callToolWithRetry(request);
-  //     expect(result.isError, isNot(true));
-  //     expect(result.content, isEmpty);
-  //   });
-  // });
+      result = await testHarness.callToolWithRetry(request);
+      expect(result.isError, isNot(true));
+      expect(
+        result.content.single,
+        isA<TextContent>().having((t) => t.text, 'text', 'No errors'),
+      );
+    });
+  });
 }


### PR DESCRIPTION
- Use `dart language-server` for errors, file watching, etc.
- Drop analyzer dependency.
- Depends on language_server_protocol package from the SDK using a git dependency for now:
  - We can fix this by moving into the SDK
  - Or publishing language_server_protocol
- The tool now just always returns all errors for all known workspaces.
- Errors are returned in a structured format right now instead of as a human readable string.
 - We might want to steal some code from analyzer/DartCode etc to get a human readable string going.
 - Or if this is just for AI input, structured may even be better.
 
 In the future, we might try to use the DTD connection to talk, which won't change this code too much. But right now DTD has very limited support (read/write properties).
 
 Closes https://github.com/dart-lang/ai/issues/65 as well