### PR TITLE
Require roots for all CLI tools

### DIFF
--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
@@ -271,7 +271,7 @@ base mixin DartAnalyzerSupport
     return CallToolResult(content: [TextContent(text: jsonEncode(result))]);
   }
 
-  /// Ensures that all prerequites for any analysis task are met.
+  /// Ensures that all prerequisites for any analysis task are met.
   ///
   /// Returns an error response if any prerequisite is not met, otherwise
   /// returns `null`.

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/dart_cli.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/dart_cli.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:dart_mcp/server.dart';
 
 import '../utils/cli_utils.dart';
+import '../utils/constants.dart';
 import '../utils/process_manager.dart';
 
 // TODO: migrate the analyze files tool to use this mixin and run the
@@ -17,13 +18,19 @@ import '../utils/process_manager.dart';
 ///
 /// The MCPServer must already have the [ToolsSupport] and [LoggingSupport]
 /// mixins applied.
-base mixin DartCliSupport on ToolsSupport, LoggingSupport
+base mixin DartCliSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
     implements ProcessManagerSupport {
   @override
   FutureOr<InitializeResult> initialize(InitializeRequest request) {
-    registerTool(dartFixTool, _runDartFixTool);
-    registerTool(dartFormatTool, _runDartFormatTool);
-    return super.initialize(request);
+    try {
+      return super.initialize(request);
+    } finally {
+      // Can't call this until after `super.initialize`.
+      if (supportsRoots) {
+        registerTool(dartFixTool, _runDartFixTool);
+        registerTool(dartFormatTool, _runDartFormatTool);
+      }
+    }
   }
 
   /// Implementation of the [dartFixTool].
@@ -33,6 +40,7 @@ base mixin DartCliSupport on ToolsSupport, LoggingSupport
       command: ['dart', 'fix', '--apply'],
       commandDescription: 'dart fix',
       processManager: processManager,
+      knownRoots: await roots,
     );
   }
 
@@ -44,6 +52,7 @@ base mixin DartCliSupport on ToolsSupport, LoggingSupport
       commandDescription: 'dart format',
       processManager: processManager,
       defaultPaths: ['.'],
+      knownRoots: await roots,
     );
   }
 
@@ -52,22 +61,8 @@ base mixin DartCliSupport on ToolsSupport, LoggingSupport
     description: 'Runs `dart fix --apply` for the given project roots.',
     annotations: ToolAnnotations(title: 'Dart fix', destructiveHint: true),
     inputSchema: Schema.object(
-      properties: {
-        'roots': Schema.list(
-          title: 'All projects roots to run dart fix in.',
-          description:
-              'These must match a root returned by a call to "listRoots".',
-          items: Schema.object(
-            properties: {
-              'root': Schema.string(
-                title: 'The URI of the project root to run `dart fix` in.',
-              ),
-            },
-            required: ['root'],
-          ),
-        ),
-      },
-      required: ['roots'],
+      properties: {ParameterNames.roots: rootsSchema()},
+      required: [ParameterNames.roots],
     ),
   );
 
@@ -76,29 +71,8 @@ base mixin DartCliSupport on ToolsSupport, LoggingSupport
     description: 'Runs `dart format .` for the given project roots.',
     annotations: ToolAnnotations(title: 'Dart format', destructiveHint: true),
     inputSchema: Schema.object(
-      properties: {
-        'roots': Schema.list(
-          title: 'All projects roots to run dart format in.',
-          description:
-              'These must match a root returned by a call to "listRoots".',
-          items: Schema.object(
-            properties: {
-              'root': Schema.string(
-                title: 'The URI of the project root to run `dart format` in.',
-              ),
-              'paths': Schema.list(
-                title:
-                    'Relative or absolute paths to analyze under the '
-                    '"root". Paths must correspond to files and not '
-                    'directories.',
-                items: Schema.string(),
-              ),
-            },
-            required: ['root'],
-          ),
-        ),
-      },
-      required: ['roots'],
+      properties: {ParameterNames.roots: rootsSchema(supportsPaths: true)},
+      required: [ParameterNames.roots],
     ),
   );
 }

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/dart_cli.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/dart_cli.dart
@@ -62,7 +62,6 @@ base mixin DartCliSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
     annotations: ToolAnnotations(title: 'Dart fix', destructiveHint: true),
     inputSchema: Schema.object(
       properties: {ParameterNames.roots: rootsSchema()},
-      required: [ParameterNames.roots],
     ),
   );
 
