### PR TITLE
Making `instructions` optional.

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -27,6 +27,8 @@
   which has all supported versions and whether or not they are supported.
 - **Breaking**: Change `InitializeRequest` and `InitializeResult` to take a
   `ProtocolVersion` instead of a string.
+- **Breaking**: Change the `InitializaeResult`'s `instructions` to `String?` to reflect
+  that not all servers return instructions.
 
 ## 0.1.0
 

--- a/pkgs/dart_mcp/lib/src/api/initialization.dart
+++ b/pkgs/dart_mcp/lib/src/api/initialization.dart
@@ -82,7 +82,7 @@ extension type InitializeResult.fromMap(Map<String, Object?> _value)
   /// This can be used by clients to improve the LLM's understanding of
   /// available tools, resources, etc. It can be thought of like a "hint" to the
   /// model. For example, this information MAY be added to the system prompt.
-  String get instructions => _value['instructions'] as String;
+  String? get instructions => _value['instructions'] as String?;
 }
 
 /// This notification is sent from the client to the server after initialization

--- a/pkgs/dart_mcp/lib/src/api/initialization.dart
+++ b/pkgs/dart_mcp/lib/src/api/initialization.dart
@@ -45,7 +45,7 @@ extension type InitializeResult.fromMap(Map<String, Object?> _value)
     required ProtocolVersion protocolVersion,
     required ServerCapabilities serverCapabilities,
     required ServerImplementation serverInfo,
-    required String instructions,
+    String? instructions,
   }) => InitializeResult.fromMap({
     'protocolVersion': protocolVersion.versionString,
     'capabilities': serverCapabilities,


### PR DESCRIPTION
Fix for https://github.com/dart-lang/ai/issues/97

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
