### PR TITLE
Break pub tools out into their own support mixin

### DIFF
--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/dart_cli.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/dart_cli.dart
@@ -3,10 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:dart_mcp/server.dart';
 
+import '../utils/cli_utils.dart';
 import '../utils/process_manager.dart';
 
 // TODO: migrate the analyze files tool to use this mixin and run the
@@ -28,198 +28,29 @@ base mixin DartCliSupport on ToolsSupport, LoggingSupport
     }
     registerTool(dartFixTool, _runDartFixTool);
     registerTool(dartFormatTool, _runDartFormatTool);
-    registerTool(dartPubTool, _runDartPubTool);
     return super.initialize(request);
   }
 
   /// Implementation of the [dartFixTool].
   Future<CallToolResult> _runDartFixTool(CallToolRequest request) async {
-    return _runDartCommandInRoots(
+    return runCommandInRoots(
       request,
+      command: ['dart', 'fix', '--apply'],
       commandDescription: 'dart fix',
-      commandArgs: ['fix', '--apply'],
+      processManager: processManager,
     );
   }
 
   /// Implementation of the [dartFormatTool].
   Future<CallToolResult> _runDartFormatTool(CallToolRequest request) async {
-    return _runDartCommandInRoots(
+    return runCommandInRoots(
       request,
+      command: ['dart', 'format'],
       commandDescription: 'dart format',
-      commandArgs: ['format'],
+      processManager: processManager,
       defaultPaths: ['.'],
     );
   }
-
-  /// Implementation of the [dartPubTool].
-  Future<CallToolResult> _runDartPubTool(CallToolRequest request) async {
-    final command = request.arguments?['command'] as String?;
-    if (command == null) {
-      return CallToolResult(
-        content: [TextContent(text: 'Missing required argument `command`.')],
-        isError: true,
-      );
-    }
-    final matchingCommand = SupportedPubCommand.fromName(command);
-    if (matchingCommand == null) {
-      return CallToolResult(
-        content: [
-          TextContent(
-            text:
-                'Unsupported pub command `$command`. Currently, the supported '
-                'commands are: '
-                '${SupportedPubCommand.values.map((e) => e.name).join(', ')}',
-          ),
-        ],
-        isError: true,
-      );
-    }
-
-    final packageName = request.arguments?['packageName'] as String?;
-    if (matchingCommand.requiresPackageName && packageName == null) {
-      return CallToolResult(
-        content: [
-          TextContent(
-            text:
-                'Missing required argument `packageName` for the `$command` '
-                'command.',
-          ),
-        ],
-        isError: true,
-      );
-    }
-
-    return _runDartCommandInRoots(
-      request,
-      commandDescription: 'dart pub $command',
-      commandArgs: ['pub', command, if (packageName != null) packageName],
-    );
-  }
-
-  /// Helper to run a dart command in multiple project roots.
-  ///
-  /// [defaultPaths] may be specified if one or more path arguments are required
-  /// for the dart command (e.g. `dart format <default paths>`).
-  Future<CallToolResult> _runDartCommandInRoots(
-    CallToolRequest request, {
-    required String commandDescription,
-    required List<String> commandArgs,
-    List<String> defaultPaths = const <String>[],
-  }) async {
-    final rootConfigs =
-        (request.arguments?['roots'] as List?)?.cast<Map<String, Object?>>();
-    if (rootConfigs == null) {
-      return CallToolResult(
-        content: [TextContent(text: 'Missing required argument `roots`.')],
-        isError: true,
-      );
-    }
-
-    final outputs = <TextContent>[];
-    for (var rootConfig in rootConfigs) {
-      final rootUriString = rootConfig['root'] as String?;
-      if (rootUriString == null) {
-        // This shouldn't happen based on the schema, but handle defensively.
-        return CallToolResult(
-          content: [
-            TextContent(
-              text: 'Invalid root configuration: missing `root` key.',
-            ),
-          ],
-          isError: true,
-        );
-      }
-
-      final rootUri = Uri.parse(rootUriString);
-      if (rootUri.scheme != 'file') {
-        return CallToolResult(
-          content: [
-            TextContent(
-              text:
-                  'Only file scheme uris are allowed for roots, but got '
-                  '$rootUri',
-            ),
-          ],
-          isError: true,
-        );
-      }
-      final projectRoot = Directory(rootUri.toFilePath());
-
-      final paths = (rootConfig['paths'] as List?)?.cast<String>();
-      if (paths != null) {
-        commandArgs.addAll(paths);
-      } else {
-        commandArgs.addAll(defaultPaths);
-      }
-
-      final result = await processManager.run(
-        ['dart', ...commandArgs],
-        workingDirectory: projectRoot.path,
-        runInShell: true,
-      );
-
-      final output = (result.stdout as String).trim();
-      final errors = (result.stderr as String).trim();
-      if (result.exitCode != 0) {
-        return CallToolResult(
-          content: [
-            TextContent(
-              text:
-                  '$commandDescription failed in ${projectRoot.path}:\n'
-                  '$output\n\nErrors\n$errors',
-            ),
-          ],
-          isError: true,
-        );
-      }
-      if (output.isNotEmpty) {
-        outputs.add(
-          TextContent(
-            text: '$commandDescription in ${projectRoot.path}:\n$output',
-          ),
-        );
-      }
-    }
-    return CallToolResult(content: outputs);
-  }
-
-  static final dartPubTool = Tool(
-    name: 'dart_pub',
-    description:
-        'Runs a dart pub command for the given project roots, like `dart pub '
-        'get` or `dart pub add`.',
-    inputSchema: ObjectSchema(
-      properties: {
-        'command': StringSchema(
-          title: 'The dart pub command to run.',
-          description:
-              'Currently only ${SupportedPubCommand.listAll} are supported.',
-        ),
-        'packageName': StringSchema(
-          title: 'The package name to run the command for.',
-          description:
-              'This is required for the '
-              '${SupportedPubCommand.listAllThatRequirePackageName} commands.',
-        ),
-        'roots': ListSchema(
-          title: 'All projects roots to run the dart pub command in.',
-          description:
-              'These must match a root returned by a call to "listRoots".',
-          items: ObjectSchema(
-            properties: {
-              'root': StringSchema(
-                title:
-                    'The URI of the project root to run the dart pub command '
-                    'in.',
-              ),
-            },
-            required: ['root'],
-          ),
-        ),
-      },
-      required: ['command', 'roots'],
-    ),
-  );
 
   static final dartFixTool = Tool(
     name: 'dart_fix',
@@ -273,56 +104,4 @@ base mixin DartCliSupport on ToolsSupport, LoggingSupport
       required: ['roots'],
     ),
   );
-}
-
-/// The set of supported `dart pub` subcommands.
-enum SupportedPubCommand {
-  // This is supported in a simplified form: `dart pub add <package-name>`.
-  // TODO(https://github.com/dart-lang/ai/issues/77): add support for adding
-  //  dev dependencies.
-  add(requiresPackageName: true),
-
-  get,
-
-  // This is supported in a simplified form: `dart pub remove <package-name>`.
-  remove(requiresPackageName: true),
-
-  upgrade;
-
-  const SupportedPubCommand({this.requiresPackageName = false});
-
-  final bool requiresPackageName;
-
-  static SupportedPubCommand? fromName(String name) {
-    for (final command in SupportedPubCommand.values) {
-      if (command.name == name) {
-        return command;
-      }
-    }
-    return null;
-  }
-
-  static String get listAll {
-    return _writeCommandsAsList(SupportedPubCommand.values);
-  }
-
-  static String get listAllThatRequirePackageName {
-    return _writeCommandsAsList(
-      SupportedPubCommand.values.where((c) => c.requiresPackageName).toList(),
-    );
-  }
-
-  static String _writeCommandsAsList(List<SupportedPubCommand> commands) {
-    final buffer = StringBuffer();
-    for (var i = 0; i < commands.length; i++) {
-      final commandName = commands[i].name;
-      buffer.write('`$commandName`');
-      if (i < commands.length - 2) {
-        buffer.write(', ');
-      } else if (i == commands.length - 2) {
-        buffer.write(' and ');
-      }
-    }
-    return buffer.toString();
-  }
 }

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/pub.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/pub.dart
@@ -1,0 +1,170 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:dart_mcp/server.dart';
+
+import '../utils/cli_utils.dart';
+import '../utils/process_manager.dart';
+
+// TODO: migrate the analyze files tool to use this mixin and run the
+// `dart analyze` command instead of the analyzer package.
+
+/// Mix this in to any MCPServer to add support for running Dart CLI commands
+/// like `dart fix` and `dart format`.
+///
+/// The MCPServer must already have the [ToolsSupport] and [LoggingSupport]
+/// mixins applied.
+base mixin PubSupport on ToolsSupport, LoggingSupport
+    implements ProcessManagerSupport {
+  @override
+  FutureOr<InitializeResult> initialize(InitializeRequest request) {
+    if (request.capabilities.roots == null) {
+      throw StateError(
+        'This server requires the "roots" capability to be implemented.',
+      );
+    }
+    registerTool(pubTool, _runDartPubTool);
+    return super.initialize(request);
+  }
+
+  /// Implementation of the [pubTool].
+  Future<CallToolResult> _runDartPubTool(CallToolRequest request) async {
+    final command = request.arguments?['command'] as String?;
+    if (command == null) {
+      return CallToolResult(
+        content: [TextContent(text: 'Missing required argument `command`.')],
+        isError: true,
+      );
+    }
+    final matchingCommand = SupportedPubCommand.fromName(command);
+    if (matchingCommand == null) {
+      return CallToolResult(
+        content: [
+          TextContent(
+            text:
+                'Unsupported pub command `$command`. Currently, the supported '
+                'commands are: '
+                '${SupportedPubCommand.values.map((e) => e.name).join(', ')}',
+          ),
+        ],
+        isError: true,
+      );
+    }
+
+    final packageName = request.arguments?['packageName'] as String?;
+    if (matchingCommand.requiresPackageName && packageName == null) {
+      return CallToolResult(
+        content: [
+          TextContent(
+            text:
+                'Missing required argument `packageName` for the `$command` '
+                'command.',
+          ),
+        ],
+        isError: true,
+      );
+    }
+
+    return runCommandInRoots(
+      request,
+      // TODO(https://github.com/dart-lang/ai/issues/81): conditionally use
+      //  flutter when appropriate.
+      command: ['dart', 'pub', command, if (packageName != null) packageName],
+      commandDescription: 'dart pub $command',
+      processManager: processManager,
+    );
+  }
+
+  static final pubTool = Tool(
+    name: 'pub',
+    description:
+        'Runs a dart pub command for the given project roots, like `dart pub '
+        'get` or `dart pub add`.',
+    inputSchema: ObjectSchema(
+      properties: {
+        'command': StringSchema(
+          title: 'The dart pub command to run.',
+          description:
+              'Currently only ${SupportedPubCommand.listAll} are supported.',
+        ),
+        'packageName': StringSchema(
+          title: 'The package name to run the command for.',
+          description:
+              'This is required for the '
+              '${SupportedPubCommand.listAllThatRequirePackageName} commands.',
+        ),
+        'roots': ListSchema(
+          title: 'All projects roots to run the dart pub command in.',
+          description:
+              'These must match a root returned by a call to "listRoots".',
+          items: ObjectSchema(
+            properties: {
+              'root': StringSchema(
+                title:
+                    'The URI of the project root to run the dart pub command '
+                    'in.',
+              ),
+            },
+            required: ['root'],
+          ),
+        ),
+      },
+      required: ['command', 'roots'],
+    ),
+  );
+}
+
+/// The set of supported `dart pub` subcommands.
+enum SupportedPubCommand {
+  // This is supported in a simplified form: `dart pub add <package-name>`.
+  // TODO(https://github.com/dart-lang/ai/issues/77): add support for adding
+  //  dev dependencies.
+  add(requiresPackageName: true),
+
+  get,
+
+  // This is supported in a simplified form: `dart pub remove <package-name>`.
+  remove(requiresPackageName: true),
+
+  upgrade;
+
+  const SupportedPubCommand({this.requiresPackageName = false});
+
+  final bool requiresPackageName;
+
+  static SupportedPubCommand? fromName(String name) {
+    for (final command in SupportedPubCommand.values) {
+      if (command.name == name) {
+        return command;
+      }
+    }
+    return null;
+  }
+
+  static String get listAll {
+    return _writeCommandsAsList(SupportedPubCommand.values);
+  }
+
+  static String get listAllThatRequirePackageName {
+    return _writeCommandsAsList(
+      SupportedPubCommand.values.where((c) => c.requiresPackageName).toList(),
+    );
+  }
+
+  static String _writeCommandsAsList(List<SupportedPubCommand> commands) {
+    final buffer = StringBuffer();
+    for (var i = 0; i < commands.length; i++) {
+      final commandName = commands[i].name;
+      buffer.write('`$commandName`');
+      if (i < commands.length - 2) {
+        buffer.write(', ');
+      } else if (i == commands.length - 2) {
+        buffer.write(' and ');
+      }
+    }
+    return buffer.toString();
+  }
+}

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/pub.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/pub.dart
@@ -9,11 +9,10 @@ import 'package:dart_mcp/server.dart';
 import '../utils/cli_utils.dart';
 import '../utils/process_manager.dart';
 
