### PR TITLE
Add `ProcessManagerSupport` mixin to make CLI command end points more testable

### DIFF
--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/dart_cli.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/dart_cli.dart
@@ -17,8 +17,8 @@ import '../utils/process_manager.dart';
 ///
 /// The MCPServer must already have the [ToolsSupport] and [LoggingSupport]
 /// mixins applied.
-base mixin DartCliSupport
-    on ToolsSupport, LoggingSupport, ProcessManagerSupport {
+base mixin DartCliSupport on ToolsSupport, LoggingSupport
+    implements ProcessManagerSupport {
   @override
   FutureOr<InitializeResult> initialize(InitializeRequest request) {
     if (request.capabilities.roots == null) {

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/dart_cli.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/dart_cli.dart
@@ -7,6 +7,8 @@ import 'dart:io';
 
 import 'package:dart_mcp/server.dart';
 
+import '../utils/process_manager.dart';
+
 // TODO: migrate the analyze files tool to use this mixin and run the
 // `dart analyze` command instead of the analyzer package.
 
@@ -15,7 +17,8 @@ import 'package:dart_mcp/server.dart';
 ///
 /// The MCPServer must already have the [ToolsSupport] and [LoggingSupport]
 /// mixins applied.
-base mixin DartCliSupport on ToolsSupport, LoggingSupport {
+base mixin DartCliSupport
+    on ToolsSupport, LoggingSupport, ProcessManagerSupport {
   @override
   FutureOr<InitializeResult> initialize(InitializeRequest request) {
     if (request.capabilities.roots == null) {
@@ -30,15 +33,19 @@ base mixin DartCliSupport on ToolsSupport, LoggingSupport {
 
   /// Implementation of the [dartFixTool].
   Future<CallToolResult> _runDartFixTool(CallToolRequest request) async {
-    return _runDartCommandInRoots(request, 'dart fix', ['fix', '--apply']);
+    return _runDartCommandInRoots(
+      request,
+      commandDescription: 'dart fix',
+      commandArgs: ['fix', '--apply'],
+    );
   }
 
   /// Implementation of the [dartFormatTool].
   Future<CallToolResult> _runDartFormatTool(CallToolRequest request) async {
     return _runDartCommandInRoots(
       request,
-      'dart format',
-      ['format'],
+      commandDescription: 'dart format',
+      commandArgs: ['format'],
       defaultPaths: ['.'],
     );
   }
@@ -48,9 +55,9 @@ base mixin DartCliSupport on ToolsSupport, LoggingSupport {
   /// [defaultPaths] may be specified if one or more path arguments are required
   /// for the dart command (e.g. `dart format <default paths>`).
   Future<CallToolResult> _runDartCommandInRoots(
-    CallToolRequest request,
-    String commandName,
-    List<String> commandArgs, {
+    CallToolRequest request, {
+    required String commandDescription,
+    required List<String> commandArgs,
     List<String> defaultPaths = const <String>[],
   }) async {
     final rootConfigs =
@@ -99,9 +106,8 @@ base mixin DartCliSupport on ToolsSupport, LoggingSupport {
         commandArgs.addAll(defaultPaths);
       }
 
-      final result = await Process.run(
-        'dart',
-        commandArgs,
+      final result = await processManager.run(
+        ['dart', ...commandArgs],
         workingDirectory: projectRoot.path,
         runInShell: true,
       );
@@ -113,8 +119,8 @@ base mixin DartCliSupport on ToolsSupport, LoggingSupport {
           content: [
             TextContent(
               text:
-                  '$commandName failed in ${projectRoot.path}:\n$output\n\n'
-                  'Errors\n$errors',
+                  '$commandDescription failed in ${projectRoot.path}:\n'
+                  '$output\n\nErrors\n$errors',
             ),
           ],
           isError: true,
@@ -122,7 +128,9 @@ base mixin DartCliSupport on ToolsSupport, LoggingSupport {
       }
       if (output.isNotEmpty) {
         outputs.add(
-          TextContent(text: '$commandName in ${projectRoot.path}:\n$output'),
+          TextContent(
+            text: '$commandDescription in ${projectRoot.path}:\n$output',
+          ),
         );
       }
     }

--- a/pkgs/dart_tooling_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/server.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:dart_mcp/server.dart';
 import 'package:meta/meta.dart';
+import 'package:process/process.dart';
 import 'package:stream_channel/stream_channel.dart';
 
 import 'mixins/analyzer.dart';
@@ -16,6 +17,7 @@ import 'utils/process_manager.dart';
 /// An MCP server for Dart and Flutter tooling.
 final class DartToolingMCPServer extends MCPServer
     with
+        ProcessManagerSupport,
         LoggingSupport,
         ToolsSupport,
         DartAnalyzerSupport,
@@ -23,7 +25,8 @@ final class DartToolingMCPServer extends MCPServer
         DartToolingDaemonSupport {
   DartToolingMCPServer({
     required super.channel,
-    @visibleForTesting ProcessManager processManager = const ProcessManager(),
+    @visibleForTesting
+    LocalProcessManager processManager = const LocalProcessManager(),
   }) : super.fromStreamChannel(
          implementation: ServerImplementation(
            name: 'dart and flutter tooling',
@@ -36,11 +39,13 @@ final class DartToolingMCPServer extends MCPServer
     _processManager = processManager;
   }
 
-  static late final ProcessManager _processManager;
-
   static Future<DartToolingMCPServer> connect(
     StreamChannel<String> mcpChannel,
   ) async {
     return DartToolingMCPServer(channel: mcpChannel);
   }
+
+  @override
+  LocalProcessManager get processManager => _processManager;
+  late final LocalProcessManager _processManager;
 }

--- a/pkgs/dart_tooling_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/server.dart
@@ -5,11 +5,13 @@
 import 'dart:async';
 
 import 'package:dart_mcp/server.dart';
+import 'package:meta/meta.dart';
 import 'package:stream_channel/stream_channel.dart';
 
 import 'mixins/analyzer.dart';
 import 'mixins/dart_cli.dart';
 import 'mixins/dtd.dart';
+import 'utils/process_manager.dart';
 
 /// An MCP server for Dart and Flutter tooling.
 final class DartToolingMCPServer extends MCPServer
@@ -19,16 +21,22 @@ final class DartToolingMCPServer extends MCPServer
         DartAnalyzerSupport,
         DartCliSupport,
         DartToolingDaemonSupport {
-  DartToolingMCPServer({required super.channel})
-    : super.fromStreamChannel(
-        implementation: ServerImplementation(
-          name: 'dart and flutter tooling',
-          version: '0.1.0-wip',
-        ),
-        instructions:
-            'This server helps to connect Dart and Flutter developers to '
-            'their development tools and running applications.',
-      );
+  DartToolingMCPServer({
+    required super.channel,
+    @visibleForTesting ProcessManager processManager = const ProcessManager(),
+  }) : super.fromStreamChannel(
+         implementation: ServerImplementation(
+           name: 'dart and flutter tooling',
+           version: '0.1.0-wip',
+         ),
+         instructions:
+             'This server helps to connect Dart and Flutter developers to '
+             'their development tools and running applications.',
+       ) {
+    _processManager = processManager;
+  }
+
+  static late final ProcessManager _processManager;
 
   static Future<DartToolingMCPServer> connect(
     StreamChannel<String> mcpChannel,

--- a/pkgs/dart_tooling_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/server.dart
@@ -17,16 +17,15 @@ import 'utils/process_manager.dart';
 /// An MCP server for Dart and Flutter tooling.
 final class DartToolingMCPServer extends MCPServer
     with
-        ProcessManagerSupport,
         LoggingSupport,
         ToolsSupport,
         DartAnalyzerSupport,
         DartCliSupport,
-        DartToolingDaemonSupport {
+        DartToolingDaemonSupport
+    implements ProcessManagerSupport {
   DartToolingMCPServer({
     required super.channel,
-    @visibleForTesting
-    LocalProcessManager processManager = const LocalProcessManager(),
+    @visibleForTesting this.processManager = const LocalProcessManager(),
   }) : super.fromStreamChannel(
          implementation: ServerImplementation(
            name: 'dart and flutter tooling',
@@ -35,9 +34,7 @@ final class DartToolingMCPServer extends MCPServer
          instructions:
              'This server helps to connect Dart and Flutter developers to '
              'their development tools and running applications.',
-       ) {
-    _processManager = processManager;
-  }
+       );
 
   static Future<DartToolingMCPServer> connect(
     StreamChannel<String> mcpChannel,
@@ -46,6 +43,5 @@ final class DartToolingMCPServer extends MCPServer
   }
 
   @override
-  LocalProcessManager get processManager => _processManager;
-  late final LocalProcessManager _processManager;
+  final LocalProcessManager processManager;
 }

--- a/pkgs/dart_tooling_mcp_server/lib/src/utils/process_manager.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/utils/process_manager.dart
@@ -14,6 +14,6 @@ import 'package:process/process.dart';
 /// MCP support mixins like `DartCliSupport` that spawn processes should use
 /// [processManager] from this mixin instead of making direct calls to dart:io's
 /// [Process] class.
-mixin ProcessManagerSupport {
+abstract interface class ProcessManagerSupport {
   LocalProcessManager get processManager;
 }

--- a/pkgs/dart_tooling_mcp_server/lib/src/utils/process_manager.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/utils/process_manager.dart
@@ -2,77 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:convert';
 import 'dart:io';
 
-/// A wrapper class around [Process] that allows CLI commands ran by MCP server
-/// tools to be easily tested.
-class ProcessManager {
-  const ProcessManager();
+import 'package:process/process.dart';
 
-  /// Starts a process and runs it non-interactively to completion.
-  ///
-  /// This is a wrapper around the [Process.run] method.
-  Future<ProcessResult> run(CliCommand command) {
-    return Process.run(
-      command.executable,
-      command.arguments,
-      workingDirectory: command.workingDirectory,
-      environment: command.environment,
-      includeParentEnvironment: command.includeParentEnvironment,
-      runInShell: command.runInShell,
-      stdoutEncoding: command.stdoutEncoding,
-      stderrEncoding: command.stderrEncoding,
-    );
-  }
-}
-
-/// A data class representing a command to be run in a [Process].
-class CliCommand {
-  CliCommand({
-    required this.executable,
-    required this.arguments,
-    this.workingDirectory,
-    this.environment,
-    this.includeParentEnvironment = true,
-    this.runInShell = false,
-    this.stdoutEncoding = systemEncoding,
-    this.stderrEncoding = systemEncoding,
-  });
-
-  final String executable;
-  final List<String> arguments;
-  final String? workingDirectory;
-  final Map<String, String>? environment;
-  final bool includeParentEnvironment;
-  final bool runInShell;
-  final Encoding? stdoutEncoding;
-  final Encoding? stderrEncoding;
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-
-    return other is CliCommand &&
-        other.executable == executable &&
-        other.arguments == arguments &&
-        other.workingDirectory == workingDirectory &&
-        other.environment == environment &&
-        other.includeParentEnvironment == includeParentEnvironment &&
-        other.runInShell == runInShell &&
-        other.stdoutEncoding == stdoutEncoding &&
-        other.stderrEncoding == stderrEncoding;
-  }
-
-  @override
-  int get hashCode {
-    return executable.hashCode ^
-        arguments.hashCode ^
-        workingDirectory.hashCode ^
-        environment.hashCode ^
-        includeParentEnvironment.hashCode ^
-        runInShell.hashCode ^
-        stdoutEncoding.hashCode ^
-        stderrEncoding.hashCode;
-  }
+/// A mixin that provides a single getter of type [LocalProcessManager].
+///
+/// The `DartToolingMCPServer` class mixes this in so that [Process] methods
+/// can be easily mocked during testing.
+///
+/// MCP support mixins like `DartCliSupport` that spawn processes should use
+/// [processManager] from this mixin instead of making direct calls to dart:io's
+/// [Process] class.
+mixin ProcessManagerSupport {
+  LocalProcessManager get processManager;
 }

--- a/pkgs/dart_tooling_mcp_server/lib/src/utils/process_manager.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/utils/process_manager.dart
@@ -6,14 +6,15 @@ import 'dart:io';
 
 import 'package:process/process.dart';
 
-/// A mixin that provides a single getter of type [LocalProcessManager].
+/// An interface class that provides a single getter of type
+/// [LocalProcessManager].
 ///
-/// The `DartToolingMCPServer` class mixes this in so that [Process] methods
-/// can be easily mocked during testing.
+/// The `DartToolingMCPServer` class implements this class so that [Process]
+/// methods can be easily mocked during testing.
 ///
-/// MCP support mixins like `DartCliSupport` that spawn processes should use
-/// [processManager] from this mixin instead of making direct calls to dart:io's
-/// [Process] class.
+/// MCP support mixins like `DartCliSupport` that spawn processes should also
+/// implement this class and use [processManager] instead of making direct calls
+/// to dart:io's [Process] class.
 abstract interface class ProcessManagerSupport {
   LocalProcessManager get processManager;
 }

--- a/pkgs/dart_tooling_mcp_server/lib/src/utils/process_manager.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/utils/process_manager.dart
@@ -1,0 +1,78 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+/// A wrapper class around [Process] that allows CLI commands ran by MCP server
+/// tools to be easily tested.
+class ProcessManager {
+  const ProcessManager();
+
+  /// Starts a process and runs it non-interactively to completion.
+  ///
+  /// This is a wrapper around the [Process.run] method.
+  Future<ProcessResult> run(CliCommand command) {
+    return Process.run(
+      command.executable,
+      command.arguments,
+      workingDirectory: command.workingDirectory,
+      environment: command.environment,
+      includeParentEnvironment: command.includeParentEnvironment,
+      runInShell: command.runInShell,
+      stdoutEncoding: command.stdoutEncoding,
+      stderrEncoding: command.stderrEncoding,
+    );
+  }
+}
+
+/// A data class representing a command to be run in a [Process].
+class CliCommand {
+  CliCommand({
+    required this.executable,
+    required this.arguments,
+    this.workingDirectory,
+    this.environment,
+    this.includeParentEnvironment = true,
+    this.runInShell = false,
+    this.stdoutEncoding = systemEncoding,
+    this.stderrEncoding = systemEncoding,
+  });
+
+  final String executable;
+  final List<String> arguments;
+  final String? workingDirectory;
+  final Map<String, String>? environment;
+  final bool includeParentEnvironment;
+  final bool runInShell;
+  final Encoding? stdoutEncoding;
+  final Encoding? stderrEncoding;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is CliCommand &&
+        other.executable == executable &&
+        other.arguments == arguments &&
+        other.workingDirectory == workingDirectory &&
+        other.environment == environment &&
+        other.includeParentEnvironment == includeParentEnvironment &&
+        other.runInShell == runInShell &&
+        other.stdoutEncoding == stdoutEncoding &&
+        other.stderrEncoding == stderrEncoding;
+  }
+
+  @override
+  int get hashCode {
+    return executable.hashCode ^
+        arguments.hashCode ^
+        workingDirectory.hashCode ^
+        environment.hashCode ^
+        includeParentEnvironment.hashCode ^
+        runInShell.hashCode ^
+        stdoutEncoding.hashCode ^
+        stderrEncoding.hashCode;
+  }
+}

--- a/pkgs/dart_tooling_mcp_server/pubspec.yaml
+++ b/pkgs/dart_tooling_mcp_server/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   json_rpc_2: ^3.0.3
   meta: ^1.16.0
   path: ^1.9.1
+  process: ^5.0.3
   stream_channel: ^2.1.4
   test_descriptor: ^2.0.2
   test_process: ^2.1.1

--- a/pkgs/dart_tooling_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_tooling_mcp_server/test/test_harness.dart
@@ -387,7 +387,11 @@ final dartCliAppsPath = p.join('test_fixtures', 'dart_cli_app');
 /// A test wrapper around [LocalProcessManager] that stores commands locally
 /// instead of running them by spawning sub-processes.
 class TestProcessManager extends LocalProcessManager {
-  final commands = <String>[];
+  TestProcessManager() {
+    addTearDown(reset);
+  }
+
+  final commandsRan = <String>[];
 
   int nextPid = 0;
 
@@ -401,11 +405,11 @@ class TestProcessManager extends LocalProcessManager {
     Encoding? stdoutEncoding = systemEncoding,
     Encoding? stderrEncoding = systemEncoding,
   }) async {
-    commands.add(command.join(' '));
+    commandsRan.add(command.join(' '));
     return ProcessResult(nextPid++, 0, '', '');
   }
 
   void reset() {
-    commands.clear();
+    commandsRan.clear();
   }
 }

--- a/pkgs/dart_tooling_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_tooling_mcp_server/test/test_harness.dart
@@ -391,7 +391,7 @@ class TestProcessManager extends LocalProcessManager {
     addTearDown(reset);
   }
 
-  final commandsRan = <String>[];
+  final commandsRan = <List<Object>>[];
 
   int nextPid = 0;
 
@@ -405,7 +405,7 @@ class TestProcessManager extends LocalProcessManager {
     Encoding? stdoutEncoding = systemEncoding,
     Encoding? stderrEncoding = systemEncoding,
   }) async {
-    commandsRan.add(command.join(' '));
+    commandsRan.add(command);
     return ProcessResult(nextPid++, 0, '', '');
   }
 

--- a/pkgs/dart_tooling_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_tooling_mcp_server/test/test_harness.dart
@@ -10,9 +10,9 @@ import 'package:async/async.dart';
 import 'package:dart_mcp/client.dart';
 import 'package:dart_tooling_mcp_server/src/mixins/dtd.dart';
 import 'package:dart_tooling_mcp_server/src/server.dart';
-import 'package:dart_tooling_mcp_server/src/utils/process_manager.dart';
 import 'package:dtd/dtd.dart';
 import 'package:path/path.dart' as p;
+import 'package:process/process.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
@@ -384,15 +384,25 @@ final counterAppPath = p.join('test_fixtures', 'counter_app');
 
 final dartCliAppsPath = p.join('test_fixtures', 'dart_cli_app');
 
-class TestProcessManager extends ProcessManager {
-  final commands = <CliCommand>[];
+/// A test wrapper around [LocalProcessManager] that stores commands locally
+/// instead of running them by spawning sub-processes.
+class TestProcessManager extends LocalProcessManager {
+  final commands = <String>[];
 
   int nextPid = 0;
 
   @override
-  Future<ProcessResult> run(CliCommand command) async {
-    commands.add(command);
-    return ProcessResult(nextPid++, 0, null, null);
+  Future<ProcessResult> run(
+    List<Object> command, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+  }) async {
+    commands.add(command.join(' '));
+    return ProcessResult(nextPid++, 0, '', '');
   }
 
   void reset() {

--- a/pkgs/dart_tooling_mcp_server/test/tools/dart_cli_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/dart_cli_test.dart
@@ -24,7 +24,6 @@ void main() {
     testProcessManager =
         testHarness.serverConnectionPair.server!.processManager
             as TestProcessManager;
-    addTearDown(() => testProcessManager.reset());
 
     testHarness.mcpClient.addRoot(testRoot);
     await pumpEventQueue();
@@ -57,7 +56,7 @@ void main() {
 
       // Verify the command was sent to the process maanger without error.
       expect(result.isError, isNot(true));
-      expect(testProcessManager.commands, ['dart fix --apply']);
+      expect(testProcessManager.commandsRan, ['dart fix --apply']);
     });
 
     test('can run dart format', () async {
@@ -73,7 +72,7 @@ void main() {
 
       // Verify the command was sent to the process maanger without error.
       expect(result.isError, isNot(true));
-      expect(testProcessManager.commands, ['dart format .']);
+      expect(testProcessManager.commandsRan, ['dart format .']);
     });
 
     test('can run dart format with paths', () async {
@@ -92,7 +91,7 @@ void main() {
 
       // Verify the command was sent to the process maanger without error.
       expect(result.isError, isNot(true));
-      expect(testProcessManager.commands, ['dart format foo.dart bar.dart']);
+      expect(testProcessManager.commandsRan, ['dart format foo.dart bar.dart']);
     });
   });
 }

--- a/pkgs/dart_tooling_mcp_server/test/tools/dart_cli_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/dart_cli_test.dart
@@ -2,68 +2,39 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:dart_mcp/server.dart';
 import 'package:dart_tooling_mcp_server/src/mixins/dart_cli.dart';
-import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import '../test_harness.dart';
 
 void main() {
   late TestHarness testHarness;
+  late TestProcessManager testProcessManager;
+
+  // This root is arbitrary for these tests since we are not actually running
+  // the CLI commands, but rather sending them through the
+  // [TestProcessManager] wrapper.
+  final testRoot = rootForPath(counterAppPath);
 
   // TODO: Use setUpAll, currently this fails due to an apparent TestProcess
   // issue.
   setUp(() async {
-    testHarness = await TestHarness.start();
+    testHarness = await TestHarness.start(inProcess: true);
+    testProcessManager =
+        testHarness.serverConnectionPair.server!.processManager
+            as TestProcessManager;
+    addTearDown(() => testProcessManager.reset());
+
+    testHarness.mcpClient.addRoot(testRoot);
+    await pumpEventQueue();
   });
+
   group('dart cli tools', () {
     late Tool dartFixTool;
     late Tool dartFormatTool;
-    late String copyDartCliAppsBin;
-    const copyDirectoryName = 'bin_copy';
-
-    Future<void> copyDartCliAppAndVerifyContents() async {
-      // Copy the original `dart_cli_app` directory so that changes from these
-      // test runs do not affect the original test_fixture code. Copy inside of
-      // the `dart_cli_app` folder so that the `analysis_options.yaml` file
-      // applies to the copied directory.
-      // TODO(https://github.com/dart-lang/ai/issues/51): it would be better to
-      // copy this to a temp directory.
-      copyDartCliAppsBin = p.join(dartCliAppsPath, copyDirectoryName);
-      await _copyDirectory(
-        Directory(p.join(dartCliAppsPath, 'bin')),
-        Directory(copyDartCliAppsBin),
-      );
-
-      addTearDown(() async {
-        // Delete the copy.
-        await Directory(copyDartCliAppsBin).delete(recursive: true);
-      });
-
-      final dartFixContent =
-          File(p.join(copyDartCliAppsBin, 'dart_fix.dart')).readAsStringSync();
-      expect(dartFixContent, contains('var myObject = MyClass();'));
-
-      // Read the initial (formatted) contents, and then remove the newlines and
-      // write that as the new contents.
-      final dartFormatFile = File(
-        p.join(copyDartCliAppsBin, 'dart_format.dart'),
-      );
-      final dartFormatContent = dartFormatFile.readAsStringSync();
-      final newContent = dartFormatContent.replaceFirst(
-        "\n  print('hello');\n",
-        "print('hello');",
-      );
-      expect(dartFormatContent, isNot(newContent));
-      await dartFormatFile.writeAsString(newContent);
-    }
 
     setUp(() async {
-      await copyDartCliAppAndVerifyContents();
-
       final tools = (await testHarness.mcpServerConnection.listTools()).tools;
       dartFixTool = tools.singleWhere(
         (t) => t.name == DartCliSupport.dartFixTool.name,
@@ -74,175 +45,54 @@ void main() {
     });
 
     test('can run dart fix', () async {
-      final root = rootForPath(copyDartCliAppsBin);
-      testHarness.mcpClient.addRoot(root);
-      await pumpEventQueue();
-
       final request = CallToolRequest(
         name: dartFixTool.name,
         arguments: {
           'roots': [
-            {'root': root.uri},
+            {'root': testRoot.uri},
           ],
         },
       );
       final result = await testHarness.callToolWithRetry(request);
 
+      // Verify the command was sent to the process maanger without error.
       expect(result.isError, isNot(true));
-      expect(
-        (result.content.single as TextContent).text,
-        contains('Computing fixes in $copyDirectoryName...'),
-      );
-      expect(
-        (result.content.single as TextContent).text,
-        contains('Applying fixes...'),
-      );
-      expect(
-        (result.content.single as TextContent).text,
-        isNot(contains('Nothing to fix!')),
-      );
-
-      // Check that the file was modified
-      final fixedContent =
-          File(p.join(copyDartCliAppsBin, 'dart_fix.dart')).readAsStringSync();
-      expect(fixedContent, contains('final myObject = MyClass();'));
-
-      // Run dart fix again and verify there are no changes.
-      final secondResult = await testHarness.callToolWithRetry(request);
-      expect(secondResult.isError, isNot(true));
-      expect(
-        (secondResult.content.single as TextContent).text,
-        contains('Nothing to fix!'),
-      );
+      expect(testProcessManager.commands, ['dart fix --apply']);
     });
 
     test('can run dart format', () async {
-      final root = rootForPath(copyDartCliAppsBin);
-      testHarness.mcpClient.addRoot(root);
-      await pumpEventQueue();
-
       final request = CallToolRequest(
         name: dartFormatTool.name,
         arguments: {
           'roots': [
-            {'root': root.uri},
+            {'root': testRoot.uri},
           ],
         },
       );
       final result = await testHarness.callToolWithRetry(request);
+
+      // Verify the command was sent to the process maanger without error.
       expect(result.isError, isNot(true));
-      expect(
-        (result.content.single as TextContent).text,
-        contains(
-          'Formatted ${Directory(copyDartCliAppsBin).listSync().length} files '
-          '(1 changed)',
-        ),
-      );
-
-      // Check that the file was modified
-      final formattedFile = File(
-        p.join(copyDartCliAppsBin, 'dart_format.dart'),
-      );
-      expect(
-        formattedFile.readAsStringSync(),
-        contains("void main() {\n  print('hello');\n}\n"),
-      );
-
-      // Run dart format again and verify there are no changes.
-      final secondResult = await testHarness.callToolWithRetry(request);
-      expect(secondResult.isError, isNot(true));
-      expect(
-        (secondResult.content.single as TextContent).text,
-        contains(
-          'Formatted ${Directory(copyDartCliAppsBin).listSync().length} files '
-          '(0 changed)',
-        ),
-      );
+      expect(testProcessManager.commands, ['dart format .']);
     });
 
     test('can run dart format with paths', () async {
-      // Create copies of the file with formatting issues.
-      final file = File(p.join(copyDartCliAppsBin, 'dart_format.dart'));
-      expect(
-        file.readAsStringSync(),
-        contains("void main() {print('hello');}"),
-      );
-      for (var i = 1; i <= 3; i++) {
-        await file.copy(p.join(copyDartCliAppsBin, 'dart_format_$i.dart'));
-      }
-
-      final root = rootForPath(copyDartCliAppsBin);
-      testHarness.mcpClient.addRoot(root);
-      await pumpEventQueue();
-
       final request = CallToolRequest(
         name: dartFormatTool.name,
         arguments: {
           'roots': [
             {
-              'root': root.uri,
-              'paths': ['dart_format.dart', 'dart_format_1.dart'],
+              'root': testRoot.uri,
+              'paths': ['foo.dart', 'bar.dart'],
             },
           ],
         },
       );
       final result = await testHarness.callToolWithRetry(request);
+
+      // Verify the command was sent to the process maanger without error.
       expect(result.isError, isNot(true));
-      expect(
-        (result.content.single as TextContent).text,
-        contains('Formatted 2 files (2 changed)'),
-      );
-
-      // Check that the files were modified
-      final firstFormattedFile = File(
-        p.join(copyDartCliAppsBin, 'dart_format.dart'),
-      );
-      expect(
-        firstFormattedFile.readAsStringSync(),
-        contains("void main() {\n  print('hello');\n}\n"),
-      );
-      final secondFormattedFile = File(
-        p.join(copyDartCliAppsBin, 'dart_format_1.dart'),
-      );
-      expect(
-        secondFormattedFile.readAsStringSync(),
-        contains("void main() {\n  print('hello');\n}\n"),
-      );
-
-      // Check that the other files in the directory were unmodified.
-      final firstUnformattedFile = File(
-        p.join(copyDartCliAppsBin, 'dart_format_2.dart'),
-      );
-      expect(
-        firstUnformattedFile.readAsStringSync(),
-        contains("void main() {print('hello');}"),
-      );
-      final secondUnformattedFile = File(
-        p.join(copyDartCliAppsBin, 'dart_format_3.dart'),
-      );
-      expect(
-        secondUnformattedFile.readAsStringSync(),
-        contains("void main() {print('hello');}"),
-      );
+      expect(testProcessManager.commands, ['dart format foo.dart bar.dart']);
     });
   });
-}
-
-/// Helper function to recursively copy a directory.
-Future<void> _copyDirectory(Directory source, Directory destination) async {
-  await destination.create(recursive: true);
-  // Add a small delay to allow filesystem changes to propagate.
-  await Future<void>.delayed(const Duration(milliseconds: 10));
-
-  assert(await source.exists());
-  assert(await destination.exists());
-
-  await for (var entity in source.list(recursive: false)) {
-    final newPath = p.join(destination.path, p.basename(entity.path));
-    if (entity is File) {
-      await entity.copy(newPath);
-    } else if (entity is Directory) {
-      await _copyDirectory(entity, Directory(newPath));
-    }
-  }
 }

--- a/pkgs/dart_tooling_mcp_server/test/tools/dart_cli_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/dart_cli_test.dart
@@ -43,7 +43,7 @@ void main() {
       );
     });
 
-    test('can run dart fix', () async {
+    test('dart fix', () async {
       final request = CallToolRequest(
         name: dartFixTool.name,
         arguments: {
@@ -56,10 +56,12 @@ void main() {
 
       // Verify the command was sent to the process maanger without error.
       expect(result.isError, isNot(true));
-      expect(testProcessManager.commandsRan, ['dart fix --apply']);
+      expect(testProcessManager.commandsRan, [
+        ['dart', 'fix', '--apply'],
+      ]);
     });
 
-    test('can run dart format', () async {
+    test('dart format', () async {
       final request = CallToolRequest(
         name: dartFormatTool.name,
         arguments: {
@@ -72,10 +74,12 @@ void main() {
 
       // Verify the command was sent to the process maanger without error.
       expect(result.isError, isNot(true));
-      expect(testProcessManager.commandsRan, ['dart format .']);
+      expect(testProcessManager.commandsRan, [
+        ['dart', 'format', '.'],
+      ]);
     });
 
-    test('can run dart format with paths', () async {
+    test('dart format with paths', () async {
       final request = CallToolRequest(
         name: dartFormatTool.name,
         arguments: {
@@ -91,7 +95,9 @@ void main() {
 
       // Verify the command was sent to the process maanger without error.
       expect(result.isError, isNot(true));
-      expect(testProcessManager.commandsRan, ['dart format foo.dart bar.dart']);
+      expect(testProcessManager.commandsRan, [
+        ['dart', 'format', 'foo.dart', 'bar.dart'],
+      ]);
     });
   });
 }


### PR DESCRIPTION
This allows us to not duplicate testing that is already done for CLI tools this server is calling into (like the Dart CLI for example). 