### PR TITLE
Add RootsFallbackSupport mixin

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Added `--help`, `--log`, and `--model` flags to the workflow example.
 - Fixed a bug where the examples would only connect to a server with the latest
   protocol version.
+- Handle failed calls to `listRoots` in the `RootsTrackingSupport` mixin more
+  gracefully. Previously this would leave the `roots` future hanging
+  indefinitely, but now it will log an error and set the roots to empty.
 
 ## 0.2.0
 

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:json_rpc_2/json_rpc_2.dart';
 import 'package:meta/meta.dart';
 import 'package:stream_transform/stream_transform.dart';
 

--- a/pkgs/dart_tooling_mcp_server/bin/main.dart
+++ b/pkgs/dart_tooling_mcp_server/bin/main.dart
@@ -6,18 +6,17 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io' as io;
 
+import 'package:args/args.dart';
 import 'package:async/async.dart';
 import 'package:dart_mcp/server.dart';
 import 'package:dart_tooling_mcp_server/dart_tooling_mcp_server.dart';
 import 'package:stream_channel/stream_channel.dart';
 
 void main(List<String> args) async {
-  if (args.isNotEmpty) {
-    io.stderr
-      ..writeln('Expected no arguments but got ${args.length}.')
-      ..writeln()
-      ..writeln('Usage: dart_tooling_mcp_server');
-    io.exit(1);
+  final parsedArgs = argParser.parse(args);
+  if (parsedArgs.flag('help')) {
+    print(argParser.usage);
+    io.exit(0);
   }
 
   DartToolingMCPServer? server;
@@ -34,6 +33,7 @@ void main(List<String> args) async {
                 },
               ),
             ),
+        forceRootsFallback: parsedArgs.flag('force-roots-fallback'),
       );
     },
     (e, s) {
@@ -62,3 +62,16 @@ void main(List<String> args) async {
     ),
   );
 }
+
+final argParser =
+    ArgParser(allowTrailingOptions: false)
+      ..addFlag(
+        'force-roots-fallback',
+        negatable: true,
+        defaultsTo: false,
+        help:
+            'Forces a behavior for project roots which uses MCP tools instead of '
+            'the native MCP roots. This can be helpful for clients like cursor '
+            'which claim to have roots support but do not actually support it.',
+      )
+      ..addFlag('help', abbr: 'h', help: 'Show usage text');

--- a/pkgs/dart_tooling_mcp_server/bin/main.dart
+++ b/pkgs/dart_tooling_mcp_server/bin/main.dart
@@ -14,7 +14,7 @@ import 'package:stream_channel/stream_channel.dart';
 
 void main(List<String> args) async {
   final parsedArgs = argParser.parse(args);
-  if (parsedArgs.flag('help')) {
+  if (parsedArgs.flag(help)) {
     print(argParser.usage);
     io.exit(0);
   }
@@ -33,7 +33,7 @@ void main(List<String> args) async {
                 },
               ),
             ),
