### PR TITLE
Add throttling for resource notifications

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -14,6 +14,10 @@
   - Handlers have to handle their own matching of templates.
 - Added a `RootsTrackingSupport` server mixin which can be used to keep an
   updated list of the roots set by the client.
+- Added default throttling with a 500ms delay for
+  `ResourceListChangedNotification`s and `ResourceUpdatedNotification`s. The
+  delay can be modified by overriding
+  `ResourcesSupport.resourceUpdateThrottleDelay`.
 - **Breaking**: Fixed paginated result subtypes to use `nextCursor` instead of
   `cursor` as the key for the next cursor.
 - **Breaking**: Change the `ProgressNotification.progress` and

--- a/pkgs/dart_mcp/lib/src/server/resources_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/resources_support.dart
@@ -45,7 +45,7 @@ base mixin ResourcesSupport on MCPServer {
   final StreamController<void> _resourceListChangedController =
       StreamController<void>();
 
-  /// At most updates for the same resource or list of resources will only be
+  /// At most, updates for the same resource or list of resources will only be
   /// sent once per this [Duration].
   ///
   /// Override this getter in subtypes in order to configure the delay.

--- a/pkgs/dart_mcp/lib/src/server/resources_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/resources_support.dart
@@ -38,7 +38,17 @@ base mixin ResourcesSupport on MCPServer {
   _resourceTemplates = [];
 
   /// The list of currently subscribed resources by URI.
-  final Set<String> _subscribedResources = {};
+  final Map<String, StreamController<ResourceUpdatedNotification>>
+  _subscribedResources = {};
+
+  final StreamController<void> _resourceListChangedController =
+      StreamController<void>();
+
+  /// At most updates for the same resource or list of resources will only be
+  /// sent once per this [Duration].
+  ///
+  /// Override this getter in subtypes in order to configure the delay.
+  Duration get resourceUpdateThrottleDelay => const Duration(milliseconds: 500);
 
   /// Invoked by the client as a part of initialization.
   ///
@@ -65,7 +75,24 @@ base mixin ResourcesSupport on MCPServer {
     (result.capabilities.resources ??= Resources())
       ..listChanged = true
       ..subscribe = true;
+    _resourceListChangedController.stream
+        .throttle(resourceUpdateThrottleDelay, trailing: true)
+        .listen(
+          (_) => sendNotification(
+            ResourceListChangedNotification.methodName,
+            ResourceListChangedNotification(),
+          ),
+        );
     return result;
+  }
+
+  @override
+  Future<void> shutdown() async {
+    await super.shutdown();
+    await _resourceListChangedController.close();
+    final subscribed = _subscribedResources.values.toList();
+    _subscribedResources.clear();
+    await Future.wait([for (var controller in subscribed) controller.close()]);
   }
 
   /// Register [resource] to call [impl] when invoked.
@@ -148,12 +175,9 @@ base mixin ResourcesSupport on MCPServer {
     }
     if (impl != null) _resourceImpls[resource.uri] = impl;
 
-    if (_subscribedResources.contains(resource.uri)) {
-      sendNotification(
-        ResourceUpdatedNotification.methodName,
-        ResourceUpdatedNotification(uri: resource.uri),
-      );
-    }
+    _subscribedResources[resource.uri]?.add(
+      ResourceUpdatedNotification(uri: resource.uri),
+    );
   }
 
   /// Removes a [Resource] by [uri].
@@ -199,22 +223,30 @@ base mixin ResourcesSupport on MCPServer {
       throw ArgumentError.value(request.uri, 'uri', 'Resource not found');
     }
 
-    _subscribedResources.add(request.uri);
+    _subscribedResources.putIfAbsent(
+      request.uri,
+      () =>
+          StreamController<ResourceUpdatedNotification>()
+            ..stream
+                .throttle(resourceUpdateThrottleDelay, trailing: true)
+                .listen((notification) {
+                  sendNotification(
+                    ResourceUpdatedNotification.methodName,
+                    notification,
+                  );
+                }),
+    );
 
     return EmptyResult();
   }
 
   /// Unsubscribes the client to the resource at `request.uri`.
-  FutureOr<EmptyResult> _unsubscribeResource(UnsubscribeRequest request) {
-    _subscribedResources.remove(request.uri);
-
+  Future<EmptyResult> _unsubscribeResource(UnsubscribeRequest request) async {
+    await _subscribedResources.remove(request.uri)?.close();
     return EmptyResult();
   }
 
   /// Called whenever the list of resources changes, it is the job of the client
   /// to then ask again for the list of tools.
-  void _notifyResourceListChanged() => sendNotification(
-    ResourceListChangedNotification.methodName,
-    ResourceListChangedNotification(),
-  );
+  void _notifyResourceListChanged() => _resourceListChangedController.add(null);
 }

--- a/pkgs/dart_mcp/lib/src/server/resources_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/resources_support.dart
@@ -93,7 +93,7 @@ base mixin ResourcesSupport on MCPServer {
     await _resourceListChangedController.close();
     final subscribed = _subscribedResources.values.toList();
     _subscribedResources.clear();
-    await Future.wait([for (var controller in subscribed) controller.close()]);
+    await subscribed.map((c) => c.close()).wait;
   }
 
   /// Register [resource] to call [impl] when invoked.

