### PR TITLE
Add some flags to example, fix version issue

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Update file system example to support relative paths.
 - Fix a bug in notification handling where leaving off the parameters caused a
   type exception.
+- Added a `--help` and `--model` flag to examples.
+- Fixed a bug where the examples would only connect to a server with the latest
+  protocol version.
 
 ## 0.2.0
 

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Update file system example to support relative paths.
 - Fix a bug in notification handling where leaving off the parameters caused a
   type exception.
-- Added a `--help` and `--model` flag to examples.
+- Added `--help`, `--log`, and `--model` flags to the workflow example.
 - Fixed a bug where the examples would only connect to a server with the latest
   protocol version.
 

--- a/pkgs/dart_mcp/example/client.dart
+++ b/pkgs/dart_mcp/example/client.dart
@@ -26,8 +26,10 @@ void main() async {
   print('initialized: $initializeResult');
   if (!initializeResult.protocolVersion!.isSupported) {
     throw StateError(
-      'Protocol version mismatch, expected ${ProtocolVersion.latestSupported}, '
-      'got ${initializeResult.protocolVersion}',
+      'Protocol version mismatch, expected a version between '
+      '${ProtocolVersion.oldestSupported} and '
+      '${ProtocolVersion.latestSupported}, but received '
+      '${initializeResult.protocolVersion}',
     );
   }
 

--- a/pkgs/dart_mcp/example/client.dart
+++ b/pkgs/dart_mcp/example/client.dart
@@ -24,7 +24,7 @@ void main() async {
     ),
   );
   print('initialized: $initializeResult');
