### PR TITLE
add basic file system server example

### DIFF
--- a/pkgs/dart_mcp/example/file_system_server.dart
+++ b/pkgs/dart_mcp/example/file_system_server.dart
@@ -1,0 +1,150 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io' as io;
+
+import 'package:async/async.dart';
+import 'package:dart_mcp/server.dart';
+import 'package:path/path.dart' as p;
+import 'package:stream_channel/stream_channel.dart';
+
+void main() {
+  SimpleFileSystemServer.fromStreamChannel(
+    StreamChannel.withCloseGuarantee(io.stdin, io.stdout)
+        .transform(StreamChannelTransformer.fromCodec(utf8))
+        .transformStream(const LineSplitter())
+        .transformSink(
+          StreamSinkTransformer.fromHandlers(
+            handleData: (data, sink) {
+              sink.add('$data\n');
+            },
+          ),
+        ),
+  );
+}
+
+/// An basic file server implementation.
+///
+/// Only allows reading/writing to the tracked [roots], and only by utf8 string.
+final class SimpleFileSystemServer extends MCPServer
+    with LoggingSupport, RootsTrackingSupport, ToolsSupport {
+  SimpleFileSystemServer.fromStreamChannel(super.channel)
+    : super.fromStreamChannel(
+        implementation: ServerImplementation(
+          name: 'file system',
+          version: '0.0.1',
+        ),
+      );
+
+  @override
+  FutureOr<InitializeResult> initialize(InitializeRequest request) {
+    registerTool(readFileTool, _readFile);
+    registerTool(writeFileTool, _writeFile);
+    registerTool(deleteFileTool, _deleteFile);
+    return super.initialize(request);
+  }
+
+  /// Checks if [path] is under any of the known [roots], and if not returns
+  /// an error result.
+  ///
+  /// Returns `null` if [path] is valid.
+  Future<CallToolResult?> _checkAllowedPath(String path) async {
+    for (var root in await roots) {
+      if (root.uri == path || p.isWithin(root.uri, path)) {
+        return CallToolResult(
+          content: [
+            TextContent(
+              text: 'Path not allowed $path, must be under a known root.',
+            ),
+          ],
+          isError: true,
+        );
+      }
+    }
+    return null;
+  }
+
+  Future<CallToolResult> _writeFile(CallToolRequest request) async {
+    final path = request.arguments!['path'] as String;
+    final errorResult = await _checkAllowedPath(path);
+    if (errorResult != null) return errorResult;
+
+    final contents = request.arguments!['contents'] as String;
+    final file = io.File(path);
+    if (!await file.exists()) {
+      await file.create(recursive: true);
+    }
+    await file.writeAsString(contents);
+    return CallToolResult(content: [TextContent(text: 'Success')]);
+  }
+
+  Future<CallToolResult> _readFile(CallToolRequest request) async {
+    final path = request.arguments!['path'] as String;
+    final errorResult = await _checkAllowedPath(path);
+    if (errorResult != null) return errorResult;
+
+    final file = io.File(path);
+    if (!await file.exists()) {
+      return CallToolResult(
+        content: [TextContent(text: 'File does not exist')],
+      );
+    }
+    return CallToolResult(
+      content: [TextContent(text: await file.readAsString())],
+    );
+  }
+
+  Future<CallToolResult> _deleteFile(CallToolRequest request) async {
+    final path = request.arguments!['path'] as String;
+    final errorResult = await _checkAllowedPath(path);
+    if (errorResult != null) return errorResult;
+
+    final file = io.File(path);
+    if (!await file.exists()) {
+      return CallToolResult(
+        content: [TextContent(text: 'File does not exist')],
+      );
+    }
+    await file.delete();
+    return CallToolResult(content: [TextContent(text: 'Success')]);
+  }
+
+  final writeFileTool = Tool(
+    name: 'writeFile',
+    description: 'Writes a file to the file system.',
+    inputSchema: Schema.object(
+      properties: {
+        'path': Schema.string(description: 'The path to the file to write.'),
+        'contents': Schema.string(
+          description: 'The string contents to write to the file.',
+        ),
+      },
+    ),
+    annotations: ToolAnnotations(destructiveHint: true),
+  );
+
+  final readFileTool = Tool(
+    name: 'readFile',
+    description: 'Reads a file from the file system.',
+    inputSchema: Schema.object(
+      properties: {
+        'path': Schema.string(description: 'The path to the file to read.'),
+      },
+    ),
+    annotations: ToolAnnotations(readOnlyHint: true),
+  );
+
+  final deleteFileTool = Tool(
+    name: 'deleteFile',
+    description: 'Deletes a file from the file system.',
+    inputSchema: Schema.object(
+      properties: {
+        'path': Schema.string(description: 'The path to the file to delete.'),
+      },
+    ),
+    annotations: ToolAnnotations(destructiveHint: true),
+  );
+}

--- a/pkgs/dart_mcp/example/file_system_server.dart
+++ b/pkgs/dart_mcp/example/file_system_server.dart
@@ -91,6 +91,7 @@ final class SimpleFileSystemServer extends MCPServer
     if (!await file.exists()) {
       return CallToolResult(
         content: [TextContent(text: 'File does not exist')],
+        isError: true,
       );
     }
     return CallToolResult(
@@ -107,6 +108,7 @@ final class SimpleFileSystemServer extends MCPServer
     if (!await file.exists()) {
       return CallToolResult(
         content: [TextContent(text: 'File does not exist')],
+        isError: true,
       );
     }
     await file.delete();

--- a/pkgs/dart_mcp/example/workflow_client.dart
+++ b/pkgs/dart_mcp/example/workflow_client.dart
@@ -330,7 +330,10 @@ final class WorkflowClient extends MCPClient with RootsSupport {
   /// Connects to all servers using [serverCommands].
   Future<void> _connectToServers() async {
     for (var server in serverCommands) {
-      serverConnections.add(await connectStdioServer(server, []));
+      final parts = server.split(' ');
+      serverConnections.add(
+        await connectStdioServer(parts.first, parts.skip(1).toList()),
+      );
     }
   }
 

--- a/pkgs/dart_mcp/pubspec.yaml
+++ b/pkgs/dart_mcp/pubspec.yaml
@@ -20,4 +20,5 @@ dev_dependencies:
   cli_util: ^0.4.2
   dart_flutter_team_lints: ^3.2.1
   google_generative_ai: ^0.4.6
+  path: ^1.9.1
   test: ^1.25.15


### PR DESCRIPTION
This is useful for testing the workflow client with more complicated flows to give it file system access, without needing to depend on a third party server for that.