### PR TITLE
add a test command and project detection

### DIFF
--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/dash_cli.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/dash_cli.dart
@@ -8,6 +8,7 @@ import 'package:dart_mcp/server.dart';
 
 import '../utils/cli_utils.dart';
 import '../utils/constants.dart';
+import '../utils/file_system.dart';
 import '../utils/process_manager.dart';
 
 /// Mix this in to any MCPServer to add support for running Dart or Flutter CLI
@@ -16,7 +17,7 @@ import '../utils/process_manager.dart';
 /// The MCPServer must already have the [ToolsSupport] and [LoggingSupport]
 /// mixins applied.
 base mixin DashCliSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
-    implements ProcessManagerSupport {
+    implements ProcessManagerSupport, FileSystemSupport {
   @override
   FutureOr<InitializeResult> initialize(InitializeRequest request) {
     try {
@@ -35,11 +36,12 @@ base mixin DashCliSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
   Future<CallToolResult> _runDartFixTool(CallToolRequest request) async {
     return runCommandInRoots(
       request,
-      commandForRoot: (_) => 'dart',
+      commandForRoot: (_, _) => 'dart',
       arguments: ['fix', '--apply'],
       commandDescription: 'dart fix',
       processManager: processManager,
       knownRoots: await roots,
+      fileSystem: fileSystem,
     );
   }
 
@@ -47,12 +49,13 @@ base mixin DashCliSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
   Future<CallToolResult> _runDartFormatTool(CallToolRequest request) async {
     return runCommandInRoots(
       request,
-      commandForRoot: (_) => 'dart',
+      commandForRoot: (_, _) => 'dart',
       arguments: ['format'],
       commandDescription: 'dart format',
       processManager: processManager,
       defaultPaths: ['.'],
       knownRoots: await roots,
+      fileSystem: fileSystem,
     );
   }
 
@@ -64,6 +67,7 @@ base mixin DashCliSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
       commandDescription: 'dart|flutter test',
       processManager: processManager,
       knownRoots: await roots,
+      fileSystem: fileSystem,
     );
   }
 

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/dash_cli.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/dash_cli.dart
@@ -36,7 +36,7 @@ base mixin DashCliSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
     return runCommandInRoots(
       request,
       commandForRoot: (_) => 'dart',
-      arguments: ['dart', 'fix', '--apply'],
+      arguments: ['fix', '--apply'],
       commandDescription: 'dart fix',
       processManager: processManager,
       knownRoots: await roots,

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/pub.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/pub.dart
@@ -8,6 +8,7 @@ import 'package:dart_mcp/server.dart';
 
 import '../utils/cli_utils.dart';
 import '../utils/constants.dart';
+import '../utils/file_system.dart';
 import '../utils/process_manager.dart';
 
 /// Mix this in to any MCPServer to add support for running Pub commands like
@@ -18,7 +19,7 @@ import '../utils/process_manager.dart';
 /// The MCPServer must already have the [ToolsSupport] and [LoggingSupport]
 /// mixins applied.
 base mixin PubSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
-    implements ProcessManagerSupport {
+    implements ProcessManagerSupport, FileSystemSupport {
   @override
   FutureOr<InitializeResult> initialize(InitializeRequest request) {
     try {
@@ -77,19 +78,20 @@ base mixin PubSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
       commandDescription: 'dart|flutter pub $command',
       processManager: processManager,
       knownRoots: await roots,
+      fileSystem: fileSystem,
     );
   }
 
   static final pubTool = Tool(
     name: 'pub',
     description:
-        'Runs a dart pub command for the given project roots, like `dart pub '
-        'get` or `dart pub add`.',
+        'Runs a pub command for the given project roots, like `dart pub '
+        'get` or `flutter pub add`.',
     annotations: ToolAnnotations(title: 'pub', readOnlyHint: false),
     inputSchema: Schema.object(
       properties: {
         ParameterNames.command: Schema.string(
-          title: 'The dart pub command to run.',
+          title: 'The pub command to run.',
           description:
               'Currently only ${SupportedPubCommand.listAll} are supported.',
         ),
@@ -151,7 +153,7 @@ enum SupportedPubCommand {
       if (i < commands.length - 2) {
         buffer.write(', ');
       } else if (i == commands.length - 2) {
-        buffer.write(' and ');
+        buffer.write(', and ');
       }
     }
     return buffer.toString();

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/pub.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/pub.dart
@@ -73,8 +73,8 @@ base mixin PubSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
       request,
       // TODO(https://github.com/dart-lang/ai/issues/81): conditionally use
       //  flutter when appropriate.
-      command: ['dart', 'pub', command, if (packageName != null) packageName],
-      commandDescription: 'dart pub $command',
+      arguments: ['pub', command, if (packageName != null) packageName],
+      commandDescription: 'dart|flutter pub $command',
       processManager: processManager,
       knownRoots: await roots,
     );

--- a/pkgs/dart_tooling_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/server.dart
@@ -10,7 +10,7 @@ import 'package:process/process.dart';
 import 'package:stream_channel/stream_channel.dart';
 
 import 'mixins/analyzer.dart';
-import 'mixins/dart_cli.dart';
+import 'mixins/dash_cli.dart';
 import 'mixins/dtd.dart';
 import 'mixins/pub.dart';
 import 'utils/process_manager.dart';
@@ -23,7 +23,7 @@ final class DartToolingMCPServer extends MCPServer
         ResourcesSupport,
         RootsTrackingSupport,
         DartAnalyzerSupport,
-        DartCliSupport,
+        DashCliSupport,
         PubSupport,
         DartToolingDaemonSupport
     implements ProcessManagerSupport {

--- a/pkgs/dart_tooling_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/server.dart
@@ -5,6 +5,8 @@
 import 'dart:async';
 
 import 'package:dart_mcp/server.dart';
+import 'package:file/file.dart';
+import 'package:file/local.dart';
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 import 'package:stream_channel/stream_channel.dart';
@@ -13,6 +15,7 @@ import 'mixins/analyzer.dart';
 import 'mixins/dash_cli.dart';
 import 'mixins/dtd.dart';
 import 'mixins/pub.dart';
+import 'utils/file_system.dart';
 import 'utils/process_manager.dart';
 
 /// An MCP server for Dart and Flutter tooling.
@@ -26,10 +29,11 @@ final class DartToolingMCPServer extends MCPServer
         DashCliSupport,
         PubSupport,
         DartToolingDaemonSupport
-    implements ProcessManagerSupport {
+    implements ProcessManagerSupport, FileSystemSupport {
   DartToolingMCPServer(
     super.channel, {
     @visibleForTesting this.processManager = const LocalProcessManager(),
+    @visibleForTesting this.fileSystem = const LocalFileSystem(),
   }) : super.fromStreamChannel(
          implementation: ServerImplementation(
            name: 'dart and flutter tooling',
@@ -48,4 +52,7 @@ final class DartToolingMCPServer extends MCPServer
 
   @override
   final LocalProcessManager processManager;
+
+  @override
+  final FileSystem fileSystem;
 }

--- a/pkgs/dart_tooling_mcp_server/lib/src/utils/cli_utils.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/utils/cli_utils.dart
@@ -2,17 +2,53 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:dart_mcp/server.dart';
 import 'package:path/path.dart' as p;
 import 'package:process/process.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
 
 import 'constants.dart';
 
-/// Runs [command] in each of the project roots specified in the [request].
+/// The supported kinds of projects.
+enum ProjectKind {
+  /// A Flutter project
+  flutter,
+
+  /// A Dart project
+  dart,
+
+  /// An unknown project, this usually means there was no pubspec.yaml.
+  unknown,
+}
+
+/// Infers the [ProjectKind] of a given [Root].
 ///
-/// The [command] should be a list of strings that can be passed directly to
+/// Currently, this is done by checking for the existence of a `pubspec.yaml`
+/// file and whether it contains a Flutter SDK dependency.
+Future<ProjectKind> inferProjectKind(Root root) async {
+  final pubspecFile = File.fromUri(Uri.parse(root.uri).resolve('pubspec.yaml'));
+  if (!await pubspecFile.exists()) {
+    return ProjectKind.unknown;
+  }
+  final pubspec = Pubspec.parse(await pubspecFile.readAsString());
+
+  if (pubspec.flutter != null ||
+      pubspec.environment.containsKey('flutter') ||
+      pubspec.dependencies.values
+          .followedBy(pubspec.devDependencies.values)
+          .any((dep) => dep is SdkDependency && dep.sdk == 'flutter')) {
+    return ProjectKind.flutter;
+  }
+  return ProjectKind.dart;
+}
+
+/// Runs [commandForRoot] in each of the project roots specified in the
+/// [request], with [arguments].
+///
+/// These [commandForRoot] plus [arguments] are passed directly to
 /// [ProcessManager.run].
 ///
 /// The [commandDescription] is used in the output to describe the command
@@ -33,7 +69,8 @@ import 'constants.dart';
 /// root's 'paths'.
 Future<CallToolResult> runCommandInRoots(
   CallToolRequest request, {
-  required List<String> command,
+  FutureOr<String> Function(Root) commandForRoot = defaultCommandForRoot,
+  List<String> arguments = const [],
   required String commandDescription,
   required ProcessManager processManager,
   required List<Root> knownRoots,
@@ -63,7 +100,8 @@ Future<CallToolResult> runCommandInRoots(
       );
     }
 
-    if (!_isAllowedRoot(rootUriString, knownRoots)) {
+    final root = _findRoot(rootUriString, knownRoots);
+    if (root == null) {
       return CallToolResult(
         content: [
           TextContent(
@@ -91,7 +129,7 @@ Future<CallToolResult> runCommandInRoots(
     }
     final projectRoot = Directory(rootUri.toFilePath());
 
-    final commandWithPaths = List.of(command);
+    final commandWithPaths = <String>[await commandForRoot(root), ...arguments];
     final paths =
         (rootConfig[ParameterNames.paths] as List?)?.cast<String>() ??
         defaultPaths;
@@ -145,15 +183,34 @@ Future<CallToolResult> runCommandInRoots(
   return CallToolResult(content: outputs);
 }
 
+/// Returns 'dart' or 'flutter' based on the pubspec contents.
+///
+/// Throws an [ArgumentError] if there is no pubspec.
+Future<String> defaultCommandForRoot(Root root) async =>
+    switch (await inferProjectKind(root)) {
+      ProjectKind.dart => 'dart',
+      ProjectKind.flutter => 'flutter',
+      ProjectKind.unknown =>
+        throw ArgumentError.value(
+          root.uri,
+          'root.uri',
+          'Unknown project kind at root ${root.uri}. All projects must have a '
+              'pubspec.',
+        ),
+    };
+
 /// Returns whether or not [rootUri] is an allowed root, either exactly matching
 /// or under on of the [knownRoots].
-bool _isAllowedRoot(String rootUri, List<Root> knownRoots) =>
-    knownRoots.any((knownRoot) {
-      final knownRootUri = Uri.parse(knownRoot.uri);
-      final resolvedRoot = knownRootUri.resolve(rootUri).toString();
-      return knownRoot.uri == resolvedRoot ||
-          p.isWithin(knownRoot.uri, resolvedRoot);
-    });
+Root? _findRoot(String rootUri, List<Root> knownRoots) {
+  for (final root in knownRoots) {
+    final knownRootUri = Uri.parse(root.uri);
+    final resolvedRoot = knownRootUri.resolve(rootUri).toString();
+    if (root.uri == resolvedRoot || p.isWithin(root.uri, resolvedRoot)) {
+      return root;
+    }
+  }
+  return null;
+}
 
 /// The schema for the `roots` parameter for any tool that accepts it.
 ListSchema rootsSchema({bool supportsPaths = false}) => Schema.list(

--- a/pkgs/dart_tooling_mcp_server/lib/src/utils/file_system.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/utils/file_system.dart
@@ -1,0 +1,17 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:file/file.dart';
+
+/// An interface class that provides a single getter of type [FileSystem].
+///
+/// The `DartToolingMCPServer` class implements this class so that [File]
+/// methods can be easily mocked during testing.
+///
+/// MCP support mixins like `DartCliSupport` that access files should also
+/// implement this class and use [fileSystem] instead of making direct calls to
+/// dart:io's [File] and [Directory] classes.
+abstract interface class FileSystemSupport {
+  FileSystem get fileSystem;
+}

--- a/pkgs/dart_tooling_mcp_server/pubspec.yaml
+++ b/pkgs/dart_tooling_mcp_server/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   dds_service_extensions: ^2.0.1
   devtools_shared: ^11.2.0
   dtd: ^2.4.0
+  file: ^7.0.1
   json_rpc_2: ^3.0.3
   # TODO: Get this another way.
   language_server_protocol:

--- a/pkgs/dart_tooling_mcp_server/pubspec.yaml
+++ b/pkgs/dart_tooling_mcp_server/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   meta: ^1.16.0
   path: ^1.9.1
   process: ^5.0.3
+  pubspec_parse: ^1.5.0
   stream_channel: ^2.1.4
   test_descriptor: ^2.0.2
   test_process: ^2.1.1

--- a/pkgs/dart_tooling_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_tooling_mcp_server/test/test_harness.dart
@@ -73,7 +73,7 @@ class TestHarness {
     final serverConnectionPair = await _initializeMCPServer(
       mcpClient,
       inProcess,
-      fileSystem
+      fileSystem,
     );
     final connection = serverConnectionPair.serverConnection;
     connection.onLog.listen((log) {

--- a/pkgs/dart_tooling_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_tooling_mcp_server/test/test_harness.dart
@@ -12,6 +12,8 @@ import 'package:dart_tooling_mcp_server/src/mixins/dtd.dart';
 import 'package:dart_tooling_mcp_server/src/server.dart';
 import 'package:dart_tooling_mcp_server/src/utils/constants.dart';
 import 'package:dtd/dtd.dart';
+import 'package:file/file.dart';
+import 'package:file/local.dart';
 import 'package:path/path.dart' as p;
 import 'package:process/process.dart';
 import 'package:stream_channel/stream_channel.dart';
@@ -32,6 +34,8 @@ class TestHarness {
   final FakeEditorExtension fakeEditorExtension;
   final DartToolingMCPClient mcpClient;
   final ServerConnectionPair serverConnectionPair;
+  final FileSystem fileSystem;
+
   ServerConnection get mcpServerConnection =>
       serverConnectionPair.serverConnection;
 
@@ -39,6 +43,7 @@ class TestHarness {
     this.mcpClient,
     this.serverConnectionPair,
     this.fakeEditorExtension,
+    this.fileSystem,
   );
 
   /// Starts a Dart Tooling Daemon as well as an MCP client and server, and
@@ -56,13 +61,19 @@ class TestHarness {
   /// MCP server is ran in process.
   ///
   /// Use [startDebugSession] to start up apps and connect to them.
-  static Future<TestHarness> start({bool inProcess = false}) async {
+  static Future<TestHarness> start({
+    bool inProcess = false,
+    FileSystem? fileSystem,
+  }) async {
+    fileSystem ??= const LocalFileSystem();
+
     final mcpClient = DartToolingMCPClient();
     addTearDown(mcpClient.shutdown);
 
     final serverConnectionPair = await _initializeMCPServer(
       mcpClient,
       inProcess,
+      fileSystem
     );
     final connection = serverConnectionPair.serverConnection;
     connection.onLog.listen((log) {
@@ -72,7 +83,12 @@ class TestHarness {
     final fakeEditorExtension = await FakeEditorExtension.connect();
     addTearDown(fakeEditorExtension.shutdown);
 
-    return TestHarness._(mcpClient, serverConnectionPair, fakeEditorExtension);
+    return TestHarness._(
+      mcpClient,
+      serverConnectionPair,
+      fakeEditorExtension,
+      fileSystem,
+    );
   }
 
   /// Starts an app debug session.
@@ -96,6 +112,10 @@ class TestHarness {
     }
     return session;
   }
+
+  /// Creates a canonical [Root] object for a given [projectPath].
+  Root rootForPath(String projectPath) =>
+      Root(uri: fileSystem.directory(projectPath).absolute.uri.toString());
 
   /// Stops an app debug session.
   Future<void> stopDebugSession(AppDebugSession session) async {
@@ -369,6 +389,7 @@ typedef ServerConnectionPair =
 Future<ServerConnectionPair> _initializeMCPServer(
   MCPClient client,
   bool inProcess,
+  FileSystem fileSystem,
 ) async {
   ServerConnection connection;
   DartToolingMCPServer? server;
@@ -392,6 +413,7 @@ Future<ServerConnectionPair> _initializeMCPServer(
     server = DartToolingMCPServer(
       serverChannel,
       processManager: TestProcessManager(),
+      fileSystem: fileSystem,
     );
     addTearDown(server.shutdown);
     connection = client.connectServer(clientChannel);
@@ -410,10 +432,6 @@ Future<ServerConnectionPair> _initializeMCPServer(
   connection.notifyInitialized(InitializedNotification());
   return (serverConnection: connection, server: server);
 }
-
-/// Creates a canonical [Root] object for a given [projectPath].
-Root rootForPath(String projectPath) =>
-    Root(uri: Directory(projectPath).absolute.uri.toString());
 
 final counterAppPath = p.join('test_fixtures', 'counter_app');
 

--- a/pkgs/dart_tooling_mcp_server/test/tools/analyzer_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/analyzer_test.dart
@@ -33,7 +33,7 @@ void main() {
     });
 
     test('can analyze a project', () async {
-      final counterAppRoot = rootForPath(counterAppPath);
+      final counterAppRoot = testHarness.rootForPath(counterAppPath);
       testHarness.mcpClient.addRoot(counterAppRoot);
       // Allow the notification to propagate, and the server to ask for the new
       // list of roots.
@@ -53,7 +53,7 @@ void main() {
         d.file('main.dart', 'void main() => 1 + "2";'),
       ]);
       await example.create();
-      final exampleRoot = rootForPath(example.io.path);
+      final exampleRoot = testHarness.rootForPath(example.io.path);
       testHarness.mcpClient.addRoot(exampleRoot);
 
       // Allow the notification to propagate, and the server to ask for the new
@@ -91,7 +91,7 @@ void main() {
     });
 
     test('can look up symbols in a workspace', () async {
-      final currentRoot = rootForPath(Directory.current.path);
+      final currentRoot = testHarness.rootForPath(Directory.current.path);
       testHarness.mcpClient.addRoot(currentRoot);
       await pumpEventQueue();
 
@@ -114,7 +114,7 @@ void main() {
     });
 
     test('can get signature help', () async {
-      final counterAppRoot = rootForPath(counterAppPath);
+      final counterAppRoot = testHarness.rootForPath(counterAppPath);
       testHarness.mcpClient.addRoot(counterAppRoot);
       await pumpEventQueue();
 

--- a/pkgs/dart_tooling_mcp_server/test/tools/dart_cli_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/dart_cli_test.dart
@@ -12,12 +12,8 @@ import '../test_harness.dart';
 void main() {
   late TestHarness testHarness;
   late TestProcessManager testProcessManager;
-
-  // This root is arbitrary for these tests since we are not actually running
-  // the CLI commands, but rather sending them through the
-  // [TestProcessManager] wrapper.
-  final counterAppRoot = rootForPath(counterAppPath);
-  final dartCliAppRoot = rootForPath(dartCliAppsPath);
+  late Root counterAppRoot;
+  late Root dartCliAppRoot;
 
   // TODO: Use setUpAll, currently this fails due to an apparent TestProcess
   // issue.
@@ -26,6 +22,8 @@ void main() {
     testProcessManager =
         testHarness.serverConnectionPair.server!.processManager
             as TestProcessManager;
+    counterAppRoot = testHarness.rootForPath(counterAppPath);
+    dartCliAppRoot = testHarness.rootForPath(dartCliAppsPath);
 
     testHarness.mcpClient.addRoot(counterAppRoot);
     await pumpEventQueue();

--- a/pkgs/dart_tooling_mcp_server/test/tools/dart_cli_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/dart_cli_test.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:dart_mcp/server.dart';
-import 'package:dart_tooling_mcp_server/src/mixins/dart_cli.dart';
+import 'package:dart_tooling_mcp_server/src/mixins/dash_cli.dart';
 import 'package:dart_tooling_mcp_server/src/utils/constants.dart';
 import 'package:test/test.dart';
 
@@ -16,7 +16,8 @@ void main() {
   // This root is arbitrary for these tests since we are not actually running
   // the CLI commands, but rather sending them through the
   // [TestProcessManager] wrapper.
-  final testRoot = rootForPath(counterAppPath);
+  final counterAppRoot = rootForPath(counterAppPath);
+  final dartCliAppRoot = rootForPath(dartCliAppsPath);
 
   // TODO: Use setUpAll, currently this fails due to an apparent TestProcess
   // issue.
@@ -26,7 +27,7 @@ void main() {
         testHarness.serverConnectionPair.server!.processManager
             as TestProcessManager;
 
-    testHarness.mcpClient.addRoot(testRoot);
+    testHarness.mcpClient.addRoot(counterAppRoot);
     await pumpEventQueue();
   });
 
@@ -37,10 +38,10 @@ void main() {
     setUp(() async {
       final tools = (await testHarness.mcpServerConnection.listTools()).tools;
       dartFixTool = tools.singleWhere(
-        (t) => t.name == DartCliSupport.dartFixTool.name,
+        (t) => t.name == DashCliSupport.dartFixTool.name,
       );
       dartFormatTool = tools.singleWhere(
-        (t) => t.name == DartCliSupport.dartFormatTool.name,
+        (t) => t.name == DashCliSupport.dartFormatTool.name,
       );
     });
 
@@ -49,7 +50,7 @@ void main() {
         name: dartFixTool.name,
         arguments: {
           ParameterNames.roots: [
-            {ParameterNames.root: testRoot.uri},
+            {ParameterNames.root: counterAppRoot.uri},
           ],
         },
       );
@@ -67,7 +68,7 @@ void main() {
         name: dartFormatTool.name,
         arguments: {
           ParameterNames.roots: [
-            {ParameterNames.root: testRoot.uri},
+            {ParameterNames.root: counterAppRoot.uri},
           ],
         },
       );
@@ -86,7 +87,7 @@ void main() {
         arguments: {
           ParameterNames.roots: [
             {
-              ParameterNames.root: testRoot.uri,
+              ParameterNames.root: counterAppRoot.uri,
               ParameterNames.paths: ['foo.dart', 'bar.dart'],
             },
           ],
@@ -98,6 +99,34 @@ void main() {
       expect(result.isError, isNot(true));
       expect(testProcessManager.commandsRan, [
         ['dart', 'format', 'foo.dart', 'bar.dart'],
+      ]);
+    });
+
+    test('flutter and dart package tests with paths', () async {
+      testHarness.mcpClient.addRoot(dartCliAppRoot);
+      await pumpEventQueue();
+      final request = CallToolRequest(
+        name: DashCliSupport.runTestsTool.name,
+        arguments: {
+          ParameterNames.roots: [
+            {
+              ParameterNames.root: counterAppRoot.uri,
+              ParameterNames.paths: ['foo_test.dart', 'bar_test.dart'],
+            },
+            {
+              ParameterNames.root: dartCliAppRoot.uri,
+              ParameterNames.paths: ['zip_test.dart'],
+            },
+          ],
+        },
+      );
+      final result = await testHarness.callToolWithRetry(request);
+
+      // Verify the command was sent to the process manager without error.
+      expect(result.isError, isNot(true));
+      expect(testProcessManager.commandsRan, [
+        ['flutter', 'test', 'foo_test.dart', 'bar_test.dart'],
+        ['dart', 'test', 'zip_test.dart'],
       ]);
     });
   });

--- a/pkgs/dart_tooling_mcp_server/test/tools/pub_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/pub_test.dart
@@ -52,7 +52,7 @@ void main() {
       // Verify the command was sent to the process maanger without error.
       expect(result.isError, isNot(true));
       expect(testProcessManager.commandsRan, [
-        ['dart', 'pub', 'add', 'foo'],
+        ['flutter', 'pub', 'add', 'foo'],
       ]);
     });
 
@@ -72,7 +72,7 @@ void main() {
       // Verify the command was sent to the process maanger without error.
       expect(result.isError, isNot(true));
       expect(testProcessManager.commandsRan, [
-        ['dart', 'pub', 'remove', 'foo'],
+        ['flutter', 'pub', 'remove', 'foo'],
       ]);
     });
 
@@ -91,7 +91,7 @@ void main() {
       // Verify the command was sent to the process maanger without error.
       expect(result.isError, isNot(true));
       expect(testProcessManager.commandsRan, [
-        ['dart', 'pub', 'get'],
+        ['flutter', 'pub', 'get'],
       ]);
     });
 
@@ -110,7 +110,7 @@ void main() {
       // Verify the command was sent to the process maanger without error.
       expect(result.isError, isNot(true));
       expect(testProcessManager.commandsRan, [
-        ['dart', 'pub', 'upgrade'],
+        ['flutter', 'pub', 'upgrade'],
       ]);
     });
 

--- a/pkgs/dart_tooling_mcp_server/test/tools/pub_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/pub_test.dart
@@ -5,6 +5,9 @@
 import 'package:dart_mcp/server.dart';
 import 'package:dart_tooling_mcp_server/src/mixins/pub.dart';
 import 'package:dart_tooling_mcp_server/src/utils/constants.dart';
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import '../test_harness.dart';
@@ -12,161 +15,190 @@ import '../test_harness.dart';
 void main() {
   late TestHarness testHarness;
   late TestProcessManager testProcessManager;
-
-  // This root is arbitrary for these tests since we are not actually running
-  // the CLI commands, but rather sending them through the
-  // [TestProcessManager] wrapper.
-  final testRoot = rootForPath(counterAppPath);
-
+  late Root testRoot;
   late Tool dartPubTool;
+  late FileSystem fileSystem;
 
-  // TODO: Use setUpAll, currently this fails due to an apparent TestProcess
-  // issue.
-  setUp(() async {
-    testHarness = await TestHarness.start(inProcess: true);
-    testProcessManager =
-        testHarness.serverConnectionPair.server!.processManager
-            as TestProcessManager;
+  final fakeAppPath = 'fake_app';
 
-    testHarness.mcpClient.addRoot(testRoot);
-    await pumpEventQueue();
-
-    final tools = (await testHarness.mcpServerConnection.listTools()).tools;
-    dartPubTool = tools.singleWhere((t) => t.name == PubSupport.pubTool.name);
-  });
-
-  group('pub tools', () {
-    test('add', () async {
-      final request = CallToolRequest(
-        name: dartPubTool.name,
-        arguments: {
-          ParameterNames.command: 'add',
-          ParameterNames.packageName: 'foo',
-          ParameterNames.roots: [
-            {ParameterNames.root: testRoot.uri},
-          ],
-        },
-      );
-      final result = await testHarness.callToolWithRetry(request);
-
-      // Verify the command was sent to the process maanger without error.
-      expect(result.isError, isNot(true));
-      expect(testProcessManager.commandsRan, [
-        ['flutter', 'pub', 'add', 'foo'],
-      ]);
-    });
-
-    test('remove', () async {
-      final request = CallToolRequest(
-        name: dartPubTool.name,
-        arguments: {
-          ParameterNames.command: 'remove',
-          ParameterNames.packageName: 'foo',
-          ParameterNames.roots: [
-            {ParameterNames.root: testRoot.uri},
-          ],
-        },
-      );
-      final result = await testHarness.callToolWithRetry(request);
-
-      // Verify the command was sent to the process maanger without error.
-      expect(result.isError, isNot(true));
-      expect(testProcessManager.commandsRan, [
-        ['flutter', 'pub', 'remove', 'foo'],
-      ]);
-    });
-
-    test('get', () async {
-      final request = CallToolRequest(
-        name: dartPubTool.name,
-        arguments: {
-          ParameterNames.command: 'get',
-          ParameterNames.roots: [
-            {ParameterNames.root: testRoot.uri},
-          ],
-        },
-      );
-      final result = await testHarness.callToolWithRetry(request);
-
-      // Verify the command was sent to the process maanger without error.
-      expect(result.isError, isNot(true));
-      expect(testProcessManager.commandsRan, [
-        ['flutter', 'pub', 'get'],
-      ]);
-    });
-
-    test('upgrade', () async {
-      final request = CallToolRequest(
-        name: dartPubTool.name,
-        arguments: {
-          ParameterNames.command: 'upgrade',
-          ParameterNames.roots: [
-            {ParameterNames.root: testRoot.uri},
-          ],
-        },
-      );
-      final result = await testHarness.callToolWithRetry(request);
-
-      // Verify the command was sent to the process maanger without error.
-      expect(result.isError, isNot(true));
-      expect(testProcessManager.commandsRan, [
-        ['flutter', 'pub', 'upgrade'],
-      ]);
-    });
-
-    group('returns error', () {
-      test('for missing command', () async {
-        final request = CallToolRequest(name: dartPubTool.name);
-        final result = await testHarness.callToolWithRetry(
-          request,
-          expectError: true,
+  for (final appKind in const ['dart', 'flutter']) {
+    group('$appKind app', () {
+      // TODO: Use setUpAll, currently this fails due to an apparent TestProcess
+      // issue.
+      setUp(() async {
+        fileSystem = MemoryFileSystem();
+        fileSystem.file(p.join(fakeAppPath, 'pubspec.yaml'))
+          ..createSync(recursive: true)
+          ..writeAsStringSync(
+            appKind == 'flutter' ? flutterPubspec : dartPubspec,
+          );
+        testHarness = await TestHarness.start(
+          inProcess: true,
+          fileSystem: fileSystem,
         );
+        testProcessManager =
+            testHarness.serverConnectionPair.server!.processManager
+                as TestProcessManager;
+        testRoot = testHarness.rootForPath(fakeAppPath);
 
-        expect(
-          (result.content.single as TextContent).text,
-          'Missing required argument `command`.',
+        testHarness.mcpClient.addRoot(testRoot);
+        await pumpEventQueue();
+
+        final tools = (await testHarness.mcpServerConnection.listTools()).tools;
+        dartPubTool = tools.singleWhere(
+          (t) => t.name == PubSupport.pubTool.name,
         );
-        expect(testProcessManager.commandsRan, isEmpty);
       });
 
-      test('for unsupported command', () async {
-        final request = CallToolRequest(
-          name: dartPubTool.name,
-          arguments: {ParameterNames.command: 'publish'},
-        );
-        final result = await testHarness.callToolWithRetry(
-          request,
-          expectError: true,
-        );
-
-        expect(
-          (result.content.single as TextContent).text,
-          contains('Unsupported pub command `publish`.'),
-        );
-        expect(testProcessManager.commandsRan, isEmpty);
-      });
-
-      for (final command in SupportedPubCommand.values.where(
-        (c) => c.requiresPackageName,
-      )) {
-        test('for missing package name: $command', () async {
+      group('pub tools', () {
+        test('add', () async {
           final request = CallToolRequest(
             name: dartPubTool.name,
-            arguments: {ParameterNames.command: command.name},
+            arguments: {
+              ParameterNames.command: 'add',
+              ParameterNames.packageName: 'foo',
+              ParameterNames.roots: [
+                {ParameterNames.root: testRoot.uri},
+              ],
+            },
           );
-          final result = await testHarness.callToolWithRetry(
-            request,
-            expectError: true,
-          );
+          final result = await testHarness.callToolWithRetry(request);
 
-          expect(
-            (result.content.single as TextContent).text,
-            'Missing required argument `packageName` for the '
-            '`${command.name}` command.',
-          );
-          expect(testProcessManager.commandsRan, isEmpty);
+          // Verify the command was sent to the process manager without error.
+          expect(result.isError, isNot(true));
+          expect(testProcessManager.commandsRan, [
+            [appKind, 'pub', 'add', 'foo'],
+          ]);
         });
-      }
+
+        test('remove', () async {
+          final request = CallToolRequest(
+            name: dartPubTool.name,
+            arguments: {
+              ParameterNames.command: 'remove',
+              ParameterNames.packageName: 'foo',
+              ParameterNames.roots: [
+                {ParameterNames.root: testRoot.uri},
+              ],
+            },
+          );
+          final result = await testHarness.callToolWithRetry(request);
+
+          // Verify the command was sent to the process manager without error.
+          expect(result.isError, isNot(true));
+          expect(testProcessManager.commandsRan, [
+            [appKind, 'pub', 'remove', 'foo'],
+          ]);
+        });
+
+        test('get', () async {
+          final request = CallToolRequest(
+            name: dartPubTool.name,
+            arguments: {
+              ParameterNames.command: 'get',
+              ParameterNames.roots: [
+                {ParameterNames.root: testRoot.uri},
+              ],
+            },
+          );
+          final result = await testHarness.callToolWithRetry(request);
+
+          // Verify the command was sent to the process manager without error.
+          expect(result.isError, isNot(true));
+          expect(testProcessManager.commandsRan, [
+            [appKind, 'pub', 'get'],
+          ]);
+        });
+
+        test('upgrade', () async {
+          final request = CallToolRequest(
+            name: dartPubTool.name,
+            arguments: {
+              ParameterNames.command: 'upgrade',
+              ParameterNames.roots: [
+                {ParameterNames.root: testRoot.uri},
+              ],
+            },
+          );
+          final result = await testHarness.callToolWithRetry(request);
+
+          // Verify the command was sent to the process manager without error.
+          expect(result.isError, isNot(true));
+          expect(testProcessManager.commandsRan, [
+            [appKind, 'pub', 'upgrade'],
+          ]);
+        });
+
+        group('returns error', () {
+          test('for missing command', () async {
+            final request = CallToolRequest(name: dartPubTool.name);
+            final result = await testHarness.callToolWithRetry(
+              request,
+              expectError: true,
+            );
+
+            expect(
+              (result.content.single as TextContent).text,
+              'Missing required argument `command`.',
+            );
+            expect(testProcessManager.commandsRan, isEmpty);
+          });
+
+          test('for unsupported command', () async {
+            final request = CallToolRequest(
+              name: dartPubTool.name,
+              arguments: {ParameterNames.command: 'publish'},
+            );
+            final result = await testHarness.callToolWithRetry(
+              request,
+              expectError: true,
+            );
+
+            expect(
+              (result.content.single as TextContent).text,
+              contains('Unsupported pub command `publish`.'),
+            );
+            expect(testProcessManager.commandsRan, isEmpty);
+          });
+
+          for (final command in SupportedPubCommand.values.where(
+            (c) => c.requiresPackageName,
+          )) {
+            test('for missing package name: $command', () async {
+              final request = CallToolRequest(
+                name: dartPubTool.name,
+                arguments: {ParameterNames.command: command.name},
+              );
+              final result = await testHarness.callToolWithRetry(
+                request,
+                expectError: true,
+              );
+
+              expect(
+                (result.content.single as TextContent).text,
+                'Missing required argument `packageName` for the '
+                '`${command.name}` command.',
+              );
+              expect(testProcessManager.commandsRan, isEmpty);
+            });
+          }
+        });
+      });
     });
-  });
+  }
 }
+
+final dartPubspec = '''
+name: dart_app
+environment:
+  sdk: ^3.7.0
+''';
+
+final flutterPubspec = '''
+name: flutter_app
+environment:
+  sdk: ^3.7.0
+dependencies:
+  flutter:
+    sdk: flutter
+''';

--- a/pkgs/dart_tooling_mcp_server/test/utils/cli_utils_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/utils/cli_utils_test.dart
@@ -5,6 +5,7 @@
 import 'package:dart_mcp/server.dart';
 import 'package:dart_tooling_mcp_server/src/utils/cli_utils.dart';
 import 'package:dart_tooling_mcp_server/src/utils/constants.dart';
+import 'package:file/memory.dart';
 import 'package:process/process.dart';
 import 'package:test/fake.dart';
 import 'package:test/test.dart';
@@ -12,6 +13,12 @@ import 'package:test/test.dart';
 import '../test_harness.dart';
 
 void main() {
+  late MemoryFileSystem fileSystem;
+
+  setUp(() {
+    fileSystem = MemoryFileSystem();
+  });
+
   group('can run commands', () {
     late TestProcessManager processManager;
     setUp(() async {
@@ -28,11 +35,12 @@ void main() {
             ],
           },
         ),
-        commandForRoot: (_) => 'testCommand',
+        commandForRoot: (_, _) => 'testCommand',
         arguments: ['a', 'b'],
         commandDescription: '',
         processManager: processManager,
         knownRoots: [Root(uri: 'file:///bar/')],
+        fileSystem: fileSystem,
       );
       expect(result.isError, isNot(true));
       expect(processManager.commandsRan, [
@@ -52,10 +60,11 @@ void main() {
               ],
             },
           ),
-          commandForRoot: (_) => 'testCommand',
+          commandForRoot: (_, _) => 'testCommand',
           commandDescription: '',
           processManager: processManager,
           knownRoots: [Root(uri: 'file:///bar/')],
+          fileSystem: fileSystem,
         );
         expect(result.isError, isNot(true));
         expect(processManager.commandsRan, [
@@ -79,10 +88,11 @@ void main() {
               ],
             },
           ),
-          commandForRoot: (_) => 'fake',
+          commandForRoot: (_, _) => 'fake',
           commandDescription: '',
           processManager: processManager,
           knownRoots: [Root(uri: 'file:///foo/')],
+          fileSystem: fileSystem,
         );
         expect(result.isError, isTrue);
         expect(
@@ -114,10 +124,11 @@ void main() {
             ],
           },
         ),
-        commandForRoot: (_) => 'fake',
+        commandForRoot: (_, _) => 'fake',
         commandDescription: '',
         processManager: processManager,
         knownRoots: [Root(uri: 'file:///foo/')],
+        fileSystem: fileSystem,
       );
       expect(result.isError, isTrue);
       expect(

--- a/pkgs/dart_tooling_mcp_server/test/utils/cli_utils_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/utils/cli_utils_test.dart
@@ -28,14 +28,15 @@ void main() {
             ],
           },
         ),
-        command: ['testCommand'],
+        commandForRoot: (_) => 'testCommand',
+        arguments: ['a', 'b'],
         commandDescription: '',
         processManager: processManager,
         knownRoots: [Root(uri: 'file:///bar/')],
       );
       expect(result.isError, isNot(true));
       expect(processManager.commandsRan, [
-        ['testCommand'],
+        ['testCommand', 'a', 'b'],
       ]);
     });
 
@@ -51,7 +52,7 @@ void main() {
               ],
             },
           ),
-          command: ['testCommand'],
+          commandForRoot: (_) => 'testCommand',
           commandDescription: '',
           processManager: processManager,
           knownRoots: [Root(uri: 'file:///bar/')],
@@ -78,7 +79,7 @@ void main() {
               ],
             },
           ),
-          command: ['fake'],
+          commandForRoot: (_) => 'fake',
           commandDescription: '',
           processManager: processManager,
           knownRoots: [Root(uri: 'file:///foo/')],
@@ -113,7 +114,7 @@ void main() {
             ],
           },
         ),
-        command: ['fake'],
+        commandForRoot: (_) => 'fake',
         commandDescription: '',
         processManager: processManager,
         knownRoots: [Root(uri: 'file:///foo/')],

--- a/pkgs/dart_tooling_mcp_server/test_fixtures/dart_cli_app/pubspec.yaml
+++ b/pkgs/dart_tooling_mcp_server/test_fixtures/dart_cli_app/pubspec.yaml
@@ -1,4 +1,4 @@
-name: exampl_dart_cli_app
+name: example_dart_cli_app
 publish_to: none
 environment:
   sdk: ^3.7.0

--- a/pkgs/dart_tooling_mcp_server/test_fixtures/dart_cli_app/pubspec.yaml
+++ b/pkgs/dart_tooling_mcp_server/test_fixtures/dart_cli_app/pubspec.yaml
@@ -1,0 +1,3 @@
+name: exampl_dart_cli_app
+environment:
+  sdk: ^3.7.0

--- a/pkgs/dart_tooling_mcp_server/test_fixtures/dart_cli_app/pubspec.yaml
+++ b/pkgs/dart_tooling_mcp_server/test_fixtures/dart_cli_app/pubspec.yaml
@@ -1,3 +1,4 @@
 name: exampl_dart_cli_app
+publish_to: none
 environment:
   sdk: ^3.7.0


### PR DESCRIPTION
- Rename `DartCliSupport` to `DashCliSupport`
- Add support for choosing the command to run based on the root it is ran in
  - Defaults to project detection, calling `flutter` or `dart` as appropriate.
    - Updated the dart only commands to explicitly use `dart` always
- Adds a tool for running tests, which requires this support.

TODO: Add support for some `test` command arguments such as `--name`, and possibly platform or other arguments. We may just want to allow general arguments.