-  if (initializeResult.protocolVersion != ProtocolVersion.latestSupported) {
+  if (!initializeResult.protocolVersion!.isSupported) {
     throw StateError(
       'Protocol version mismatch, expected ${ProtocolVersion.latestSupported}, '
       'got ${initializeResult.protocolVersion}',

--- a/pkgs/dart_mcp/example/workflow_client.dart
+++ b/pkgs/dart_mcp/example/workflow_client.dart
@@ -12,6 +12,14 @@ import 'package:cli_util/cli_logging.dart';
 import 'package:dart_mcp/client.dart';
 import 'package:google_generative_ai/google_generative_ai.dart' as gemini;
 
+/// The list of Gemini models that are accepted as a "--model" argument.
+/// Defaults to the first one in the list.
+const List<String> allowedGeminiModels = [
+  'gemini-2.5-pro-exp-03-25',
+  'gemini-2.0-flash',
+  'gemini-2.5-flash-preview-04-17',
+];
+
 void main(List<String> args) {
   final geminiApiKey = Platform.environment['GEMINI_API_KEY'];
   if (geminiApiKey == null) {
@@ -29,6 +37,7 @@ void main(List<String> args) {
   }
   final serverCommands = parsedArgs['server'] as List<String>;
   final logger = Logger.standard();
+  final logFilePath = parsedArgs.option('log');
   runZonedGuarded(
     () {
       WorkflowClient(
@@ -36,13 +45,14 @@ void main(List<String> args) {
         geminiApiKey: geminiApiKey,
         verbose: parsedArgs.flag('verbose'),
         dtdUri: parsedArgs.option('dtd'),
-        model: parsedArgs.option('model'),
+        model: parsedArgs.option('model')!,
         persona: parsedArgs.flag('dash') ? _dashPersona : null,
         logger: logger,
+        logFile: logFilePath != null ? File(logFilePath) : null,
       );
     },
-    (e, s) {
-      logger.stderr('$e\n$s\n');
+    (exception, stack) {
+      logger.stderr('$exception\n$stack\n');
     },
   );
 }
@@ -59,6 +69,13 @@ final argParser =
         abbr: 'v',
         help: 'Enables verbose logging for logs from servers.',
       )
+      ..addOption(
+        'log',
+        abbr: 'l',
+        help:
+            'If specified, will create the given log file and log server '
+            'traffic and diagnostic messages.',
+      )
       ..addFlag('dash', help: 'Use the Dash mascot persona.', defaultsTo: false)
       ..addOption(
         'dtd',
@@ -66,29 +83,24 @@ final argParser =
       )
       ..addOption(
         'model',
-        // defaultsTo: 'gemini-2.0-flash',
-        // defaultsTo: 'gemini-2.5-flash-preview-04-17',
-        defaultsTo: 'gemini-2.5-pro-exp-03-25',
-        // defaultsTo: 'gemini-2.5-flash-preview-04-17',
+        defaultsTo: allowedGeminiModels.first,
+        allowed: allowedGeminiModels,
         help: 'Pass the name of the model to use to run inferences.',
       )
       ..addFlag('help', abbr: 'h', help: 'Print the usage for this command.');
 
 final class WorkflowClient extends MCPClient with RootsSupport {
-  final Logger logger;
-  int totalInputTokens = 0;
-  int totalOutputTokens = 0;
-
   WorkflowClient(
     this.serverCommands, {
     required String geminiApiKey,
-    String? dtdUri,
-    String? model,
-    this.verbose = false,
+    required String model,
     required this.logger,
+    String? dtdUri,
+    this.verbose = false,
     String? persona,
+    File? logFile,
   }) : model = gemini.GenerativeModel(
-         model: model ?? 'gemini-2.0-flash',
+         model: model,
          apiKey: geminiApiKey,
          systemInstruction: systemInstructions(persona: persona),
        ),
@@ -98,6 +110,7 @@ final class WorkflowClient extends MCPClient with RootsSupport {
        super(
          ClientImplementation(name: 'Gemini workflow client', version: '0.1.0'),
        ) {
+    logSink = _createLogSink(logFile);
     addRoot(
       Root(
         uri: Directory.current.absolute.uri.toString(),
@@ -123,6 +136,10 @@ final class WorkflowClient extends MCPClient with RootsSupport {
     _startChat();
   }
 
+  final Logger logger;
+  Sink<String>? logSink;
+  int totalInputTokens = 0;
+  int totalOutputTokens = 0;
   final StreamQueue<String> stdinQueue;
   final List<String> serverCommands;
   final List<ServerConnection> serverConnections = [];
@@ -130,6 +147,36 @@ final class WorkflowClient extends MCPClient with RootsSupport {
   final List<gemini.Content> chatHistory = [];
   final gemini.GenerativeModel model;
   final bool verbose;
+
+  Sink<String>? _createLogSink(File? logFile) {
+    if (logFile == null) {
+      return null;
+    }
+    Sink<String>? logSink;
+    logFile.createSync(recursive: true);
+    final fileByteSink = logFile.openWrite(
+      mode: FileMode.write,
+      encoding: utf8,
+    );
+    logSink = fileByteSink.transform<String>(
+      StreamSinkTransformer.fromHandlers(
+        handleData: (String data, EventSink<List<int>> innerSink) {
+          innerSink.add(utf8.encode(data));
+        },
+        handleError: (
+          Object error,
+          StackTrace stackTrace,
+          EventSink<List<int>> innerSink,
+        ) {
+          innerSink.addError(error, stackTrace);
+        },
+        handleDone: (EventSink<List<int>> innerSink) {
+          innerSink.close();
+        },
+      ),
+    );
+    return logSink;
+  }
 
   void _startChat() async {
     if (serverCommands.isNotEmpty) {
@@ -330,9 +377,9 @@ final class WorkflowClient extends MCPClient with RootsSupport {
   /// Invokes a function and adds the result as context to the chat history.
   Future<void> _handleFunctionCall(gemini.FunctionCall functionCall) async {
     chatHistory.add(gemini.Content.model([functionCall]));
-    logger.stderr(
-      'Calling function ${functionCall.name} with args: '
-      '${functionCall.args}',
+    logSink?.add(
+      '+++ Calling function ${functionCall.name} with args: '
+      '${functionCall.args}\n',
     );
     final connection = connectionForFunction[functionCall.name]!;
     final result = await connection.callTool(
@@ -366,7 +413,11 @@ final class WorkflowClient extends MCPClient with RootsSupport {
       final parts = server.split(' ');
       try {
         serverConnections.add(
-          await connectStdioServer(parts.first, parts.skip(1).toList()),
+          await connectStdioServer(
+            parts.first,
+            parts.skip(1).toList(),
+            protocolLogSink: logSink,
+          ),
         );
       } catch (e) {
         logger.stderr('Failed to connect to server $server: $e');

--- a/pkgs/dart_mcp/lib/src/api/initialization.dart
+++ b/pkgs/dart_mcp/lib/src/api/initialization.dart
@@ -295,7 +295,7 @@ extension type Tools.fromMap(Map<String, Object?> _value) {
   }
 }
 
-/// Describes the name and version of an MCP implementation.
+/// Describes the name and version of an MCP client implementation.
 extension type ClientImplementation.fromMap(Map<String, Object?> _value) {
   factory ClientImplementation({
     required String name,
@@ -306,7 +306,7 @@ extension type ClientImplementation.fromMap(Map<String, Object?> _value) {
   String get version => _value['version'] as String;
 }
 
-/// Describes the name and version of an MCP implementation.
+/// Describes the name and version of an MCP server implementation.
 extension type ServerImplementation.fromMap(Map<String, Object?> _value) {
   factory ServerImplementation({
     required String name,

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -128,13 +128,16 @@ base class ServerConnection extends MCPBase {
 
   /// The [ServerImplementation] returned from the [initialize] request.
   ///
-  /// Only assigned after [initialize] has successfully completed.
-  late ServerImplementation serverInfo;
+  /// Only non-null after [initialize] has successfully completed.
+  ServerImplementation? serverInfo;
 
   /// The [ServerCapabilities] returned from the [initialize] request.
   ///
   /// Only assigned after [initialize] has successfully completed.
   late ServerCapabilities serverCapabilities;
+
+  @override
+  String get name => serverInfo?.name ?? super.name;
 
   /// Emits an event any time the server notifies us of a change to the list of
   /// prompts it supports.
@@ -212,7 +215,7 @@ base class ServerConnection extends MCPBase {
       registerRequestHandler(
         CreateMessageRequest.methodName,
         (CreateMessageRequest request) =>
-            samplingSupport.handleCreateMessage(request, serverInfo),
+            samplingSupport.handleCreateMessage(request, serverInfo!),
       );
     }
 

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -48,6 +48,9 @@ abstract base class MCPServer extends MCPBase {
   /// Only assigned after `initialize` has been called.
   late ClientCapabilities clientCapabilities;
 
+  @override
+  String get name => implementation.name;
+
   /// Emits an event any time the client notifies us of a change to the list of
   /// roots it supports.
   ///

--- a/pkgs/dart_mcp/lib/src/shared.dart
+++ b/pkgs/dart_mcp/lib/src/shared.dart
@@ -167,7 +167,7 @@ StreamChannel<String> _maybeForwardMessages(
       .transformStream(
         StreamTransformer.fromHandlers(
           handleData: (data, sink) {
-            protocolLogSink.add('<<< $data');
+            protocolLogSink.add('<<< $data\n');
             sink.add(data);
           },
         ),
@@ -175,7 +175,7 @@ StreamChannel<String> _maybeForwardMessages(
       .transformSink(
         StreamSinkTransformer.fromHandlers(
           handleData: (data, sink) {
-            protocolLogSink.add('>>> $data');
+            protocolLogSink.add('>>> $data\n');
             sink.add(data);
           },
         ),

--- a/pkgs/dart_mcp/lib/src/shared.dart
+++ b/pkgs/dart_mcp/lib/src/shared.dart
@@ -2,21 +2,33 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+/// @docImport 'client/client.dart';
+/// @docImport 'server/server.dart';
+library;
+
 import 'dart:async';
 
 import 'package:async/async.dart' show StreamSinkTransformer;
 import 'package:json_rpc_2/json_rpc_2.dart';
 import 'package:meta/meta.dart';
 import 'package:stream_channel/stream_channel.dart';
-
 import 'api/api.dart';
 
-/// Base class for both client and server implementations.
+/// Base class for MCP server-related implementations.
 ///
 /// Handles registering method and notification handlers, sending requests and
 /// notifications, progress support, and any other shared functionality.
+///
+/// See also:
+/// - [MCPServer] A base class to extend when implementing an MCP server.
+/// - [ServerConnection] A class that represents an active server connection.
 base class MCPBase {
-  final Peer _peer;
+  late final Peer _peer;
+
+  /// The name of the associated server.
+  ///
+  /// Used to identify log messages.
+  String get name => 'unknown';
 
   /// Progress controllers by token.
   ///
@@ -27,8 +39,8 @@ base class MCPBase {
   /// Whether the connection with the peer is active.
   bool get isActive => !_peer.isClosed;
 
-  MCPBase(StreamChannel<String> channel, {Sink<String>? protocolLogSink})
-    : _peer = Peer(_maybeForwardMessages(channel, protocolLogSink)) {
+  MCPBase(StreamChannel<String> channel, {Sink<String>? protocolLogSink}) {
+    _peer = Peer(_maybeForwardMessages(channel, protocolLogSink));
     registerNotificationHandler(
       ProgressNotification.methodName,
       _handleProgress,
@@ -150,34 +162,34 @@ base class MCPBase {
         PingRequest.methodName,
         null,
       ).then((_) => true).timeout(timeout, onTimeout: () => false);
-}
 
-/// If [protocolLogSink] is non-null, emits messages to it for all messages
-/// sent over [channel].
-///
-/// This is intended to be written to a file or emitted to a user to aid in
-/// debugging protocol messages between the client and server.
-StreamChannel<String> _maybeForwardMessages(
-  StreamChannel<String> channel,
-  Sink<String>? protocolLogSink,
-) {
-  if (protocolLogSink == null) return channel;
+  /// If [protocolLogSink] is non-null, emits messages to it for all messages
+  /// sent over [channel].
+  ///
+  /// This is intended to be written to a file or emitted to a user to aid in
+  /// debugging protocol messages between the client and server.
+  StreamChannel<String> _maybeForwardMessages(
+    StreamChannel<String> channel,
+    Sink<String>? protocolLogSink,
+  ) {
+    if (protocolLogSink == null) return channel;
 
-  return channel
-      .transformStream(
-        StreamTransformer.fromHandlers(
-          handleData: (data, sink) {
-            protocolLogSink.add('<<< $data\n');
-            sink.add(data);
-          },
-        ),
-      )
-      .transformSink(
-        StreamSinkTransformer.fromHandlers(
-          handleData: (data, sink) {
-            protocolLogSink.add('>>> $data\n');
-            sink.add(data);
-          },
-        ),
-      );
+    return channel
+        .transformStream(
+          StreamTransformer.fromHandlers(
+            handleData: (data, sink) {
+              protocolLogSink.add('<<< ($name) $data\n');
+              sink.add(data);
+            },
+          ),
+        )
+        .transformSink(
+          StreamSinkTransformer.fromHandlers(
+            handleData: (data, sink) {
+              protocolLogSink.add('>>> ($name) $data\n');
+              sink.add(data);
+            },
+          ),
+        );
+  }
 }


### PR DESCRIPTION
## Description

Adds `--help`, `--log`, and `--model` flags to the workflow example and fixes a problem where the examples would only connect to servers with the latest protocol version (instead of any supported version).
