### PR TITLE
use `dart pub run` for the server to speed up tests. 

### DIFF
--- a/pkgs/dart_tooling_mcp_server/README.md
+++ b/pkgs/dart_tooling_mcp_server/README.md
@@ -27,12 +27,30 @@ WIP. This package is still experimental and is likely to evolve quickly.
 
 ## Usage
 
-To use this package, you will need to compile the `bin/main.dart` script to exe
-and use the compiled path as the command in your MCP server config.
+This server only supports the STDIO transport mechanism and runs locally on
+your machine. Many of the tools require that your MCP client has `roots`
+support, and usage of the tools is scoped to only these directories.
 
-```shell
+The server entrypoint lives at `bin/main.dart`, and is can be ran however you
+choose, but the easiest way is to run it as a globally activated package:
+
+```sh
+dart pub global activate -s path .
+```
+
+And the, assuming the pub cache bin dir  is set up on your PATH, the
+`dart_tooling_mcp_server` command will run it, and recompile as necessary.
+
+**Note:**: For some clients, depending on how they launch the MCP server and how
+tolerant they are, you may need to compile it to exe to avoid extra output on
+stdout:
+
+```sh
 dart compile exe bin/main.dart
 ```
+
+And then provide the path to the executable instead of using the globally
+activated `dart_tooling_mcp_server` command.
 
 ### With the example WorkflowBot
 
@@ -45,15 +63,16 @@ the app you wish to test the server against.
 
 
 ```dart
-dart ../dart_mcp/example/workflow_client.dart --server bin/main.exe
+dart ../dart_mcp/example/workflow_client.dart --server dart_tooling_mcp_server
 ```
 
 ### With Cursor
 
 Go to Cursor -> Settings -> Cursor Settings and select "MCP".
 
-Then, click "Add new global MCP server". Put in the full path to the executable
-you created in the first step as the "command".
+Then, click "Add new global MCP server". Assuming you have already globally
+activated the package and it is on  your path, you can add
+`dart_tooling_mcp_server` as the command.
 
 If you are directly editing your mcp.json file, it should look like this:
 
@@ -61,16 +80,16 @@ If you are directly editing your mcp.json file, it should look like this:
 {
   "mcpServers": {
     "dart_mcp": {
-      "command": "<path-to-compiled-exe>",
+      "command": "dart_tooling_mcp_server",
       "args": []
     }
   }
 }
 ```
 
-Each time you make changes to the server, you'll need to re-run
-`dart compile exe bin/main.dart` and reload the Cursor window
-(Developer: Reload Window from the Command Pallete) to see the changes.
+Each time you make changes to the server, you'll need to restart the server on
+the MCP configuration page or reload the Cursor window (Developer: Reload Window
+from the Command Palette) to see the changes.
 
 ## Development
 
@@ -81,8 +100,7 @@ For local development, use the [MCP Inspector](https://modelcontextprotocol.io/d
     npx @modelcontextprotocol/inspector
     ```
 
-2. Open the MCP Inspector in the browser and enter the path to the server
-executable in the "Command" field
-(e.g. `/Users/me/path/to/ai/pkgs/dart_tooling_mcp_server/bin/main.exe`).
+2. Open the MCP Inspector in the browser and enter `dart_tooling_mcp_server` in
+the "Command" field.
 
 3. Click "Connect" to connect to the server and debug using the MCP Inspector.

--- a/pkgs/dart_tooling_mcp_server/README.md
+++ b/pkgs/dart_tooling_mcp_server/README.md
@@ -32,14 +32,25 @@ your machine. Many of the tools require that your MCP client has `roots`
 support, and usage of the tools is scoped to only these directories.
 
 The server entrypoint lives at `bin/main.dart`, and is can be ran however you
-choose, but the easiest way is to run it as a globally activated package:
+choose, but the easiest way is to run it as a globally activated package.
+
+You can globally activate it from path for local development:
 
 ```sh
 dart pub global activate -s path .
 ```
 
-And the, assuming the pub cache bin dir  is set up on your PATH, the
+Or from git:
+
+```sh
+dart pub global activate -s git https://github.com/dart-lang/ai.git \
+  --git-path pkgs/dart_tooling_mcp_server/
+```
+
+And then, assuming the pub cache bin dir is [on your PATH][set-up-path], the
 `dart_tooling_mcp_server` command will run it, and recompile as necessary.
+
+[set-up-path]: https://dart.dev/tools/pub/cmd/pub-global#running-a-script-from-your-path
 
 **Note:**: For some clients, depending on how they launch the MCP server and how
 tolerant they are, you may need to compile it to exe to avoid extra output on

--- a/pkgs/dart_tooling_mcp_server/README.md
+++ b/pkgs/dart_tooling_mcp_server/README.md
@@ -31,7 +31,7 @@ This server only supports the STDIO transport mechanism and runs locally on
 your machine. Many of the tools require that your MCP client has `roots`
 support, and usage of the tools is scoped to only these directories.
 
-The server entrypoint lives at `bin/main.dart`, and is can be ran however you
+The server entrypoint lives at `bin/main.dart`, and can be ran however you
 choose, but the easiest way is to run it as a globally activated package.
 
 You can globally activate it from path for local development:

--- a/pkgs/dart_tooling_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_tooling_mcp_server/test/test_harness.dart
@@ -18,7 +18,6 @@ import 'package:path/path.dart' as p;
 import 'package:process/process.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
-import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';
 
 /// A full environment for integration testing the MCP server.
@@ -363,20 +362,6 @@ Future<String> _getDTDUri(TestProcess dtdProcess) async {
   return dtdUri;
 }
 
-/// Compiles the dart tooling mcp server to AOT and returns the location.
-Future<String> _compileMCPServer() async {
-  final filePath = d.path('main.exe');
-  final result = await TestProcess.start(Platform.executable, [
-    'compile',
-    'exe',
-    'bin/main.dart',
-    '-o',
-    filePath,
-  ]);
-  await result.shouldExit(0);
-  return filePath;
-}
-
 typedef ServerConnectionPair =
     ({ServerConnection serverConnection, DartToolingMCPServer? server});
 
@@ -416,7 +401,11 @@ Future<ServerConnectionPair> _initializeMCPServer(
     addTearDown(server.shutdown);
     connection = client.connectServer(clientChannel);
   } else {
-    connection = await client.connectStdioServer(await _compileMCPServer(), []);
+    connection = await client.connectStdioServer('dart', [
+      'run',
+      '-r',
+      'bin/main.dart',
+    ]);
   }
 
   final initializeResult = await connection.initialize(

--- a/pkgs/dart_tooling_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_tooling_mcp_server/test/test_harness.dart
@@ -402,8 +402,8 @@ Future<ServerConnectionPair> _initializeMCPServer(
     connection = client.connectServer(clientChannel);
   } else {
     connection = await client.connectStdioServer('dart', [
+      'pub', // Using `pub` gives us incremental compilation
       'run',
-      '-r',
       'bin/main.dart',
     ]);
   }


### PR DESCRIPTION
Also updates the readme with pub global activate instructions as opposed to suggesting you must use the compiled exe. This makes development a lot easier (don't have to recompile manually all the time).

Closes https://github.com/dart-lang/ai/issues/44