### PR TITLE
implement a tool to resolve workspace symbols based on a query

### DIFF
--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
@@ -57,6 +57,7 @@ base mixin DartAnalyzerSupport on ToolsSupport, LoggingSupport {
     unsupportedReason ??= await _initializeAnalyzerLspServer();
     if (unsupportedReason == null) {
       registerTool(analyzeFilesTool, _analyzeFiles);
+      registerTool(resolveWorkspaceSymbolTool, _resolveWorkspaceSymbol);
     }
 
     // Don't call any methods on the client until we are fully initialized
@@ -129,6 +130,39 @@ base mixin DartAnalyzerSupport on ToolsSupport, LoggingSupport {
                     diagnostics: lsp.DiagnosticWorkspaceClientCapabilities(
                       refreshSupport: true,
                     ),
+                    symbol: lsp.WorkspaceSymbolClientCapabilities(
+                      symbolKind:
+                          lsp.WorkspaceSymbolClientCapabilitiesSymbolKind(
+                            valueSet: [
+                              lsp.SymbolKind.Array,
+                              lsp.SymbolKind.Boolean,
+                              lsp.SymbolKind.Class,
+                              lsp.SymbolKind.Constant,
+                              lsp.SymbolKind.Constructor,
+                              lsp.SymbolKind.Enum,
+                              lsp.SymbolKind.EnumMember,
+                              lsp.SymbolKind.Event,
+                              lsp.SymbolKind.Field,
+                              lsp.SymbolKind.File,
+                              lsp.SymbolKind.Function,
+                              lsp.SymbolKind.Interface,
+                              lsp.SymbolKind.Key,
+                              lsp.SymbolKind.Method,
+                              lsp.SymbolKind.Module,
+                              lsp.SymbolKind.Namespace,
+                              lsp.SymbolKind.Null,
+                              lsp.SymbolKind.Number,
+                              lsp.SymbolKind.Obj,
+                              lsp.SymbolKind.Operator,
+                              lsp.SymbolKind.Package,
+                              lsp.SymbolKind.Property,
+                              lsp.SymbolKind.Str,
+                              lsp.SymbolKind.Struct,
+                              lsp.SymbolKind.TypeParameter,
+                              lsp.SymbolKind.Variable,
+                            ],
+                          ),
+                    ),
                   ),
                   textDocument: lsp.TextDocumentClientCapabilities(
                     publishDiagnostics:
@@ -148,15 +182,30 @@ base mixin DartAnalyzerSupport on ToolsSupport, LoggingSupport {
     }
 
     if (initializeResult != null) {
+      // Checks that we can set workspaces on the LSP server.
       final workspaceSupport =
           initializeResult.capabilities.workspace?.workspaceFolders;
       if (workspaceSupport?.supported != true) {
         error ??= 'Workspaces are not supported by the LSP server';
-      }
-      if (workspaceSupport?.changeNotifications?.valueEquals(true) != true) {
+      } else if (workspaceSupport?.changeNotifications?.valueEquals(true) !=
+          true) {
         error ??=
             'Workspace change notifications are not supported by the LSP '
             'server';
+      }
+
+      // Checks that we resolve workspace symbols.
+      final workspaceSymbolProvider =
+          initializeResult.capabilities.workspaceSymbolProvider;
+      final symbolProvidersSupported =
+          workspaceSymbolProvider != null &&
+          workspaceSymbolProvider.map(
+            (b) => b,
+            (options) => options.resolveProvider == true,
+          );
+      if (!symbolProvidersSupported) {
+        error ??=
+            'Workspace symbol resolution is not supported by the LSP server';
       }
     }
 
@@ -197,6 +246,20 @@ base mixin DartAnalyzerSupport on ToolsSupport, LoggingSupport {
       messages.add(TextContent(text: 'No errors'));
     }
     return CallToolResult(content: messages);
+  }
+
+  /// Implementation of the [resolveWorkspaceSymbolTool], resolves a given
+  /// symbol or symbols in a workspace.
+  Future<CallToolResult> _resolveWorkspaceSymbol(
+    CallToolRequest request,
+  ) async {
+    await _doneAnalyzing?.future;
+    final query = request.arguments!['query'] as String;
+    final result = await _lspConnection.sendRequest(
+      lsp.Method.workspace_symbol.toString(),
+      lsp.WorkspaceSymbolParams(query: query).toJson(),
+    );
+    return CallToolResult(content: [TextContent(text: jsonEncode(result))]);
   }
 
   /// Handles `$/analyzerStatus` events, which tell us when analysis starts and
@@ -268,7 +331,19 @@ base mixin DartAnalyzerSupport on ToolsSupport, LoggingSupport {
   static final analyzeFilesTool = Tool(
     name: 'analyze_files',
     description: 'Analyzes the entire project for errors.',
-    inputSchema: ObjectSchema(),
+    inputSchema: Schema.object(),
+  );
+
+  @visibleForTesting
+  static final resolveWorkspaceSymbolTool = Tool(
+    name: 'resolve_workspace_symbol',
+    description: 'Resolves a given symbol or symbols in a workspace.',
+    inputSchema: Schema.object(
+      properties: {
+        'query': Schema.string(title: 'The query for the symbol(s) to look up'),
+      },
+      required: ['query'],
+    ),
   );
 }
 

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
@@ -337,13 +337,19 @@ base mixin DartAnalyzerSupport on ToolsSupport, LoggingSupport {
   @visibleForTesting
   static final resolveWorkspaceSymbolTool = Tool(
     name: 'resolve_workspace_symbol',
-    description: 'Resolves a given symbol or symbols in a workspace.',
+    description: 'Look up a symbol or symbols in all workspaces by name.',
     inputSchema: Schema.object(
       properties: {
-        'query': Schema.string(title: 'The query for the symbol(s) to look up'),
+        'query': Schema.string(
+          description:
+              'Queries are matched based on a case-insensitive partial name '
+              'match, and do not support complex pattern matching, regexes, '
+              'or scoped lookups.',
+        ),
       },
       required: ['query'],
     ),
+    annotations: ToolAnnotations(title: 'Project search', readOnlyHint: true),
   );
 }
 

--- a/pkgs/dart_tooling_mcp_server/test/tools/analyzer_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/analyzer_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:dart_mcp/server.dart';
 import 'package:dart_tooling_mcp_server/src/mixins/analyzer.dart';
 import 'package:test/test.dart';
@@ -83,6 +85,29 @@ void main() {
       expect(
         result.content.single,
         isA<TextContent>().having((t) => t.text, 'text', 'No errors'),
+      );
+    });
+
+    test('can look up symbols in a workspace', () async {
+      final currentRoot = rootForPath(Directory.current.path);
+      testHarness.mcpClient.addRoot(currentRoot);
+      await pumpEventQueue();
+
+      final result = await testHarness.callToolWithRetry(
+        CallToolRequest(
+          name: DartAnalyzerSupport.resolveWorkspaceSymbolTool.name,
+          arguments: {'query': 'DartAnalyzerSupport'},
+        ),
+      );
+      expect(result.isError, isNot(true));
+
+      expect(
+        result.content.single,
+        isA<TextContent>().having(
+          (t) => t.text,
+          'text',
+          contains('analyzer.dart'),
+        ),
       );
     });
   });


### PR DESCRIPTION
This allows you to ask things like "Tell me about <class-name> in my project" and it will tell you where it is located.

Follow on features will allow for looking up more detailed information about the symbol such as its doc comments and API.