### PR TITLE
add hover tool support

### DIFF
--- a/pkgs/dart_tooling_mcp_server/README.md
+++ b/pkgs/dart_tooling_mcp_server/README.md
@@ -10,6 +10,7 @@ WIP. This package is still experimental and is likely to evolve quickly.
 | --- | --- | --- |
 | `analyze_files` | `static analysis` | Analyzes the entire project for errors. |
 | `signature_help` | `static_analysis` | Gets signature information for usage at a given cursor position. |
+| `hover` | `static_analysis` | Gets the hover information for a given cursor position. |
 | `resolve_workspace_symbol` | `static analysis` | Look up a symbol or symbols in all workspaces by name. |
 | `dart_fix` | `static tool` | Runs `dart fix --apply` for the given project roots. |
 | `dart_format` | `static tool` | Runs `dart format .` for the given project roots. |

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
@@ -173,6 +173,7 @@ base mixin DartAnalyzerSupport
                     ),
                   ),
                   textDocument: lsp.TextDocumentClientCapabilities(
+                    hover: lsp.HoverClientCapabilities(),
                     publishDiagnostics:
                         lsp.PublishDiagnosticsClientCapabilities(),
                     signatureHelp: lsp.SignatureHelpClientCapabilities(),

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
@@ -441,24 +441,7 @@ base mixin DartAnalyzerSupport
     description:
         'Get signature help for an API being used at a given cursor '
         'position in a file.',
-    inputSchema: Schema.object(
-      properties: {
-        ParameterNames.uri: Schema.string(
-          description: 'The URI of the file to get signature help for.',
-        ),
-        ParameterNames.line: Schema.int(
-          description: 'The line number of the cursor position.',
-        ),
-        ParameterNames.column: Schema.int(
-          description: 'The column number of the cursor position.',
-        ),
-      },
-      required: [
-        ParameterNames.uri,
-        ParameterNames.line,
-        ParameterNames.column,
-      ],
-    ),
+    inputSchema: _locationSchema,
     annotations: ToolAnnotations(title: 'Signature help', readOnlyHint: true),
   );
 
@@ -467,26 +450,9 @@ base mixin DartAnalyzerSupport
     name: 'hover',
     description:
         'Get hover information at a given cursor position in a file. This can '
-        'include documentation, type information, etc for the text at the '
+        'include documentation, type information, etc for the text at that '
         'position.',
-    inputSchema: Schema.object(
-      properties: {
-        ParameterNames.uri: Schema.string(
-          description: 'The URI of the file to get hover information for.',
-        ),
-        ParameterNames.line: Schema.int(
-          description: 'The line number of the cursor position.',
-        ),
-        ParameterNames.column: Schema.int(
-          description: 'The column number of the cursor position.',
-        ),
-      },
-      required: [
-        ParameterNames.uri,
-        ParameterNames.line,
-        ParameterNames.column,
-      ],
-    ),
+    inputSchema: _locationSchema,
     annotations: ToolAnnotations(
       title: 'Hover information',
       readOnlyHint: true,
@@ -505,6 +471,20 @@ base mixin DartAnalyzerSupport
     ],
   );
 }
+
+/// Common schema for tools that require a file URI, line, and column.
+final _locationSchema = Schema.object(
+  properties: {
+    ParameterNames.uri: Schema.string(description: 'The URI of the file.'),
+    ParameterNames.line: Schema.int(
+      description: 'The zero-based line number of the cursor position.',
+    ),
+    ParameterNames.column: Schema.int(
+      description: 'The zero-based column number of the cursor position.',
+    ),
+  },
+  required: [ParameterNames.uri, ParameterNames.line, ParameterNames.column],
+);
 
 extension on Root {
   /// Converts a [Root] to an [lsp.WorkspaceFolder].


### PR DESCRIPTION
An additional tool to be used to get information for a cursor position, forwards directly to the LSP hover support https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_hover.