### PR TITLE
add test for server closing early to validate behavior

### DIFF
--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -264,6 +264,11 @@ base class ServerConnection extends MCPBase {
   ///
   /// The client must call [notifyInitialized] after receiving and accepting
   /// this response.
+  ///
+  /// Throws a [StateError] if initialization fails for unknown reasons (usually
+  /// the server connection closes prematurely due to misconfiguration). To
+  /// debug these errors you should pass a `protocolLogSink` when creating these
+  /// connection
   Future<InitializeResult> initialize(InitializeRequest request) async {
     final response = await sendRequest<InitializeResult>(
       InitializeRequest.methodName,

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -268,7 +268,7 @@ base class ServerConnection extends MCPBase {
   /// Throws a [StateError] if initialization fails for unknown reasons (usually
   /// the server connection closes prematurely due to misconfiguration). To
   /// debug these errors you should pass a `protocolLogSink` when creating these
-  /// connection
+  /// connections.
   Future<InitializeResult> initialize(InitializeRequest request) async {
     final response = await sendRequest<InitializeResult>(
       InitializeRequest.methodName,

--- a/pkgs/dart_mcp/pubspec.yaml
+++ b/pkgs/dart_mcp/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   async: ^2.13.0
   collection: ^1.19.1
-  json_rpc_2: ^3.0.3
+  json_rpc_2: '>=3.0.3 <5.0.0'
   meta: ^1.16.0
   stream_channel: ^2.1.4
   stream_transform: ^2.1.1

--- a/pkgs/dart_mcp/test/client_and_server_test.dart
+++ b/pkgs/dart_mcp/test/client_and_server_test.dart
@@ -320,6 +320,9 @@ void main() {
         ),
       );
 
+      // This shuts down the channel between the client and server, so it
+      // happens during the initialization request (which the server never)
+      // responds to.
       serverChannel.sink.close();
 
       addTearDown(() {

--- a/pkgs/dart_mcp/test/client_and_server_test.dart
+++ b/pkgs/dart_mcp/test/client_and_server_test.dart
@@ -9,6 +9,7 @@ import 'package:dart_mcp/client.dart';
 import 'package:dart_mcp/server.dart';
 import 'package:json_rpc_2/error_code.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';
+import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
 
 import 'test_utils.dart';
@@ -286,6 +287,45 @@ void main() {
         emitsThrough(allOf(startsWith('<<<'), contains('Invalid JSON'))),
       );
       expect(environment.initializeServer(), completes);
+    });
+
+    test('server exits before initialization', () {
+      final client = TestMCPClient();
+      final clientController = StreamController<String>();
+      final serverController = StreamController<String>();
+      final clientChannel = StreamChannel<String>.withGuarantees(
+        clientController.stream,
+        serverController.sink,
+      );
+      final serverChannel = StreamChannel<String>.withGuarantees(
+        serverController.stream,
+        clientController.sink,
+      );
+      final connection = client.connectServer(clientChannel);
+
+      expect(
+        connection.initialize(
+          InitializeRequest(
+            protocolVersion: ProtocolVersion.latestSupported,
+            capabilities: ClientCapabilities(),
+            clientInfo: ClientImplementation(name: '', version: ''),
+          ),
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            'The client closed with pending request "initialize".',
+          ),
+        ),
+      );
+
+      serverChannel.sink.close();
+
+      addTearDown(() {
+        expect(connection.isActive, false);
+        expect(client.connections, isEmpty);
+      });
     });
   });
 }


### PR DESCRIPTION
Related to https://github.com/dart-lang/ai/issues/96

- Tests the current behavior, ensures we aren't leaking exceptions beyond what is expected.
- Also documents explicitly the behavior in initialize to encourage exception handling, and helping you to debug.
