### PR TITLE
Adds a check to pub tool to see if a root is a Flutter project.

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.2.1-wip
 
+- Adds a check in the pub tool that checks to see if a project is a Flutter
+  project before it calls the pub tool. If it is, then it automatically runs
+  'flutter pub' instead of 'dart pub'.
 - Update workflow example to show thinking spinner and input and output token
   usage.
 

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
-import 'dart:io';
+import 'dart:io' show Platform, Process;
 
 import 'package:dart_mcp/server.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/dart_cli.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/dart_cli.dart
@@ -8,6 +8,7 @@ import 'package:dart_mcp/server.dart';
 
 import '../utils/cli_utils.dart';
 import '../utils/constants.dart';
+import '../utils/filesystem.dart';
 import '../utils/process_manager.dart';
 
 // TODO: migrate the analyze files tool to use this mixin and run the
@@ -19,7 +20,7 @@ import '../utils/process_manager.dart';
 /// The MCPServer must already have the [ToolsSupport] and [LoggingSupport]
 /// mixins applied.
 base mixin DartCliSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
-    implements ProcessManagerSupport {
+    implements ProcessManagerSupport, FileSystemSupport {
   @override
   FutureOr<InitializeResult> initialize(InitializeRequest request) {
     try {
@@ -41,6 +42,7 @@ base mixin DartCliSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
       commandDescription: 'dart fix',
       processManager: processManager,
       knownRoots: await roots,
+      fileSystem: fs,
     );
   }
 
@@ -53,6 +55,7 @@ base mixin DartCliSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
       processManager: processManager,
       defaultPaths: ['.'],
       knownRoots: await roots,
+      fileSystem: fs,
     );
   }
 

--- a/pkgs/dart_tooling_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/server.dart
@@ -5,6 +5,8 @@
 import 'dart:async';
 
 import 'package:dart_mcp/server.dart';
+import 'package:file/file.dart';
+import 'package:file/local.dart';
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 import 'package:stream_channel/stream_channel.dart';
@@ -13,6 +15,7 @@ import 'mixins/analyzer.dart';
 import 'mixins/dart_cli.dart';
 import 'mixins/dtd.dart';
 import 'mixins/pub.dart';
+import 'utils/filesystem.dart';
 import 'utils/process_manager.dart';
 
 /// An MCP server for Dart and Flutter tooling.
@@ -26,10 +29,11 @@ final class DartToolingMCPServer extends MCPServer
         DartCliSupport,
         PubSupport,
         DartToolingDaemonSupport
