### PR TITLE
Continue making `instructions` optional.

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -32,8 +32,10 @@
   which has all supported versions and whether or not they are supported.
 - **Breaking**: Change `InitializeRequest` and `InitializeResult` to take a
   `ProtocolVersion` instead of a string.
-- **Breaking**: Change the `InitializeResult`'s `instructions` to `String?` to reflect
-  that not all servers return instructions.
+- **Breaking**: Change the `InitializeResult`'s `instructions` to `String?` to
+  reflect that not all servers return instructions.
+- Change the `MCPServer.fromStreamChannel` constructor to make the `instructions`
+  parameter optional.
 - **Breaking**: Change `MCPBase` to accept a `StreamChannel<String>` instead of
   a `Peer`, and construct its own `Peer`.
 - **Breaking**: Add `protocolLogSink` optional parameter to connect methods on

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -36,7 +36,7 @@ abstract base class MCPServer extends MCPBase {
   /// Instructions for how to use this server, which are given to the client.
   ///
   /// These may be used in system prompts.
-  final String instructions;
+  final String? instructions;
 
   /// The negotiated protocol version.
   ///
@@ -62,7 +62,7 @@ abstract base class MCPServer extends MCPBase {
   MCPServer.fromStreamChannel(
     super.channel, {
     required this.implementation,
-    required this.instructions,
+    this.instructions,
     super.protocolLogSink,
   }) {
     registerRequestHandler(InitializeRequest.methodName, initialize);


### PR DESCRIPTION
This is a continuation of https://github.com/dart-lang/ai/pull/98

PTAL @jakemac53 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