@@ -72,7 +71,6 @@ base mixin DartCliSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
     annotations: ToolAnnotations(title: 'Dart format', destructiveHint: true),
     inputSchema: Schema.object(
       properties: {ParameterNames.roots: rootsSchema(supportsPaths: true)},
-      required: [ParameterNames.roots],
     ),
   );
 }

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/pub.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/pub.dart
@@ -21,8 +21,13 @@ base mixin PubSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
     implements ProcessManagerSupport {
   @override
   FutureOr<InitializeResult> initialize(InitializeRequest request) {
-    registerTool(pubTool, _runDartPubTool);
-    return super.initialize(request);
+    try {
+      return super.initialize(request);
+    } finally {
+      if (supportsRoots) {
+        registerTool(pubTool, _runDartPubTool);
+      }
+    }
   }
 
   /// Implementation of the [pubTool].

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/pub.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/pub.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:dart_mcp/server.dart';
 
 import '../utils/cli_utils.dart';
+import '../utils/constants.dart';
 import '../utils/process_manager.dart';
 
 /// Mix this in to any MCPServer to add support for running Pub commands like
@@ -16,7 +17,7 @@ import '../utils/process_manager.dart';
 ///
 /// The MCPServer must already have the [ToolsSupport] and [LoggingSupport]
 /// mixins applied.
-base mixin PubSupport on ToolsSupport, LoggingSupport
+base mixin PubSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
     implements ProcessManagerSupport {
   @override
   FutureOr<InitializeResult> initialize(InitializeRequest request) {
@@ -26,7 +27,7 @@ base mixin PubSupport on ToolsSupport, LoggingSupport
 
   /// Implementation of the [pubTool].
   Future<CallToolResult> _runDartPubTool(CallToolRequest request) async {
-    final command = request.arguments?['command'] as String?;
+    final command = request.arguments?[ParameterNames.command] as String?;
     if (command == null) {
       return CallToolResult(
         content: [TextContent(text: 'Missing required argument `command`.')],
@@ -48,7 +49,8 @@ base mixin PubSupport on ToolsSupport, LoggingSupport
       );
     }
 
-    final packageName = request.arguments?['packageName'] as String?;
+    final packageName =
+        request.arguments?[ParameterNames.packageName] as String?;
     if (matchingCommand.requiresPackageName && packageName == null) {
       return CallToolResult(
         content: [
@@ -69,6 +71,7 @@ base mixin PubSupport on ToolsSupport, LoggingSupport
       command: ['dart', 'pub', command, if (packageName != null) packageName],
       commandDescription: 'dart pub $command',
       processManager: processManager,
+      knownRoots: await roots,
     );
   }
 
@@ -80,34 +83,20 @@ base mixin PubSupport on ToolsSupport, LoggingSupport
     annotations: ToolAnnotations(title: 'pub', readOnlyHint: false),
     inputSchema: Schema.object(
       properties: {
-        'command': Schema.string(
+        ParameterNames.command: Schema.string(
           title: 'The dart pub command to run.',
           description:
               'Currently only ${SupportedPubCommand.listAll} are supported.',
         ),
-        'packageName': Schema.string(
+        ParameterNames.packageName: Schema.string(
           title: 'The package name to run the command for.',
           description:
               'This is required for the '
               '${SupportedPubCommand.listAllThatRequirePackageName} commands.',
         ),
-        'roots': Schema.list(
-          title: 'All projects roots to run the dart pub command in.',
-          description:
-              'These must match a root returned by a call to "listRoots".',
-          items: Schema.object(
-            properties: {
-              'root': Schema.string(
-                title:
-                    'The URI of the project root to run the dart pub command '
-                    'in.',
-              ),
-            },
-            required: ['root'],
-          ),
-        ),
+        ParameterNames.roots: rootsSchema(),
       },
-      required: ['command', 'roots'],
+      required: [ParameterNames.command, ParameterNames.roots],
     ),
   );
 }

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/pub.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/pub.dart
@@ -101,7 +101,7 @@ base mixin PubSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
         ),
         ParameterNames.roots: rootsSchema(),
       },
-      required: [ParameterNames.command, ParameterNames.roots],
+      required: [ParameterNames.command],
     ),
   );
 }

--- a/pkgs/dart_tooling_mcp_server/lib/src/utils/cli_utils.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/utils/cli_utils.dart
@@ -72,6 +72,7 @@ Future<CallToolResult> runCommandInRoots(
                 'registered project roots:\n\n${knownRoots.join('\n')}',
           ),
         ],
+        isError: true,
       );
     }
 
