### PR TITLE
fix error handling around stream listeners

### DIFF
--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/dtd.dart
@@ -841,8 +841,8 @@ class _AppErrorsListener {
           vmService.streamListen(EventStreams.kExtension),
           vmService.streamListen(EventStreams.kStderr),
         ].wait;
-      } on RPCError catch (e) {
-        logger.log(LoggingLevel.error, 'Error subscribing app errors: $e');
+      } catch (e) {
+        logger.log(LoggingLevel.error, 'Error subscribing to app errors: $e');
       }
       return _AppErrorsListener._(
         errors,


### PR DESCRIPTION
This now gives a ParallelWaitError so the catch wasn't catching it, I just dropped the specific kind of error, we don't want anything from here to leak out and we are logging them.