-// TODO: migrate the analyze files tool to use this mixin and run the
-// `dart analyze` command instead of the analyzer package.
-
-/// Mix this in to any MCPServer to add support for running Dart CLI commands
-/// like `dart fix` and `dart format`.
+/// Mix this in to any MCPServer to add support for running Pub commands like
+/// like `pub add` and `pub get`.
+///
+/// See [SupportedPubCommand] for the set of currently supported pub commands.
 ///
 /// The MCPServer must already have the [ToolsSupport] and [LoggingSupport]
 /// mixins applied.
@@ -21,11 +20,6 @@ base mixin PubSupport on ToolsSupport, LoggingSupport
     implements ProcessManagerSupport {
   @override
   FutureOr<InitializeResult> initialize(InitializeRequest request) {
-    if (request.capabilities.roots == null) {
-      throw StateError(
-        'This server requires the "roots" capability to be implemented.',
-      );
-    }
     registerTool(pubTool, _runDartPubTool);
     return super.initialize(request);
   }

--- a/pkgs/dart_tooling_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/server.dart
@@ -12,6 +12,7 @@ import 'package:stream_channel/stream_channel.dart';
 import 'mixins/analyzer.dart';
 import 'mixins/dart_cli.dart';
 import 'mixins/dtd.dart';
+import 'mixins/pub.dart';
 import 'utils/process_manager.dart';
 
 /// An MCP server for Dart and Flutter tooling.
@@ -21,6 +22,7 @@ final class DartToolingMCPServer extends MCPServer
         ToolsSupport,
         DartAnalyzerSupport,
         DartCliSupport,
+        PubSupport,
         DartToolingDaemonSupport
     implements ProcessManagerSupport {
   DartToolingMCPServer({

--- a/pkgs/dart_tooling_mcp_server/lib/src/utils/cli_utils.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/utils/cli_utils.dart
@@ -1,0 +1,94 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:dart_mcp/server.dart';
+import 'package:process/process.dart';
+
+/// Helper to run a command in multiple project roots.
+///
+/// [defaultPaths] may be specified if one or more path arguments are required
+/// for the command (e.g. `dart format <default paths>`).
+Future<CallToolResult> runCommandInRoots(
+  CallToolRequest request, {
+  required List<String> command,
+  required String commandDescription,
+  required ProcessManager processManager,
+  List<String> defaultPaths = const <String>[],
+}) async {
+  final rootConfigs =
+      (request.arguments?['roots'] as List?)?.cast<Map<String, Object?>>();
+  if (rootConfigs == null) {
+    return CallToolResult(
+      content: [TextContent(text: 'Missing required argument `roots`.')],
+      isError: true,
+    );
+  }
+
+  final outputs = <TextContent>[];
+  for (var rootConfig in rootConfigs) {
+    final rootUriString = rootConfig['root'] as String?;
+    if (rootUriString == null) {
+      // This shouldn't happen based on the schema, but handle defensively.
+      return CallToolResult(
+        content: [
+          TextContent(text: 'Invalid root configuration: missing `root` key.'),
+        ],
+        isError: true,
+      );
+    }
+
+    final rootUri = Uri.parse(rootUriString);
+    if (rootUri.scheme != 'file') {
+      return CallToolResult(
+        content: [
+          TextContent(
+            text:
+                'Only file scheme uris are allowed for roots, but got '
+                '$rootUri',
+          ),
+        ],
+        isError: true,
+      );
+    }
+    final projectRoot = Directory(rootUri.toFilePath());
+
+    final paths = (rootConfig['paths'] as List?)?.cast<String>();
+    if (paths != null) {
+      command.addAll(paths);
+    } else {
+      command.addAll(defaultPaths);
+    }
+
+    final result = await processManager.run(
+      command,
+      workingDirectory: projectRoot.path,
+      runInShell: true,
+    );
+
+    final output = (result.stdout as String).trim();
+    final errors = (result.stderr as String).trim();
+    if (result.exitCode != 0) {
+      return CallToolResult(
+        content: [
+          TextContent(
+            text:
+                '$commandDescription failed in ${projectRoot.path}:\n'
+                '$output\n\nErrors\n$errors',
+          ),
+        ],
+        isError: true,
+      );
+    }
+    if (output.isNotEmpty) {
+      outputs.add(
+        TextContent(
+          text: '$commandDescription in ${projectRoot.path}:\n$output',
+        ),
+      );
+    }
+  }
+  return CallToolResult(content: outputs);
+}

--- a/pkgs/dart_tooling_mcp_server/test/tools/dart_cli_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/dart_cli_test.dart
@@ -32,7 +32,6 @@ void main() {
   group('dart cli tools', () {
     late Tool dartFixTool;
     late Tool dartFormatTool;
-    late Tool dartPubTool;
 
     setUp(() async {
       final tools = (await testHarness.mcpServerConnection.listTools()).tools;
@@ -41,9 +40,6 @@ void main() {
       );
       dartFormatTool = tools.singleWhere(
         (t) => t.name == DartCliSupport.dartFormatTool.name,
-      );
-      dartPubTool = tools.singleWhere(
-        (t) => t.name == DartCliSupport.dartPubTool.name,
       );
     });
 
@@ -102,158 +98,6 @@ void main() {
       expect(testProcessManager.commandsRan, [
         ['dart', 'format', 'foo.dart', 'bar.dart'],
       ]);
-    });
-
-    group('dart pub', () {
-      test('add', () async {
-        final request = CallToolRequest(
-          name: dartPubTool.name,
-          arguments: {
-            'command': 'add',
-            'packageName': 'foo',
-            'roots': [
-              {'root': testRoot.uri},
-            ],
-          },
-        );
-        final result = await testHarness.callToolWithRetry(request);
-
-        // Verify the command was sent to the process maanger without error.
-        expect(result.isError, isNot(true));
-        expect(testProcessManager.commandsRan, [
-          ['dart', 'pub', 'add', 'foo'],
-        ]);
-      });
-
-      test('remove', () async {
-        final request = CallToolRequest(
-          name: dartPubTool.name,
-          arguments: {
-            'command': 'remove',
-            'packageName': 'foo',
-            'roots': [
-              {'root': testRoot.uri},
-            ],
-          },
-        );
-        final result = await testHarness.callToolWithRetry(request);
-
-        // Verify the command was sent to the process maanger without error.
-        expect(result.isError, isNot(true));
-        expect(testProcessManager.commandsRan, [
-          ['dart', 'pub', 'remove', 'foo'],
-        ]);
-      });
-
-      test('get', () async {
-        final request = CallToolRequest(
-          name: dartPubTool.name,
-          arguments: {
-            'command': 'get',
-            'roots': [
-              {'root': testRoot.uri},
-            ],
-          },
-        );
-        final result = await testHarness.callToolWithRetry(request);
-
-        // Verify the command was sent to the process maanger without error.
-        expect(result.isError, isNot(true));
-        expect(testProcessManager.commandsRan, [
-          ['dart', 'pub', 'get'],
-        ]);
-      });
-
-      test('upgrade', () async {
-        final request = CallToolRequest(
-          name: dartPubTool.name,
-          arguments: {
-            'command': 'upgrade',
-            'roots': [
-              {'root': testRoot.uri},
-            ],
-          },
-        );
-        final result = await testHarness.callToolWithRetry(request);
-
-        // Verify the command was sent to the process maanger without error.
-        expect(result.isError, isNot(true));
-        expect(testProcessManager.commandsRan, [
-          ['dart', 'pub', 'upgrade'],
-        ]);
-      });
-
-      group('returns error', () {
-        test('for missing command', () async {
-          final request = CallToolRequest(name: dartPubTool.name);
-          final result = await testHarness.callToolWithRetry(
-            request,
-            expectError: true,
-          );
-
-          expect(
-            (result.content.single as TextContent).text,
-            'Missing required argument `command`.',
-          );
-          expect(testProcessManager.commandsRan, isEmpty);
-        });
-
-        test('for unsupported command', () async {
-          final request = CallToolRequest(
-            name: dartPubTool.name,
-            arguments: {'command': 'publish'},
-          );
-          final result = await testHarness.callToolWithRetry(
-            request,
-            expectError: true,
-          );
-
-          expect(
-            (result.content.single as TextContent).text,
-            contains('Unsupported pub command `publish`.'),
-          );
-          expect(testProcessManager.commandsRan, isEmpty);
-        });
-
-        for (final command in SupportedPubCommand.values.where(
-          (c) => c.requiresPackageName,
-        )) {
-          test('for missing package name: $command', () async {
-            final request = CallToolRequest(
-              name: dartPubTool.name,
-              arguments: {'command': command.name},
-            );
-            final result = await testHarness.callToolWithRetry(
-              request,
-              expectError: true,
-            );
-
-            expect(
-              (result.content.single as TextContent).text,
-              'Missing required argument `packageName` for the '
-              '`${command.name}` command.',
-            );
-            expect(testProcessManager.commandsRan, isEmpty);
-          });
-        }
-
-        test('for missing roots', () async {
-          final request = CallToolRequest(
-            name: dartPubTool.name,
-            arguments: {'command': 'get'},
-          );
-          final result = await testHarness.callToolWithRetry(
-            request,
-            expectError: true,
-          );
-
-          expect(
-            (result.content.single as TextContent).text,
-            'Missing required argument `roots`.',
-          );
-          expect(testProcessManager.commandsRan, isEmpty);
-        });
-      });
     });
   });
 }

--- a/pkgs/dart_tooling_mcp_server/test/tools/pub_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/pub_test.dart
@@ -1,0 +1,188 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dart_mcp/server.dart';
+import 'package:dart_tooling_mcp_server/src/mixins/pub.dart';
+import 'package:test/test.dart';
+
+import '../test_harness.dart';
+
+void main() {
+  late TestHarness testHarness;
+  late TestProcessManager testProcessManager;
+
+  // This root is arbitrary for these tests since we are not actually running
+  // the CLI commands, but rather sending them through the
+  // [TestProcessManager] wrapper.
+  final testRoot = rootForPath(counterAppPath);
+
+  late Tool dartPubTool;
+
+  // TODO: Use setUpAll, currently this fails due to an apparent TestProcess
+  // issue.
+  setUp(() async {
+    testHarness = await TestHarness.start(inProcess: true);
+    testProcessManager =
+        testHarness.serverConnectionPair.server!.processManager
+            as TestProcessManager;
+
+    testHarness.mcpClient.addRoot(testRoot);
+    await pumpEventQueue();
+
+    final tools = (await testHarness.mcpServerConnection.listTools()).tools;
+    dartPubTool = tools.singleWhere((t) => t.name == PubSupport.pubTool.name);
+  });
+
+  group('pub tools', () {
+    test('add', () async {
+      final request = CallToolRequest(
+        name: dartPubTool.name,
+        arguments: {
+          'command': 'add',
+          'packageName': 'foo',
+          'roots': [
+            {'root': testRoot.uri},
+          ],
+        },
+      );
+      final result = await testHarness.callToolWithRetry(request);
+
+      // Verify the command was sent to the process maanger without error.
+      expect(result.isError, isNot(true));
+      expect(testProcessManager.commandsRan, [
+        ['dart', 'pub', 'add', 'foo'],
+      ]);
+    });
+
+    test('remove', () async {
+      final request = CallToolRequest(
+        name: dartPubTool.name,
+        arguments: {
+          'command': 'remove',
+          'packageName': 'foo',
+          'roots': [
+            {'root': testRoot.uri},
+          ],
+        },
+      );
+      final result = await testHarness.callToolWithRetry(request);
+
+      // Verify the command was sent to the process maanger without error.
+      expect(result.isError, isNot(true));
+      expect(testProcessManager.commandsRan, [
+        ['dart', 'pub', 'remove', 'foo'],
+      ]);
+    });
+
+    test('get', () async {
+      final request = CallToolRequest(
+        name: dartPubTool.name,
+        arguments: {
+          'command': 'get',
+          'roots': [
+            {'root': testRoot.uri},
+          ],
+        },
+      );
+      final result = await testHarness.callToolWithRetry(request);
+
+      // Verify the command was sent to the process maanger without error.
+      expect(result.isError, isNot(true));
+      expect(testProcessManager.commandsRan, [
+        ['dart', 'pub', 'get'],
+      ]);
+    });
+
+    test('upgrade', () async {
+      final request = CallToolRequest(
+        name: dartPubTool.name,
+        arguments: {
+          'command': 'upgrade',
+          'roots': [
+            {'root': testRoot.uri},
+          ],
+        },
+      );
+      final result = await testHarness.callToolWithRetry(request);
+
+      // Verify the command was sent to the process maanger without error.
+      expect(result.isError, isNot(true));
+      expect(testProcessManager.commandsRan, [
+        ['dart', 'pub', 'upgrade'],
+      ]);
+    });
+
+    group('returns error', () {
+      test('for missing command', () async {
+        final request = CallToolRequest(name: dartPubTool.name);
+        final result = await testHarness.callToolWithRetry(
+          request,
+          expectError: true,
+        );
+
+        expect(
+          (result.content.single as TextContent).text,
+          'Missing required argument `command`.',
+        );
+        expect(testProcessManager.commandsRan, isEmpty);
+      });
+
+      test('for unsupported command', () async {
+        final request = CallToolRequest(
+          name: dartPubTool.name,
+          arguments: {'command': 'publish'},
+        );
+        final result = await testHarness.callToolWithRetry(
+          request,
+          expectError: true,
+        );
+
+        expect(
+          (result.content.single as TextContent).text,
+          contains('Unsupported pub command `publish`.'),
+        );
+        expect(testProcessManager.commandsRan, isEmpty);
+      });
+
+      for (final command in SupportedPubCommand.values.where(
+        (c) => c.requiresPackageName,
+      )) {
+        test('for missing package name: $command', () async {
+          final request = CallToolRequest(
+            name: dartPubTool.name,
+            arguments: {'command': command.name},
+          );
+          final result = await testHarness.callToolWithRetry(
+            request,
+            expectError: true,
+          );
+
+          expect(
+            (result.content.single as TextContent).text,
+            'Missing required argument `packageName` for the '
+            '`${command.name}` command.',
+          );
+          expect(testProcessManager.commandsRan, isEmpty);
+        });
+      }
+
+      test('for missing roots', () async {
+        final request = CallToolRequest(
+          name: dartPubTool.name,
+          arguments: {'command': 'get'},
+        );
+        final result = await testHarness.callToolWithRetry(
+          request,
+          expectError: true,
+        );
+
+        expect(
+          (result.content.single as TextContent).text,
+          'Missing required argument `roots`.',
+        );
+        expect(testProcessManager.commandsRan, isEmpty);
+      });
+    });
+  });
+}


### PR DESCRIPTION
This refactors the pub support to be part of its own support mixin instead of being part of the Dart CLI tools mixin. This is because once https://github.com/dart-lang/ai/issues/81 is resolved, this tool won't necessarily be using the Dart CLI or the Flutter CLI, but may use either.

This PR pulls out a utility method `runCommandInRoots` from the Dart CLI support mixin for reuse.