### PR TITLE
add option to log protocol messages to a Sink<String>

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -18,6 +18,9 @@
   `ResourceListChangedNotification`s and `ResourceUpdatedNotification`s. The
   delay can be modified by overriding
   `ResourcesSupport.resourceUpdateThrottleDelay`.
+- Add `Sink<String> protocolLogSink` parameters to server constructor and client
+  connection methods, which can be used to capture protocol messages for
+  debugging purposes.
 - **Breaking**: Fixed paginated result subtypes to use `nextCursor` instead of
   `cursor` as the key for the next cursor.
 - **Breaking**: Change the `ProgressNotification.progress` and
@@ -27,6 +30,12 @@
   which has all supported versions and whether or not they are supported.
 - **Breaking**: Change `InitializeRequest` and `InitializeResult` to take a
   `ProtocolVersion` instead of a string.
+- **Breaking**: Change `MCPBase` to accept a `StreamChannel<String>` instead of
+  a `Peer`, and construct its own `Peer`.
+- **Breaking**: Add `protocolLogSink` optional parameter to connect methods on
+  `MCPClient`.
+- **Breaking**: Move `channel` parameter on `MCPServer.new` to a positional
+  parameter for consistency.
 
 ## 0.1.0
 

--- a/pkgs/dart_mcp/example/server.dart
+++ b/pkgs/dart_mcp/example/server.dart
@@ -12,7 +12,7 @@ import 'package:stream_channel/stream_channel.dart';
 
 void main() {
   DartMCPServer(
-    channel: StreamChannel.withCloseGuarantee(io.stdin, io.stdout)
+    StreamChannel.withCloseGuarantee(io.stdin, io.stdout)
         .transform(StreamChannelTransformer.fromCodec(utf8))
         .transformStream(const LineSplitter())
         .transformSink(
@@ -27,7 +27,7 @@ void main() {
 
 /// Our actual MCP server.
 base class DartMCPServer extends MCPServer with ToolsSupport {
-  DartMCPServer({required super.channel})
+  DartMCPServer(super.channel)
     : super.fromStreamChannel(
         implementation: ServerImplementation(
           name: 'example dart server',

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -9,7 +9,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:async/async.dart' hide Result;
-import 'package:json_rpc_2/json_rpc_2.dart';
 import 'package:meta/meta.dart';
 import 'package:stream_channel/stream_channel.dart';
 
@@ -52,10 +51,16 @@ base class MCPClient {
 
   /// Connect to a new MCP server by invoking [command] with [arguments] and
   /// talking to that process over stdin/stdout.
+  ///
+  ///
+  /// If [protocolLogSink] is provided, all messages sent between the client and
+  /// server will be forwarded to that [Sink] as well, with `<<<` preceding
+  /// incoming messages and `>>>` preceding outgoing messages.
   Future<ServerConnection> connectStdioServer(
     String command,
-    List<String> arguments,
-  ) async {
+    List<String> arguments, {
+    Sink<String>? protocolLogSink,
+  }) async {
     final process = await Process.start(command, arguments);
     process.stderr
         .transform(utf8.decoder)
@@ -83,12 +88,19 @@ base class MCPClient {
 
   /// Returns a connection for an MCP server using a [channel], which is already
   /// established.
-  ServerConnection connectServer(StreamChannel<String> channel) {
+  ///
+  /// If [protocolLogSink] is provided, all messages sent on [channel] will be
+  /// forwarded to that [Sink] as well, with `<<<` preceding incoming messages
+  /// and `>>>` preceding outgoing messages.
+  ServerConnection connectServer(
+    StreamChannel<String> channel, {
+    Sink<String>? protocolLogSink,
+  }) {
     // For type promotion in this function.
     final self = this;
-
     final connection = ServerConnection.fromStreamChannel(
       channel,
+      protocolLogSink: protocolLogSink,
       rootsSupport: self is RootsSupport ? self : null,
       samplingSupport: self is SamplingSupport ? self : null,
     );
@@ -185,10 +197,11 @@ base class ServerConnection extends MCPBase {
   /// If the client supports "sampling", then it should provide an
   /// implementation through [samplingSupport].
   ServerConnection.fromStreamChannel(
-    StreamChannel<String> channel, {
+    super.channel, {
+    super.protocolLogSink,
     RootsSupport? rootsSupport,
     SamplingSupport? samplingSupport,
-  }) : super(Peer(channel)) {
+  }) {
     if (rootsSupport != null) {
       registerRequestHandler(
         ListRootsRequest.methodName,

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -4,9 +4,7 @@
 
 import 'dart:async';
 
-import 'package:json_rpc_2/json_rpc_2.dart';
 import 'package:meta/meta.dart';
-import 'package:stream_channel/stream_channel.dart';
 import 'package:stream_transform/stream_transform.dart';
 
 import '../api/api.dart';
@@ -61,11 +59,12 @@ abstract base class MCPServer extends MCPBase {
       _rootsListChangedController?.stream;
   StreamController<RootsListChangedNotification>? _rootsListChangedController;
 
-  MCPServer.fromStreamChannel({
+  MCPServer.fromStreamChannel(
+    super.channel, {
     required this.implementation,
     required this.instructions,
-    required StreamChannel<String> channel,
-  }) : super(Peer(channel)) {
+    super.protocolLogSink,
+  }) {
     registerRequestHandler(InitializeRequest.methodName, initialize);
 
     registerNotificationHandler(

--- a/pkgs/dart_mcp/test/completions_test.dart
+++ b/pkgs/dart_mcp/test/completions_test.dart
@@ -13,7 +13,7 @@ void main() {
   test('client can request prompt completions', () async {
     final environment = TestEnvironment(
       TestMCPClient(),
-      (c) => TestMCPServerWithCompletions(channel: c),
+      TestMCPServerWithCompletions.new,
     );
     final initializeResult = await environment.initializeServer();
     expect(initializeResult.capabilities.completions, Completions());
@@ -41,7 +41,7 @@ void main() {
   test('client can request resource completions', () async {
     final environment = TestEnvironment(
       TestMCPClient(),
-      (c) => TestMCPServerWithCompletions(channel: c),
+      TestMCPServerWithCompletions.new,
     );
     final initializeResult = await environment.initializeServer();
     expect(initializeResult.capabilities.completions, Completions());
@@ -70,7 +70,7 @@ void main() {
 
 final class TestMCPServerWithCompletions extends TestMCPServer
     with CompletionsSupport {
-  TestMCPServerWithCompletions({required super.channel});
+  TestMCPServerWithCompletions(super.channel);
 
   @override
   FutureOr<CompleteResult> handleComplete(CompleteRequest request) {

--- a/pkgs/dart_mcp/test/logging_test.dart
+++ b/pkgs/dart_mcp/test/logging_test.dart
@@ -11,7 +11,7 @@ void main() {
   test('client can set the logging level', () async {
     final environment = TestEnvironment(
       TestMCPClient(),
-      (c) => TestMCPServerWithLogging(channel: c),
+      TestMCPServerWithLogging.new,
     );
     final initializeResult = await environment.initializeServer();
 
@@ -40,7 +40,7 @@ void main() {
   test('client can receive log messages', () async {
     final environment = TestEnvironment(
       TestMCPClient(),
-      (c) => TestMCPServerWithLogging(channel: c),
+      TestMCPServerWithLogging.new,
     );
     await environment.initializeServer();
 
@@ -95,7 +95,7 @@ void main() {
   test('server can log functions for lazy evaluation', () async {
     final environment = TestEnvironment(
       TestMCPClient(),
-      (c) => TestMCPServerWithLogging(channel: c),
+      TestMCPServerWithLogging.new,
     );
     await environment.initializeServer();
 
@@ -148,5 +148,5 @@ void main() {
 }
 
 final class TestMCPServerWithLogging extends TestMCPServer with LoggingSupport {
-  TestMCPServerWithLogging({required super.channel});
+  TestMCPServerWithLogging(super.channel);
 }

--- a/pkgs/dart_mcp/test/prompts_test.dart
+++ b/pkgs/dart_mcp/test/prompts_test.dart
@@ -13,7 +13,7 @@ void main() {
   test('client can list and get prompts from the server', () async {
     final environment = TestEnvironment(
       TestMCPClient(),
-      (c) => TestMCPServerWithPrompts(channel: c),
+      TestMCPServerWithPrompts.new,
     );
     final initializeResult = await environment.initializeServer();
 
@@ -48,7 +48,7 @@ void main() {
   test('client is notified of changes to prompts from the server', () async {
     final environment = TestEnvironment(
       TestMCPClient(),
-      (c) => TestMCPServerWithPrompts(channel: c),
+      TestMCPServerWithPrompts.new,
     );
     await environment.initializeServer();
 
@@ -78,7 +78,7 @@ void main() {
 }
 
 final class TestMCPServerWithPrompts extends TestMCPServer with PromptsSupport {
-  TestMCPServerWithPrompts({required super.channel});
+  TestMCPServerWithPrompts(super.channel);
 
   @override
   FutureOr<InitializeResult> initialize(InitializeRequest request) {

--- a/pkgs/dart_mcp/test/resources_support_test.dart
+++ b/pkgs/dart_mcp/test/resources_support_test.dart
@@ -16,7 +16,7 @@ void main() {
   test('client can read resources from the server', () async {
     final environment = TestEnvironment(
       TestMCPClient(),
-      (c) => TestMCPServerWithResources(channel: c),
+      TestMCPServerWithResources.new,
     );
     final initializeResult = await environment.initializeServer();
 
@@ -52,7 +52,7 @@ void main() {
   test('client can subscribe to resource updates from the server', () async {
     final environment = TestEnvironment(
       TestMCPClient(),
-      (c) => TestMCPServerWithResources(channel: c),
+      TestMCPServerWithResources.new,
     );
     await environment.initializeServer();
 
@@ -139,7 +139,7 @@ void main() {
   test('resource change notifications are throttled', () async {
     final environment = TestEnvironment(
       TestMCPClient(),
-      (c) => TestMCPServerWithResources(channel: c),
+      TestMCPServerWithResources.new,
     );
     await environment.initializeServer();
 
@@ -204,7 +204,7 @@ void main() {
   test('Resource templates can be listed and queried', () async {
     final environment = TestEnvironment(
       TestMCPClient(),
-      (c) => TestMCPServerWithResources(channel: c),
+      TestMCPServerWithResources.new,
     );
     await environment.initializeServer();
 
@@ -237,7 +237,7 @@ final class TestMCPServerWithResources extends TestMCPServer
   /// Shorten this delay for the test so they run quickly.
   Duration get resourceUpdateThrottleDelay => Duration.zero;
 
-  TestMCPServerWithResources({required super.channel});
+  TestMCPServerWithResources(super.channel);
 
   @override
   FutureOr<InitializeResult> initialize(InitializeRequest request) {

--- a/pkgs/dart_mcp/test/roots_test.dart
+++ b/pkgs/dart_mcp/test/roots_test.dart
@@ -12,7 +12,7 @@ void main() {
   test('server can list and subscribe to changes to roots', () async {
     final environment = TestEnvironment(
       TestMCPClientWithRoots(),
-      (c) => TestMCPServer(channel: c),
+      TestMCPServer.new,
     );
     await environment.initializeServer();
 

--- a/pkgs/dart_mcp/test/roots_tracking_support_test.dart
+++ b/pkgs/dart_mcp/test/roots_tracking_support_test.dart
@@ -13,7 +13,7 @@ void main() {
   test('server can track the workspace roots if enabled', () async {
     final environment = TestEnvironment(
       TestMCPClientWithRoots(),
-      (c) => TestMCPServerWithRootsTracking(channel: c),
+      TestMCPServerWithRootsTracking.new,
     );
     await environment.initializeServer();
 
@@ -72,5 +72,5 @@ final class TestMCPClientWithRoots extends TestMCPClient with RootsSupport {
 
 final class TestMCPServerWithRootsTracking extends TestMCPServer
     with LoggingSupport, RootsTrackingSupport {
-  TestMCPServerWithRootsTracking({required super.channel});
+  TestMCPServerWithRootsTracking(super.channel);
 }

--- a/pkgs/dart_mcp/test/sampling_test.dart
+++ b/pkgs/dart_mcp/test/sampling_test.dart
@@ -14,7 +14,7 @@ void main() {
   test('server can request LLM messages from the client', () async {
     final environment = TestEnvironment(
       SamplingTestMCPClient(),
-      (c) => TestMCPServer(channel: c),
+      TestMCPServer.new,
     );
     await environment.initializeServer();
     final server = environment.server;

--- a/pkgs/dart_mcp/test/tools_support_test.dart
+++ b/pkgs/dart_mcp/test/tools_support_test.dart
@@ -13,7 +13,7 @@ void main() {
   test('client can list and invoke tools from the server', () async {
     final environment = TestEnvironment(
       TestMCPClient(),
-      (c) => TestMCPServerWithTools(channel: c),
+      TestMCPServerWithTools.new,
     );
     final initializeResult = await environment.initializeServer();
     expect(
@@ -44,7 +44,7 @@ void main() {
   test('client can subscribe to tool list updates from the server', () async {
     final environment = TestEnvironment(
       TestMCPClient(),
-      (c) => TestMCPServerWithTools(channel: c),
+      TestMCPServerWithTools.new,
     );
     await environment.initializeServer();
 
@@ -241,7 +241,7 @@ void main() {
 }
 
 final class TestMCPServerWithTools extends TestMCPServer with ToolsSupport {
-  TestMCPServerWithTools({required super.channel});
+  TestMCPServerWithTools(super.channel);
 
   @override
   FutureOr<InitializeResult> initialize(InitializeRequest request) {

--- a/pkgs/dart_tooling_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/server.dart
@@ -26,8 +26,8 @@ final class DartToolingMCPServer extends MCPServer
         PubSupport,
         DartToolingDaemonSupport
     implements ProcessManagerSupport {
-  DartToolingMCPServer({
-    required super.channel,
+  DartToolingMCPServer(
+    super.channel, {
     @visibleForTesting this.processManager = const LocalProcessManager(),
   }) : super.fromStreamChannel(
          implementation: ServerImplementation(
@@ -42,7 +42,7 @@ final class DartToolingMCPServer extends MCPServer
   static Future<DartToolingMCPServer> connect(
     StreamChannel<String> mcpChannel,
   ) async {
-    return DartToolingMCPServer(channel: mcpChannel);
+    return DartToolingMCPServer(mcpChannel);
   }
 
   @override

--- a/pkgs/dart_tooling_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_tooling_mcp_server/test/test_harness.dart
@@ -356,7 +356,7 @@ Future<ServerConnectionPair> _initializeMCPServer(
       serverController.sink,
     );
     server = DartToolingMCPServer(
-      channel: serverChannel,
+      serverChannel,
       processManager: TestProcessManager(),
     );
     addTearDown(server.shutdown);


### PR DESCRIPTION
Closes https://github.com/dart-lang/ai/issues/4.

I also used this functionality to test the invalid protocol message flow, which does appear to work fine as is (json_rpc_2 handles it well for us), but is now tested.
