### PR TITLE
Flutter/Dart create tool

### DIFF
--- a/pkgs/dart_mcp_server/README.md
+++ b/pkgs/dart_mcp_server/README.md
@@ -23,6 +23,8 @@ WIP. This package is still experimental and is likely to evolve quickly.
 | `hot_reload` | `runtime tool` | Performs a hot reload of the active Flutter application. |
 | `connect_dart_tooling_daemon`* | `configuration` | Connects to the locally running Dart Tooling Daemon. |
 | `get_active_location` | `editor` | Gets the active cursor position in the connected editor (if available). |
+| `run_tests` | `static tool` | Runs tests for the given project roots. |
+| `create_project` | `static tool` | Creates a new Dart or Flutter project. |
 
 > *Experimental: may be removed.
 

--- a/pkgs/dart_mcp_server/lib/src/mixins/dash_cli.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dash_cli.dart
@@ -158,7 +158,10 @@ base mixin DashCliSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
   static final createProjectTool = Tool(
     name: 'create_project',
     description: 'Creates a new Dart or Flutter project.',
-    annotations: ToolAnnotations(title: 'Create project'),
+    annotations: ToolAnnotations(
+      title: 'Create project',
+      destructiveHint: true,
+    ),
     inputSchema: Schema.object(
       properties: {
         ParameterNames.root: rootSchema,

--- a/pkgs/dart_mcp_server/lib/src/mixins/dash_cli.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dash_cli.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:dart_mcp/server.dart';
+import 'package:path/path.dart' as p;
 
 import '../utils/cli_utils.dart';
 import '../utils/constants.dart';
@@ -89,7 +90,7 @@ base mixin DashCliSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
       );
     }
     final directory = args![ParameterNames.directory] as String;
-    if (Uri.parse(directory).isAbsolute) {
+    if (p.isAbsolute(directory)) {
       errors.add(
         ValidationError(
           ValidationErrorType.itemInvalid,
@@ -116,7 +117,7 @@ base mixin DashCliSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
       directory,
     ];
 
-    return runCommandInRoots(
+    return runCommandInRoot(
       request,
       arguments: commandArgs,
       commandForRoot: (_, _) => projectType!,
@@ -160,7 +161,7 @@ base mixin DashCliSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
     annotations: ToolAnnotations(title: 'Create project'),
     inputSchema: Schema.object(
       properties: {
-        ParameterNames.roots: rootsSchema(),
+        ParameterNames.root: rootSchema,
         ParameterNames.directory: Schema.string(
           description:
               'The subdirectory in which to create the project, must '

--- a/pkgs/dart_mcp_server/lib/src/mixins/dash_cli.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dash_cli.dart
@@ -79,8 +79,7 @@ base mixin DashCliSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
 
     final errors = createProjectTool.inputSchema.validate(args);
     final projectType = args?[ParameterNames.projectType] as String?;
-    if (projectType == null ||
-        projectType != 'dart' && projectType != 'flutter') {
+    if (projectType != 'dart' && projectType != 'flutter') {
       errors.add(
         ValidationError(
           ValidationErrorType.itemInvalid,

--- a/pkgs/dart_mcp_server/lib/src/utils/constants.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/constants.dart
@@ -8,14 +8,17 @@ import 'package:dart_mcp/server.dart';
 extension ParameterNames on Never {
   static const column = 'column';
   static const command = 'command';
+  static const directory = 'directory';
   static const line = 'line';
   static const name = 'name';
   static const packageName = 'packageName';
   static const paths = 'paths';
   static const position = 'position';
+  static const projectType = 'projectType';
   static const query = 'query';
   static const root = 'root';
   static const roots = 'roots';
+  static const template = 'template';
   static const uri = 'uri';
   static const uris = 'uris';
 }


### PR DESCRIPTION
Adds a `create_project` tool, which takes a project kind (flutter or dart) and runs the appropriate command.

Requires a root to keep things on the rails, but accepts a relative path anywhere under the root to create the app in.

Also accepts a template configuration.