-    implements ProcessManagerSupport {
+    implements ProcessManagerSupport, FileSystemSupport {
   DartToolingMCPServer(
     super.channel, {
     @visibleForTesting this.processManager = const LocalProcessManager(),
+    @visibleForTesting this.fs = const LocalFileSystem(),
   }) : super.fromStreamChannel(
          implementation: ServerImplementation(
            name: 'dart and flutter tooling',
@@ -48,4 +52,7 @@ final class DartToolingMCPServer extends MCPServer
 
   @override
   final LocalProcessManager processManager;
+
+  @override
+  final FileSystem fs;
 }

--- a/pkgs/dart_tooling_mcp_server/lib/src/utils/filesystem.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/utils/filesystem.dart
@@ -1,0 +1,17 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:file/file.dart';
+
+/// An interface class that provides a single getter of type [FileSystem].
+///
+/// The `DartToolingMCPServer` class implements this class so that [File]
+/// methods can be easily mocked during testing.
+///
+/// MCP support mixins like `DartCliSupport` that access files should also
+/// implement this class and use [fs] instead of making direct calls to
+/// dart:io's [File] and [Directory] classes.
+abstract interface class FileSystemSupport {
+  FileSystem get fs;
+}

--- a/pkgs/dart_tooling_mcp_server/pubspec.yaml
+++ b/pkgs/dart_tooling_mcp_server/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   dds_service_extensions: ^2.0.1
   devtools_shared: ^11.2.0
   dtd: ^2.4.0
+  file: ^7.0.1
   json_rpc_2: ^3.0.3
   # TODO: Get this another way.
   language_server_protocol:
@@ -33,6 +34,7 @@ dependencies:
   test_process: ^2.1.1
   vm_service: ^15.0.0
   watcher: ^1.1.1
+  yaml: ^3.1.3
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.2.1

--- a/pkgs/dart_tooling_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_tooling_mcp_server/test/test_harness.dart
@@ -12,6 +12,8 @@ import 'package:dart_tooling_mcp_server/src/mixins/dtd.dart';
 import 'package:dart_tooling_mcp_server/src/server.dart';
 import 'package:dart_tooling_mcp_server/src/utils/constants.dart';
 import 'package:dtd/dtd.dart';
+import 'package:file/file.dart';
+import 'package:file/local.dart';
 import 'package:path/path.dart' as p;
 import 'package:process/process.dart';
 import 'package:stream_channel/stream_channel.dart';
@@ -32,6 +34,8 @@ class TestHarness {
   final FakeEditorExtension fakeEditorExtension;
   final DartToolingMCPClient mcpClient;
   final ServerConnectionPair serverConnectionPair;
+  final FileSystem fs;
+
   ServerConnection get mcpServerConnection =>
       serverConnectionPair.serverConnection;
 
@@ -39,6 +43,7 @@ class TestHarness {
     this.mcpClient,
     this.serverConnectionPair,
     this.fakeEditorExtension,
+    this.fs,
   );
 
   /// Starts a Dart Tooling Daemon as well as an MCP client and server, and
@@ -56,13 +61,19 @@ class TestHarness {
   /// MCP server is ran in process.
   ///
   /// Use [startDebugSession] to start up apps and connect to them.
-  static Future<TestHarness> start({bool inProcess = false}) async {
+  static Future<TestHarness> start({
+    bool inProcess = false,
+    FileSystem? fs,
+  }) async {
+    final fileSystem = fs ?? const LocalFileSystem();
+
     final mcpClient = DartToolingMCPClient();
     addTearDown(mcpClient.shutdown);
 
     final serverConnectionPair = await _initializeMCPServer(
       mcpClient,
       inProcess,
+      fileSystem,
     );
     final connection = serverConnectionPair.serverConnection;
     connection.onLog.listen((log) {
@@ -72,7 +83,12 @@ class TestHarness {
     final fakeEditorExtension = await FakeEditorExtension.connect();
     addTearDown(fakeEditorExtension.shutdown);
 
-    return TestHarness._(mcpClient, serverConnectionPair, fakeEditorExtension);
+    return TestHarness._(
+      mcpClient,
+      serverConnectionPair,
+      fakeEditorExtension,
+      fileSystem,
+    );
   }
 
   /// Starts an app debug session.
@@ -89,6 +105,7 @@ class TestHarness {
       args: args,
     );
     await fakeEditorExtension.addDebugSession(session);
+
     final root = rootForPath(projectRoot);
     final roots = (await mcpClient.handleListRoots(ListRootsRequest())).roots;
     if (!roots.any((r) => r.uri == root.uri)) {
@@ -96,6 +113,10 @@ class TestHarness {
     }
     return session;
   }
+
+  /// Creates a canonical [Root] object for a given [projectPath].
+  Root rootForPath(String projectPath) =>
+      Root(uri: fs.directory(projectPath).absolute.uri.toString());
 
   /// Stops an app debug session.
   Future<void> stopDebugSession(AppDebugSession session) async {
@@ -369,6 +390,7 @@ typedef ServerConnectionPair =
 Future<ServerConnectionPair> _initializeMCPServer(
   MCPClient client,
   bool inProcess,
+  FileSystem fileSystem,
 ) async {
   ServerConnection connection;
   DartToolingMCPServer? server;
@@ -392,6 +414,7 @@ Future<ServerConnectionPair> _initializeMCPServer(
     server = DartToolingMCPServer(
       serverChannel,
       processManager: TestProcessManager(),
+      fs: fileSystem,
     );
     addTearDown(server.shutdown);
     connection = client.connectServer(clientChannel);
@@ -410,10 +433,6 @@ Future<ServerConnectionPair> _initializeMCPServer(
   connection.notifyInitialized(InitializedNotification());
   return (serverConnection: connection, server: server);
 }
-
-/// Creates a canonical [Root] object for a given [projectPath].
-Root rootForPath(String projectPath) =>
-    Root(uri: Directory(projectPath).absolute.uri.toString());
 
 final counterAppPath = p.join('test_fixtures', 'counter_app');
 

--- a/pkgs/dart_tooling_mcp_server/test/tools/analyzer_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/analyzer_test.dart
@@ -33,7 +33,7 @@ void main() {
     });
 
     test('can analyze a project', () async {
-      final counterAppRoot = rootForPath(counterAppPath);
+      final counterAppRoot = testHarness.rootForPath(counterAppPath);
       testHarness.mcpClient.addRoot(counterAppRoot);
       // Allow the notification to propagate, and the server to ask for the new
       // list of roots.
@@ -53,7 +53,7 @@ void main() {
         d.file('main.dart', 'void main() => 1 + "2";'),
       ]);
       await example.create();
-      final exampleRoot = rootForPath(example.io.path);
+      final exampleRoot = testHarness.rootForPath(example.io.path);
       testHarness.mcpClient.addRoot(exampleRoot);
 
       // Allow the notification to propagate, and the server to ask for the new
@@ -91,7 +91,7 @@ void main() {
     });
 
     test('can look up symbols in a workspace', () async {
-      final currentRoot = rootForPath(Directory.current.path);
+      final currentRoot = testHarness.rootForPath(Directory.current.path);
       testHarness.mcpClient.addRoot(currentRoot);
       await pumpEventQueue();
 
@@ -114,7 +114,7 @@ void main() {
     });
 
     test('can get signature help', () async {
-      final counterAppRoot = rootForPath(counterAppPath);
+      final counterAppRoot = testHarness.rootForPath(counterAppPath);
       testHarness.mcpClient.addRoot(counterAppRoot);
       await pumpEventQueue();
 

--- a/pkgs/dart_tooling_mcp_server/test/tools/dart_cli_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/dart_cli_test.dart
@@ -16,7 +16,7 @@ void main() {
   // This root is arbitrary for these tests since we are not actually running
   // the CLI commands, but rather sending them through the
   // [TestProcessManager] wrapper.
-  final testRoot = rootForPath(counterAppPath);
+  Root getTestRoot() => testHarness.rootForPath(counterAppPath);
 
   // TODO: Use setUpAll, currently this fails due to an apparent TestProcess
   // issue.
@@ -26,7 +26,7 @@ void main() {
         testHarness.serverConnectionPair.server!.processManager
             as TestProcessManager;
 
-    testHarness.mcpClient.addRoot(testRoot);
+    testHarness.mcpClient.addRoot(getTestRoot());
     await pumpEventQueue();
   });
 
@@ -49,7 +49,7 @@ void main() {
         name: dartFixTool.name,
         arguments: {
           ParameterNames.roots: [
-            {ParameterNames.root: testRoot.uri},
+            {ParameterNames.root: getTestRoot().uri},
           ],
         },
       );
@@ -67,7 +67,7 @@ void main() {
         name: dartFormatTool.name,
         arguments: {
           ParameterNames.roots: [
-            {ParameterNames.root: testRoot.uri},
+            {ParameterNames.root: getTestRoot().uri},
           ],
         },
       );
@@ -86,7 +86,7 @@ void main() {
         arguments: {
           ParameterNames.roots: [
             {
-              ParameterNames.root: testRoot.uri,
+              ParameterNames.root: getTestRoot().uri,
               ParameterNames.paths: ['foo.dart', 'bar.dart'],
             },
           ],

--- a/pkgs/dart_tooling_mcp_server/test/utils/cli_utils_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/utils/cli_utils_test.dart
@@ -5,6 +5,7 @@
 import 'package:dart_mcp/server.dart';
 import 'package:dart_tooling_mcp_server/src/utils/cli_utils.dart';
 import 'package:dart_tooling_mcp_server/src/utils/constants.dart';
+import 'package:file/memory.dart';
 import 'package:process/process.dart';
 import 'package:test/fake.dart';
 import 'package:test/test.dart';
@@ -12,8 +13,15 @@ import 'package:test/test.dart';
 import '../test_harness.dart';
 
 void main() {
+  late MemoryFileSystem fileSystem;
+
+  setUp(() async {
+    fileSystem = MemoryFileSystem();
+  });
+
   group('can run commands', () {
     late TestProcessManager processManager;
+
     setUp(() async {
       processManager = TestProcessManager();
     });
@@ -32,6 +40,7 @@ void main() {
         commandDescription: '',
         processManager: processManager,
         knownRoots: [Root(uri: 'file:///bar/')],
+        fileSystem: fileSystem,
       );
       expect(result.isError, isNot(true));
       expect(processManager.commandsRan, [
@@ -55,6 +64,7 @@ void main() {
           commandDescription: '',
           processManager: processManager,
           knownRoots: [Root(uri: 'file:///bar/')],
+          fileSystem: fileSystem,
         );
         expect(result.isError, isNot(true));
         expect(processManager.commandsRan, [
@@ -82,6 +92,7 @@ void main() {
           commandDescription: '',
           processManager: processManager,
           knownRoots: [Root(uri: 'file:///foo/')],
+          fileSystem: fileSystem,
         );
         expect(result.isError, isTrue);
         expect(
@@ -117,6 +128,7 @@ void main() {
         commandDescription: '',
         processManager: processManager,
         knownRoots: [Root(uri: 'file:///foo/')],
+        fileSystem: fileSystem,
       );
       expect(result.isError, isTrue);
       expect(


### PR DESCRIPTION
## Description

This adds a check in the pub tool that checks to see if a project is a Flutter project before it calls the pub tool.  If it is, then it automatically runs 'flutter pub' instead of 'dart pub'.

This required that tests write to the filesystem, so I added a `FileSystemSupport` mixin so that the test harness could provide a `MemoryFileSystem` instead of using a local (real) filesystem.

`FileSystemSupport` can't override out-of-process tests, of course, but it's useful for in-process tests.

## Related Issues
 - https://github.com/dart-lang/ai/issues/81

## Tests
 - Added a test to make sure it conditionally runs flutter.