-        forceRootsFallback: parsedArgs.flag('force-roots-fallback'),
+        forceRootsFallback: parsedArgs.flag(forceRootsFallback),
       );
     },
     (e, s) {
@@ -66,7 +66,7 @@ void main(List<String> args) async {
 final argParser =
     ArgParser(allowTrailingOptions: false)
       ..addFlag(
-        'force-roots-fallback',
+        forceRootsFallback,
         negatable: true,
         defaultsTo: false,
         help:
@@ -75,4 +75,7 @@ final argParser =
             'cursor which claim to have roots support but do not actually '
             'support it.',
       )
-      ..addFlag('help', abbr: 'h', help: 'Show usage text');
+      ..addFlag(help, abbr: 'h', help: 'Show usage text');
+
+const forceRootsFallback = 'force-roots-fallback';
+const help = 'help';

--- a/pkgs/dart_tooling_mcp_server/bin/main.dart
+++ b/pkgs/dart_tooling_mcp_server/bin/main.dart
@@ -70,8 +70,9 @@ final argParser =
         negatable: true,
         defaultsTo: false,
         help:
-            'Forces a behavior for project roots which uses MCP tools instead of '
-            'the native MCP roots. This can be helpful for clients like cursor '
-            'which claim to have roots support but do not actually support it.',
+            'Forces a behavior for project roots which uses MCP tools instead '
+            'of the native MCP roots. This can be helpful for clients like '
+            'cursor which claim to have roots support but do not actually '
+            'support it.',
       )
       ..addFlag('help', abbr: 'h', help: 'Show usage text');

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
@@ -323,16 +323,6 @@ base mixin DartAnalyzerSupport
   /// Returns an error response if any prerequisite is not met, otherwise
   /// returns `null`.
   Future<CallToolResult?> _ensurePrerequisites(CallToolRequest request) async {
-    if (!supportsRootsChanged) {
-      return CallToolResult(
-        content: [
-          Content.text(
-            text:
-                'roots changed support not provided, roots support $supportsRoots',
-          ),
-        ],
-      );
-    }
     final roots = await this.roots;
     if (roots.isEmpty) {
       return noRootsSetResponse;

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/analyzer.dart
@@ -323,6 +323,16 @@ base mixin DartAnalyzerSupport
   /// Returns an error response if any prerequisite is not met, otherwise
   /// returns `null`.
   Future<CallToolResult?> _ensurePrerequisites(CallToolRequest request) async {
+    if (!supportsRootsChanged) {
+      return CallToolResult(
+        content: [
+          Content.text(
+            text:
+                'roots changed support not provided, roots support $supportsRoots',
+          ),
+        ],
+      );
+    }
     final roots = await this.roots;
     if (roots.isEmpty) {
       return noRootsSetResponse;

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/roots_fallback_support.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/roots_fallback_support.dart
@@ -1,0 +1,120 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:dart_mcp/server.dart';
+import 'package:meta/meta.dart';
+
+import '../utils/constants.dart';
+
+/// Adds a fallback mode for roots when they aren't supported.
+///
+/// Overrides [listRoots] to return the manually added roots through
+/// an MCP tool command.
+///
+/// Overrides [rootsListChanged] to return a custom stream of events based
+/// on the tool calls.
+base mixin RootsFallbackSupport on ToolsSupport, RootsTrackingSupport {
+  /// Set of custom roots
+  final Set<Root> _customRoots = HashSet<Root>(
+    equals: (a, b) => a.uri == b.uri,
+    hashCode: (root) => root.uri.hashCode,
+  );
+
+  @override
+  bool get supportsRoots => true;
+
+  @override
+  bool get supportsRootsChanged =>
+      // If the client supports roots, then we only support root change events
+      // if they do. If we are implementing the support, we always support it.
+      super.supportsRoots ? super.supportsRootsChanged : true;
+
+  @override
+  Stream<RootsListChangedNotification>? get rootsListChanged =>
+      // If the client supports roots, just use their stream (or lack thereof).
+      // If they don't, use our own stream.
+      super.supportsRoots
+          ? super.rootsListChanged
+          : _rootsListChangedFallbackController?.stream;
+  StreamController<RootsListChangedNotification>?
+  _rootsListChangedFallbackController;
+
+  @override
+  FutureOr<InitializeResult> initialize(InitializeRequest request) async {
+    registerTool(addRootsTool, addRoot);
+    try {
+      return super.initialize(request);
+    } finally {
+      if (!super.supportsRoots) {
+        _rootsListChangedFallbackController =
+            StreamController<RootsListChangedNotification>.broadcast();
+      }
+    }
+  }
+
+  /// Delegates to the inherited implementation if [supportsRoots] is true,
+  /// otherwise returns our own custom roots.
+  @override
+  Future<ListRootsResult> listRoots(ListRootsRequest request) async =>
+      supportsRoots
+          ? super.listRoots(request)
+          : ListRootsResult(roots: _customRoots.toList());
+
+  /// Adds the roots in [request] the custom roots and calls [updateRoots].
+  ///
+  /// Should only be called if [supportsRoots] is false.
+  Future<CallToolResult> addRoot(CallToolRequest request) async {
+    if (super.supportsRoots) {
+      throw StateError(
+        'This tool should not be invoked if the client supports roots',
+      );
+    }
+
+    final rootsConfigs =
+        (request.arguments?[ParameterNames.roots] as List?)
+            ?.cast<Map<String, Object?>>() ??
+        [];
+
+    for (final config in rootsConfigs) {
+      _customRoots.add(
+        Root(
+          uri: config[ParameterNames.uri] as String,
+          name: config[ParameterNames.name] as String?,
+        ),
+      );
+    }
+    _rootsListChangedFallbackController?.add(RootsListChangedNotification());
+    return CallToolResult(content: [Content.text(text: 'Success')]);
+  }
+
+  @visibleForTesting
+  static final addRootsTool = Tool(
+    name: 'add_roots',
+    description:
+        'Adds one or more project roots. Tools are only allowed to run under '
+        'these roots, so you must call this function before passing any roots '
+        'to any other tools.',
+    annotations: ToolAnnotations(title: 'Add roots', readOnlyHint: false),
+    inputSchema: Schema.object(
+      properties: {
+        ParameterNames.roots: Schema.list(
+          description: 'All the project roots to add to this server.',
+          items: Schema.object(
+            properties: {
+              ParameterNames.uri: Schema.string(
+                description: 'The URI of the root.',
+              ),
+              ParameterNames.name: Schema.string(
+                description: 'An optional name of the root.',
+              ),
+            },
+            required: [ParameterNames.uri],
+          ),
+        ),
+      },
+    ),
+  );
+}

--- a/pkgs/dart_tooling_mcp_server/lib/src/mixins/roots_fallback_support.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/mixins/roots_fallback_support.dart
@@ -25,7 +25,7 @@ base mixin RootsFallbackSupport on ToolsSupport, RootsTrackingSupport {
   );
 
   /// Whether or not to force the fallback mode for roots, regardless of the
-  /// clients reported support.
+  /// client's reported support.
   ///
   /// Override this to enable it.
   bool get forceRootsFallback => false;
@@ -81,7 +81,7 @@ base mixin RootsFallbackSupport on ToolsSupport, RootsTrackingSupport {
 
   /// Adds the roots in [request] the custom roots and calls [updateRoots].
   ///
-  /// Should only be called if [supportsRoots] is false.
+  /// Should only be called if [_fallbackEnabled] is `true`.
   Future<CallToolResult> _addRoots(CallToolRequest request) async {
     if (!_fallbackEnabled) {
       throw StateError(
@@ -89,19 +89,17 @@ base mixin RootsFallbackSupport on ToolsSupport, RootsTrackingSupport {
       );
     }
 
-    final roots =
-        (request.arguments![ParameterNames.roots] as List).cast<Root>();
-    for (final root in roots) {
-      _customRoots.add(root);
-    }
+    (request.arguments![ParameterNames.roots] as List).cast<Root>().forEach(
+      _customRoots.add,
+    );
     _rootsListChangedFallbackController?.add(RootsListChangedNotification());
-    return CallToolResult(content: [Content.text(text: 'Success')]);
+    return success;
   }
 
   /// Removes the roots in [request] from the custom roots and calls
   /// [updateRoots].
   ///
-  /// Should only be called if [supportsRoots] is false.
+  /// Should only be called if [_fallbackEnabled] is true.
   Future<CallToolResult> _removeRoots(CallToolRequest request) async {
     if (!_fallbackEnabled) {
       throw StateError(
@@ -115,7 +113,7 @@ base mixin RootsFallbackSupport on ToolsSupport, RootsTrackingSupport {
     _customRoots.removeAll(roots);
     _rootsListChangedFallbackController?.add(RootsListChangedNotification());
 
-    return CallToolResult(content: [Content.text(text: 'Success')]);
+    return success;
   }
 
   @override

--- a/pkgs/dart_tooling_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/server.dart
@@ -36,6 +36,7 @@ final class DartToolingMCPServer extends MCPServer
     super.channel, {
     @visibleForTesting this.processManager = const LocalProcessManager(),
     @visibleForTesting this.fileSystem = const LocalFileSystem(),
+    this.forceRootsFallback = false,
   }) : super.fromStreamChannel(
          implementation: ServerImplementation(
            name: 'dart and flutter tooling',
@@ -47,9 +48,13 @@ final class DartToolingMCPServer extends MCPServer
        );
 
   static Future<DartToolingMCPServer> connect(
-    StreamChannel<String> mcpChannel,
-  ) async {
-    return DartToolingMCPServer(mcpChannel);
+    StreamChannel<String> mcpChannel, {
+    bool forceRootsFallback = false,
+  }) async {
+    return DartToolingMCPServer(
+      mcpChannel,
+      forceRootsFallback: forceRootsFallback,
+    );
   }
 
   @override
@@ -57,4 +62,7 @@ final class DartToolingMCPServer extends MCPServer
 
   @override
   final FileSystem fileSystem;
+
+  @override
+  final bool forceRootsFallback;
 }

--- a/pkgs/dart_tooling_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/server.dart
@@ -15,6 +15,7 @@ import 'mixins/analyzer.dart';
 import 'mixins/dash_cli.dart';
 import 'mixins/dtd.dart';
 import 'mixins/pub.dart';
+import 'mixins/roots_fallback_support.dart';
 import 'utils/file_system.dart';
 import 'utils/process_manager.dart';
 
@@ -25,6 +26,7 @@ final class DartToolingMCPServer extends MCPServer
         ToolsSupport,
         ResourcesSupport,
         RootsTrackingSupport,
+        RootsFallbackSupport,
         DartAnalyzerSupport,
         DashCliSupport,
         PubSupport,

--- a/pkgs/dart_tooling_mcp_server/lib/src/utils/constants.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/utils/constants.dart
@@ -7,6 +7,7 @@ extension ParameterNames on Never {
   static const column = 'column';
   static const command = 'command';
   static const line = 'line';
+  static const name = 'name';
   static const packageName = 'packageName';
   static const paths = 'paths';
   static const position = 'position';

--- a/pkgs/dart_tooling_mcp_server/lib/src/utils/constants.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/utils/constants.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:dart_mcp/server.dart';
+
 /// A namespace for all the parameter names.
 extension ParameterNames on Never {
   static const column = 'column';
@@ -17,3 +19,6 @@ extension ParameterNames on Never {
   static const uri = 'uri';
   static const uris = 'uris';
 }
+
+/// A shared success response for tools.
+final success = CallToolResult(content: [Content.text(text: 'Success')]);

--- a/pkgs/dart_tooling_mcp_server/lib/src/utils/constants.dart
+++ b/pkgs/dart_tooling_mcp_server/lib/src/utils/constants.dart
@@ -15,4 +15,5 @@ extension ParameterNames on Never {
   static const root = 'root';
   static const roots = 'roots';
   static const uri = 'uri';
+  static const uris = 'uris';
 }

--- a/pkgs/dart_tooling_mcp_server/pubspec.yaml
+++ b/pkgs/dart_tooling_mcp_server/pubspec.yaml
@@ -13,6 +13,7 @@ executables:
   dart_tooling_mcp_server: main
 
 dependencies:
+  args: ^2.7.0
   async: ^2.13.0
   dart_mcp: ^0.2.0
   dds_service_extensions: ^2.0.1

--- a/pkgs/dart_tooling_mcp_server/test/tools/roots_fallback_support_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/roots_fallback_support_test.dart
@@ -197,7 +197,7 @@ final class TestClientWithoutRoots extends MCPClient {
       );
 }
 
-// A test client that does not support roots
+/// A test client that supports roots
 final class TestClientWithRoots extends MCPClient with RootsSupport {
   TestClientWithRoots()
     : super(
@@ -208,7 +208,7 @@ final class TestClientWithRoots extends MCPClient with RootsSupport {
       );
 }
 
-// Test class that mixes in RootsFallbackSupport
+/// A test server that mixes in RootsFallbackSupport
 final class TestServer extends MCPServer
     with
         LoggingSupport,

--- a/pkgs/dart_tooling_mcp_server/test/tools/roots_fallback_support_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/roots_fallback_support_test.dart
@@ -215,12 +215,18 @@ final class TestServer extends MCPServer
         ToolsSupport,
         RootsTrackingSupport,
         RootsFallbackSupport {
-  TestServer(super.channel, {super.protocolLogSink})
-    : super.fromStreamChannel(
-        implementation: ServerImplementation(
-          name: 'test server',
-          version: '0.1.0',
-        ),
-        instructions: 'A test server with roots fallback support',
-      );
+  @override
+  final bool forceRootsFallback;
+
+  TestServer(
+    super.channel, {
+    super.protocolLogSink,
+    this.forceRootsFallback = false,
+  }) : super.fromStreamChannel(
+         implementation: ServerImplementation(
+           name: 'test server',
+           version: '0.1.0',
+         ),
+         instructions: 'A test server with roots fallback support',
+       );
 }

--- a/pkgs/dart_tooling_mcp_server/test/tools/roots_fallback_support_test.dart
+++ b/pkgs/dart_tooling_mcp_server/test/tools/roots_fallback_support_test.dart
@@ -1,0 +1,226 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:async/async.dart';
+import 'package:dart_mcp/client.dart';
+import 'package:dart_mcp/server.dart';
+import 'package:dart_tooling_mcp_server/src/mixins/roots_fallback_support.dart';
+import 'package:dart_tooling_mcp_server/src/utils/constants.dart';
+import 'package:stream_channel/stream_channel.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late RootsTrackingSupport server;
+  late ServerConnection serverConnection;
+  final rootA = Root(uri: 'file:///a/');
+  final rootB = Root(uri: 'file:///b/');
+
+  late StreamController<String> clientController;
+  late StreamController<String> serverController;
+
+  setUp(() async {
+    clientController = StreamController<String>();
+    serverController = StreamController<String>();
+    server = TestServer(
+      StreamChannel.withCloseGuarantee(
+        serverController.stream,
+        clientController.sink,
+      ),
+    );
+    addTearDown(() async {
+      await clientController.close();
+      await serverController.close();
+    });
+  });
+
+  group('RootsFallbackSupport', () {
+    group('when the client doesn\'t support roots', () {
+      late TestClientWithoutRoots client;
+
+      Future<void> addRoots(List<Root> roots) async {
+        await serverConnection.callTool(
+          CallToolRequest(
+            name: RootsFallbackSupport.addRootsTool.name,
+            arguments: {ParameterNames.roots: roots},
+          ),
+        );
+      }
+
+      Future<void> removeRoots(List<Root> roots) async {
+        await serverConnection.callTool(
+          CallToolRequest(
+            name: RootsFallbackSupport.removeRootsTool.name,
+            arguments: {
+              ParameterNames.uris: [for (final root in roots) root.uri],
+            },
+          ),
+        );
+      }
+
+      setUp(() async {
+        client = TestClientWithoutRoots();
+        addTearDown(client.shutdown);
+        serverConnection = client.connectServer(
+          StreamChannel.withCloseGuarantee(
+            clientController.stream,
+            serverController.sink,
+          ),
+        );
+        await serverConnection.initialize(
+          InitializeRequest(
+            protocolVersion: ProtocolVersion.latestSupported,
+            capabilities: client.capabilities,
+            clientInfo: client.implementation,
+          ),
+        );
+        serverConnection.notifyInitialized();
+      });
+
+      test('supportsRoots is true', () async {
+        expect(server.supportsRoots, isTrue);
+      });
+
+      test('registers tools to add and remove roots', () async {
+        final tools = await serverConnection.listTools(ListToolsRequest());
+        expect(
+          tools.tools,
+          unorderedEquals([
+            RootsFallbackSupport.addRootsTool,
+            RootsFallbackSupport.removeRootsTool,
+          ]),
+        );
+      });
+
+      test('Gives roots changed notifications when tools are called', () async {
+        final notifications = StreamQueue(server.rootsListChanged!);
+        await addRoots([rootA]);
+        expect(await notifications.hasNext, true);
+        await notifications.next;
+
+        await removeRoots([rootA]);
+        expect(await notifications.hasNext, true);
+        await notifications.next;
+      });
+
+      test('can add, remove, and list roots', () async {
+        expect((await server.listRoots(ListRootsRequest())).roots, isEmpty);
+
+        await addRoots([rootA, rootB]);
+        expect(
+          (await server.listRoots(ListRootsRequest())).roots,
+          unorderedEquals([rootA, rootB]),
+        );
+
+        await removeRoots([rootB]);
+        expect(
+          (await server.listRoots(ListRootsRequest())).roots,
+          unorderedEquals([rootA]),
+        );
+      });
+    });
+
+    group('when the client does support roots', () {
+      late TestClientWithRoots client;
+
+      setUp(() async {
+        client = TestClientWithRoots();
+        addTearDown(client.shutdown);
+        serverConnection = client.connectServer(
+          StreamChannel.withCloseGuarantee(
+            clientController.stream,
+            serverController.sink,
+          ),
+        );
+        await serverConnection.initialize(
+          InitializeRequest(
+            protocolVersion: ProtocolVersion.latestSupported,
+            capabilities: client.capabilities,
+            clientInfo: client.implementation,
+          ),
+        );
+        serverConnection.notifyInitialized();
+      });
+
+      test('supportsRoots is true', () async {
+        expect(server.supportsRoots, isTrue);
+        await server.roots; // wait for the first listRoots request to complete
+      });
+
+      test('registers no tools', () async {
+        final tools = await serverConnection.listTools(ListToolsRequest());
+        expect(tools.tools, isEmpty);
+      });
+
+      test('Gives roots changed notifications when roots are added', () async {
+        final notifications = StreamQueue(server.rootsListChanged!);
+        client.addRoot(rootA);
+        expect(await notifications.hasNext, true);
+        await notifications.next;
+
+        client.removeRoot(rootA);
+        expect(await notifications.hasNext, true);
+        await notifications.next;
+      });
+
+      test('can add, remove, and list roots', () async {
+        expect((await server.listRoots(ListRootsRequest())).roots, isEmpty);
+
+        client
+          ..addRoot(rootA)
+          ..addRoot(rootB);
+        expect(
+          (await server.listRoots(ListRootsRequest())).roots,
+          unorderedEquals([rootA, rootB]),
+        );
+
+        client.removeRoot(rootB);
+        expect(
+          (await server.listRoots(ListRootsRequest())).roots,
+          unorderedEquals([rootA]),
+        );
+      });
+    });
+  });
+}
+
+// A test client that does not support roots
+final class TestClientWithoutRoots extends MCPClient {
+  TestClientWithoutRoots()
+    : super(
+        ClientImplementation(
+          name: 'test client with no roots support',
+          version: '0.1.0',
+        ),
+      );
+}
+
+// A test client that does not support roots
+final class TestClientWithRoots extends MCPClient with RootsSupport {
+  TestClientWithRoots()
+    : super(
+        ClientImplementation(
+          name: 'test client with roots support',
+          version: '0.1.0',
+        ),
+      );
+}
+
+// Test class that mixes in RootsFallbackSupport
+final class TestServer extends MCPServer
+    with
+        LoggingSupport,
+        ToolsSupport,
+        RootsTrackingSupport,
+        RootsFallbackSupport {
+  TestServer(super.channel, {super.protocolLogSink})
+    : super.fromStreamChannel(
+        implementation: ServerImplementation(
+          name: 'test server',
+          version: '0.1.0',
+        ),
+        instructions: 'A test server with roots fallback support',
+      );
+}


### PR DESCRIPTION
This mixin can be used to conditionally add `addRoots` and `removeRoots` tools, when the client doesn't support roots.

It overrides all the `RootsTrackingSupport` functionality as well as the `listRoots` method, to use the custom behavior instead.

Also adds a flag to force this fallback mode to the server, which is required for some clients who claim to support roots but do not actually (like cursor).

Closes https://github.com/dart-lang/ai/issues/111