@@ -92,9 +93,13 @@ Future<CallToolResult> runCommandInRoots(
 
     final commandWithPaths = List.of(command);
     final paths =
-        (rootConfig[ParameterNames.paths] as List?)?.cast<String>() ??
+        (rootConfig[ParameterNames.paths] as List?)?.cast<String>().map(
+          (path) => rootUri.resolve(path).toString(),
+        ) ??
         defaultPaths;
-    final invalidPaths = paths.where((path) => !p.isWithin(rootUri.path, path));
+    final invalidPaths = paths.where(
+      (path) => !p.isWithin(rootUri.toString(), path),
+    );
     if (invalidPaths.isNotEmpty) {
       return CallToolResult(
         content: [

--- a/pkgs/dart_tooling_mcp_server/lib/src/utils/constants.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/utils/constants.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// A namespace for all the parameter names.
+extension ParameterNames on Never {
+  static const command = 'command';
+  static const packageName = 'packageName';
+  static const paths = 'paths';
+  static const root = 'root';
+  static const roots = 'roots';
+}

--- a/pkgs/dart_tooling_mcp_server/test/tools/dart_cli_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/dart_cli_test.dart
@@ -55,7 +55,7 @@ void main() {
       );
       final result = await testHarness.callToolWithRetry(request);
 
-      // Verify the command was sent to the process maanger without error.
+      // Verify the command was sent to the process manager without error.
       expect(result.isError, isNot(true));
       expect(testProcessManager.commandsRan, [
         ['dart', 'fix', '--apply'],
@@ -73,7 +73,7 @@ void main() {
       );
       final result = await testHarness.callToolWithRetry(request);
 
-      // Verify the command was sent to the process maanger without error.
+      // Verify the command was sent to the process manager without error.
       expect(result.isError, isNot(true));
       expect(testProcessManager.commandsRan, [
         ['dart', 'format', '.'],
@@ -94,7 +94,7 @@ void main() {
       );
       final result = await testHarness.callToolWithRetry(request);
 
-      // Verify the command was sent to the process maanger without error.
+      // Verify the command was sent to the process manager without error.
       expect(result.isError, isNot(true));
       expect(testProcessManager.commandsRan, [
         ['dart', 'format', 'foo.dart', 'bar.dart'],

--- a/pkgs/dart_tooling_mcp_server/test/tools/dart_cli_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/dart_cli_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:dart_mcp/server.dart';
 import 'package:dart_tooling_mcp_server/src/mixins/dart_cli.dart';
+import 'package:dart_tooling_mcp_server/src/utils/constants.dart';
 import 'package:test/test.dart';
 
 import '../test_harness.dart';
@@ -47,8 +48,8 @@ void main() {
       final request = CallToolRequest(
         name: dartFixTool.name,
         arguments: {
-          'roots': [
-            {'root': testRoot.uri},
+          ParameterNames.roots: [
+            {ParameterNames.root: testRoot.uri},
           ],
         },
       );
@@ -65,8 +66,8 @@ void main() {
       final request = CallToolRequest(
         name: dartFormatTool.name,
         arguments: {
-          'roots': [
-            {'root': testRoot.uri},
+          ParameterNames.roots: [
+            {ParameterNames.root: testRoot.uri},
           ],
         },
       );
@@ -83,10 +84,10 @@ void main() {
       final request = CallToolRequest(
         name: dartFormatTool.name,
         arguments: {
-          'roots': [
+          ParameterNames.roots: [
             {
-              'root': testRoot.uri,
-              'paths': ['foo.dart', 'bar.dart'],
+              ParameterNames.root: testRoot.uri,
+              ParameterNames.paths: ['foo.dart', 'bar.dart'],
             },
           ],
         },

--- a/pkgs/dart_tooling_mcp_server/test/tools/pub_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/pub_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:dart_mcp/server.dart';
 import 'package:dart_tooling_mcp_server/src/mixins/pub.dart';
+import 'package:dart_tooling_mcp_server/src/utils/constants.dart';
 import 'package:test/test.dart';
 
 import '../test_harness.dart';
@@ -39,10 +40,10 @@ void main() {
       final request = CallToolRequest(
         name: dartPubTool.name,
         arguments: {
-          'command': 'add',
-          'packageName': 'foo',
-          'roots': [
-            {'root': testRoot.uri},
+          ParameterNames.command: 'add',
+          ParameterNames.packageName: 'foo',
+          ParameterNames.roots: [
+            {ParameterNames.root: testRoot.uri},
           ],
         },
       );
@@ -59,10 +60,10 @@ void main() {
       final request = CallToolRequest(
         name: dartPubTool.name,
         arguments: {
-          'command': 'remove',
-          'packageName': 'foo',
-          'roots': [
-            {'root': testRoot.uri},
+          ParameterNames.command: 'remove',
+          ParameterNames.packageName: 'foo',
+          ParameterNames.roots: [
+            {ParameterNames.root: testRoot.uri},
           ],
         },
       );
@@ -79,9 +80,9 @@ void main() {
       final request = CallToolRequest(
         name: dartPubTool.name,
         arguments: {
-          'command': 'get',
-          'roots': [
-            {'root': testRoot.uri},
+          ParameterNames.command: 'get',
+          ParameterNames.roots: [
+            {ParameterNames.root: testRoot.uri},
           ],
         },
       );
@@ -98,9 +99,9 @@ void main() {
       final request = CallToolRequest(
         name: dartPubTool.name,
         arguments: {
-          'command': 'upgrade',
-          'roots': [
-            {'root': testRoot.uri},
+          ParameterNames.command: 'upgrade',
+          ParameterNames.roots: [
+            {ParameterNames.root: testRoot.uri},
           ],
         },
       );
@@ -131,7 +132,7 @@ void main() {
       test('for unsupported command', () async {
         final request = CallToolRequest(
           name: dartPubTool.name,
-          arguments: {'command': 'publish'},
+          arguments: {ParameterNames.command: 'publish'},
         );
         final result = await testHarness.callToolWithRetry(
           request,
@@ -151,7 +152,7 @@ void main() {
         test('for missing package name: $command', () async {
           final request = CallToolRequest(
             name: dartPubTool.name,
-            arguments: {'command': command.name},
+            arguments: {ParameterNames.command: command.name},
           );
           final result = await testHarness.callToolWithRetry(
             request,
@@ -170,7 +171,7 @@ void main() {
       test('for missing roots', () async {
         final request = CallToolRequest(
           name: dartPubTool.name,
-          arguments: {'command': 'get'},
+          arguments: {ParameterNames.command: 'get'},
         );
         final result = await testHarness.callToolWithRetry(
           request,

--- a/pkgs/dart_tooling_mcp_server/test/utils/cli_utils_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/utils/cli_utils_test.dart
@@ -1,0 +1,82 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dart_mcp/server.dart';
+import 'package:dart_tooling_mcp_server/src/utils/cli_utils.dart';
+import 'package:dart_tooling_mcp_server/src/utils/constants.dart';
+import 'package:process/process.dart';
+import 'package:test/fake.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final processManager = FakeProcessManager();
+
+  test('cannot run commands with roots outside of known roots', () async {
+    final result = await runCommandInRoots(
+      CallToolRequest(
+        name: 'foo',
+        arguments: {
+          ParameterNames.roots: [
+            {ParameterNames.root: 'file:///bar/'},
+          ],
+        },
+      ),
+      command: ['fake'],
+      commandDescription: '',
+      processManager: processManager,
+      knownRoots: [Root(uri: 'file:///foo/')],
+    );
+    expect(result.isError, isTrue);
+    expect(
+      result.content.single,
+      isA<TextContent>().having(
+        (t) => t.text,
+        'text',
+        contains('Invalid root file:///bar/'),
+      ),
+    );
+  });
+
+  test('cannot run commands with paths outside of known roots', () async {
+    final result = await runCommandInRoots(
+      CallToolRequest(
+        name: 'foo',
+        arguments: {
+          ParameterNames.roots: [
+            {
+              ParameterNames.root: 'file:///foo/',
+              ParameterNames.paths: [
+                'file:///bar/',
+                '../baz/',
+                'zip/../../zap/',
+                'ok.dart',
+              ],
+            },
+          ],
+        },
+      ),
+      command: ['fake'],
+      commandDescription: '',
+      processManager: processManager,
+      knownRoots: [Root(uri: 'file:///foo/')],
+    );
+    expect(result.isError, isTrue);
+    expect(
+      result.content.single,
+      isA<TextContent>().having(
+        (t) => t.text,
+        'text',
+        allOf(
+          contains('Paths are not allowed to escape their project root'),
+          contains('bar/'),
+          contains('baz/'),
+          contains('zap/'),
+          isNot(contains('ok.dart')),
+        ),
+      ),
+    );
+  });
+}
+
+class FakeProcessManager extends Fake implements ProcessManager {}


### PR DESCRIPTION
Updates all CLI tools to only allow them to be ran under one of the client specified roots.

- If paths are specified, those also must not escape the roots.
- Make roots not required any longer, use the client specified roots by default for all tools.
- Create some shared constants for argument names and a shared function to create the schemas for the roots parameters. 