--- a/pkgs/dart_mcp/lib/src/server/resources_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/resources_support.dart
@@ -37,10 +37,11 @@ base mixin ResourcesSupport on MCPServer {
   final List<({ResourceTemplate template, ReadResourceHandler handler})>
   _resourceTemplates = [];
 
-  /// The list of currently subscribed resources by URI.
+  /// The currently subscribed resource [StreamController]s by URI.
   final Map<String, StreamController<ResourceUpdatedNotification>>
   _subscribedResources = {};
 
+  /// The [StreamController] which controls [ResourceListChangedNotification]s.
   final StreamController<void> _resourceListChangedController =
       StreamController<void>();
 

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:json_rpc_2/json_rpc_2.dart';
 import 'package:meta/meta.dart';
 import 'package:stream_channel/stream_channel.dart';
+import 'package:stream_transform/stream_transform.dart';
 
 import '../api/api.dart';
 import '../shared.dart';

--- a/pkgs/dart_mcp/pubspec.yaml
+++ b/pkgs/dart_mcp/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   json_rpc_2: ^3.0.3
   meta: ^1.16.0
   stream_channel: ^2.1.4
+  stream_transform: ^2.1.1
 
 dev_dependencies:
   args: ^2.7.0

--- a/pkgs/dart_mcp/test/resources_support_test.dart
+++ b/pkgs/dart_mcp/test/resources_support_test.dart
@@ -167,13 +167,8 @@ void main() {
     // Should get exactly two notifications even though we have more resources,
     // one initial notification and one after the throttle delay.
     await resourceListChangedQueue.take(2);
-    expect(
-      resourceListChangedQueue.hasNext.timeout(
-        const Duration(milliseconds: 10),
-        onTimeout: () => false,
-      ),
-      completion(false),
-    );
+    expect(resourceListChangedQueue.hasNext, completion(false));
+    await pumpEventQueue();
 
     final resourceChangedQueue = StreamQueue(serverConnection.resourceUpdated);
     final resource = resources.first;
@@ -200,13 +195,8 @@ void main() {
         ),
       );
     }
-    expect(
-      resourceChangedQueue.hasNext.timeout(
-        const Duration(milliseconds: 10),
-        onTimeout: () => false,
-      ),
-      completion(false),
-    );
+    expect(resourceChangedQueue.hasNext, completion(false));
+    await pumpEventQueue();
 
     await environment.shutdown();
   });
@@ -245,7 +235,7 @@ final class TestMCPServerWithResources extends TestMCPServer
     with ResourcesSupport {
   @override
   /// Shorten this delay for the test so they run quickly.
-  Duration get resourceUpdateThrottleDelay => const Duration(milliseconds: 1);
+  Duration get resourceUpdateThrottleDelay => Duration.zero;
 
   TestMCPServerWithResources({required super.channel});
 

--- a/pkgs/dart_mcp/test/resources_support_test.dart
+++ b/pkgs/dart_mcp/test/resources_support_test.dart
@@ -136,6 +136,81 @@ void main() {
     await environment.shutdown();
   });
 
+  test('resource change notifications are throttled', () async {
+    final environment = TestEnvironment(
+      TestMCPClient(),
+      (c) => TestMCPServerWithResources(channel: c),
+    );
+    await environment.initializeServer();
+
+    final serverConnection = environment.serverConnection;
+    final server = environment.server;
+
+    final resourceListChangedQueue = StreamQueue(
+      serverConnection.resourceListChanged,
+    );
+
+    final resources = [
+      for (var i = 0; i < 5; i++) Resource(name: '$i', uri: 'foo://$i'),
+    ];
+    for (var resource in resources) {
+      server.addResource(
+        resource,
+        (_) => ReadResourceResult(
+          contents: [
+            TextResourceContents(uri: resource.uri, text: resource.name),
+          ],
+        ),
+      );
+    }
+
+    // Should get exactly two notifications even though we have more resources,
+    // one initial notification and one after the throttle delay.
+    await resourceListChangedQueue.take(2);
+    expect(
+      resourceListChangedQueue.hasNext.timeout(
+        const Duration(milliseconds: 10),
+        onTimeout: () => false,
+      ),
+      completion(false),
+    );
+
+    final resourceChangedQueue = StreamQueue(serverConnection.resourceUpdated);
+    final resource = resources.first;
+    await serverConnection.subscribeResource(
+      SubscribeRequest(uri: resource.uri),
+    );
+    // Allow the subscription to propagate.
+    await pumpEventQueue();
+
+    // Send 5 notifications back to back.
+    for (var i = 0; i < 5; i++) {
+      server.updateResource(resource);
+    }
+
+    // Only two should make it through, one at the start and one after the
+    // timeout.
+    for (var i = 0; i < 2; i++) {
+      expect(
+        await resourceChangedQueue.next,
+        isA<ResourceUpdatedNotification>().having(
+          (n) => n.uri,
+          'uri',
+          resource.uri,
+        ),
+      );
+    }
+    expect(
+      resourceChangedQueue.hasNext.timeout(
+        const Duration(milliseconds: 10),
+        onTimeout: () => false,
+      ),
+      completion(false),
+    );
+
+    await environment.shutdown();
+  });
+
   test('Resource templates can be listed and queried', () async {
     final environment = TestEnvironment(
       TestMCPClient(),
@@ -168,6 +243,10 @@ void main() {
 
 final class TestMCPServerWithResources extends TestMCPServer
     with ResourcesSupport {
+  @override
+  /// Shorten this delay for the test so they run quickly.
+  Duration get resourceUpdateThrottleDelay => const Duration(milliseconds: 1);
+
   TestMCPServerWithResources({required super.channel});
 
   @override


### PR DESCRIPTION
This is in anticipation of potentially modeling runtime errors as resources, so they might be updated often. But it is in general a good practice to throttle these.