### PR TITLE
Fix notification bug where null parameters caused type error

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Update workflow example to show thinking spinner and input and output token
   usage.
 - Update file system example to support relative paths.
+- Fix a bug in notification handling where leaving off the parameters caused a
+  type exception.
 
 ## 0.2.0
 

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -257,7 +257,7 @@ base class ServerConnection extends MCPBase {
   }
 
   /// Called after a successful call to [initialize].
-  void notifyInitialized(InitializedNotification notification) =>
+  void notifyInitialized([InitializedNotification? notification]) =>
       sendNotification(InitializedNotification.methodName, notification);
 
   /// Initializes the server, this should be done before anything else.

--- a/pkgs/dart_mcp/lib/src/shared.dart
+++ b/pkgs/dart_mcp/lib/src/shared.dart
@@ -68,7 +68,9 @@ base class MCPBase {
     void Function(T) impl,
   ) => _peer.registerMethod(
     name,
-    (Parameters p) => impl((p.value as Map?)?.cast<String, Object?>() as T),
+    (Parameters p) => impl(
+      (p.value as Map? ?? <String, Object?>{}).cast<String, Object?>() as T,
+    ),
   );
 
   /// Sends a notification to the peer.

--- a/pkgs/dart_mcp/test/client_and_server_test.dart
+++ b/pkgs/dart_mcp/test/client_and_server_test.dart
@@ -121,6 +121,35 @@ void main() {
     );
   });
 
+  test(
+    'server can handle initialized notification with null parameters',
+    () async {
+      final serverLog = StreamController<String>();
+      final environment = TestEnvironment(
+        TestMCPClient(),
+        (c) => TestMCPServer(c, protocolLogSink: serverLog.sink),
+      );
+      await environment.serverConnection.initialize(
+        InitializeRequest(
+          protocolVersion: ProtocolVersion.latestSupported,
+          capabilities: environment.client.capabilities,
+          clientInfo: environment.client.implementation,
+        ),
+      );
+      // Send a notification that doesn't have any parameters.
+      environment.serverConnection.notifyInitialized();
+      await environment.server.initialized;
+      expect(
+        serverLog.stream,
+        emitsInOrder([
+          allOf(startsWith('<<<'), contains('initialize')),
+          allOf(startsWith('>>>'), contains('serverInfo')),
+          allOf(startsWith('<<<'), contains('notifications/initialized')),
+        ]),
+      );
+    },
+  );
+
   test('clients can handle progress notifications', () async {
     final environment = TestEnvironment(
       TestMCPClient(),


### PR DESCRIPTION
This fixes a bug in notification handling where if the parameters were left off, as in:

```json
{"jsonrpc":"2.0","method":"notifications/initialized"}
```

instead of:

```json
{"jsonrpc":"2.0","method":"notifications/initialized", "params": {}}
```

A type error would get silently ignored and the notification would never be received.