### PR TITLE
Invoke dart/flutter in a more robust way

### DIFF
--- a/pkgs/dart_mcp_server/bin/main.dart
+++ b/pkgs/dart_mcp_server/bin/main.dart
@@ -39,10 +39,7 @@ void main(List<String> args) async {
               ),
             ),
         forceRootsFallback: parsedArgs.flag(forceRootsFallback),
-        sdk:
-            dartSdkPath != null
-                ? Sdk.findFromDartSdk(dartSdkPath, flutterSdk: flutterSdkPath)
-                : Sdk(),
+        sdk: Sdk.find(dartSdkPath: dartSdkPath, flutterSdkPath: flutterSdkPath),
       );
     },
     (e, s) {

--- a/pkgs/dart_mcp_server/lib/dart_mcp_server.dart
+++ b/pkgs/dart_mcp_server/lib/dart_mcp_server.dart
@@ -3,3 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 export 'src/server.dart';
+export 'src/utils/sdk.dart' show Sdk;

--- a/pkgs/dart_mcp_server/lib/src/mixins/analyzer.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/analyzer.dart
@@ -14,13 +14,15 @@ import 'package:meta/meta.dart';
 
 import '../lsp/wire_format.dart';
 import '../utils/constants.dart';
+import '../utils/sdk.dart';
 
 /// Mix this in to any MCPServer to add support for analyzing Dart projects.
 ///
 /// The MCPServer must already have the [ToolsSupport] and [LoggingSupport]
 /// mixins applied.
 base mixin DartAnalyzerSupport
-    on ToolsSupport, LoggingSupport, RootsTrackingSupport {
+    on ToolsSupport, LoggingSupport, RootsTrackingSupport
+    implements SdkSupport {
   /// The LSP server connection for the analysis server.
   late final Peer _lspConnection;
 
@@ -52,9 +54,8 @@ base mixin DartAnalyzerSupport
       if (!supportsRoots)
         'Project analysis requires the "roots" capability which is not '
             'supported. Analysis tools have been disabled.',
-      if (Platform.environment['DART_SDK'] == null)
-        'Project analysis requires a "DART_SDK" environment variable to be set '
-            '(this should be the path to the root of the dart SDK). Analysis '
+      if (sdk.dartSdkPath == null)
+        'Project analysis requires a Dart SDK but none was given. Analysis '
             'tools have been disabled.',
     ];
 
@@ -90,7 +91,7 @@ base mixin DartAnalyzerSupport
   ///
   /// On failure, returns a reason for the failure.
   Future<String?> _initializeAnalyzerLspServer() async {
-    _lspServer = await Process.start('dart', [
+    _lspServer = await Process.start(sdk.dartExecutablePath, [
       'language-server',
       // Required even though it is documented as the default.
       // https://github.com/dart-lang/sdk/issues/60574

--- a/pkgs/dart_mcp_server/lib/src/mixins/pub.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/pub.dart
@@ -10,6 +10,7 @@ import '../utils/cli_utils.dart';
 import '../utils/constants.dart';
 import '../utils/file_system.dart';
 import '../utils/process_manager.dart';
+import '../utils/sdk.dart';
 
 /// Mix this in to any MCPServer to add support for running Pub commands like
 /// like `pub add` and `pub get`.
@@ -19,7 +20,7 @@ import '../utils/process_manager.dart';
 /// The MCPServer must already have the [ToolsSupport] and [LoggingSupport]
 /// mixins applied.
 base mixin PubSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
-    implements ProcessManagerSupport, FileSystemSupport {
+    implements ProcessManagerSupport, FileSystemSupport, SdkSupport {
   @override
   FutureOr<InitializeResult> initialize(InitializeRequest request) {
     try {
@@ -79,6 +80,7 @@ base mixin PubSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
       processManager: processManager,
       knownRoots: await roots,
       fileSystem: fileSystem,
+      sdk: sdk,
     );
   }
 

--- a/pkgs/dart_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_mcp_server/lib/src/server.dart
@@ -2,14 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:dart_mcp/server.dart';
 import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
-import 'package:stream_channel/stream_channel.dart';
 
 import 'mixins/analyzer.dart';
 import 'mixins/dash_cli.dart';
@@ -37,6 +34,7 @@ final class DartMCPServer extends MCPServer
     implements ProcessManagerSupport, FileSystemSupport, SdkSupport {
   DartMCPServer(
     super.channel, {
+    required this.sdk,
     @visibleForTesting this.processManager = const LocalProcessManager(),
     @visibleForTesting this.fileSystem = const LocalFileSystem(),
     this.forceRootsFallback = false,
@@ -50,13 +48,6 @@ final class DartMCPServer extends MCPServer
              'their development tools and running applications.',
        );
 
-  static Future<DartMCPServer> connect(
-    StreamChannel<String> mcpChannel, {
-    bool forceRootsFallback = false,
-  }) async {
-    return DartMCPServer(mcpChannel, forceRootsFallback: forceRootsFallback);
-  }
-
   @override
   final LocalProcessManager processManager;
 
@@ -65,4 +56,7 @@ final class DartMCPServer extends MCPServer
 
   @override
   final bool forceRootsFallback;
+
+  @override
+  final Sdk sdk;
 }

--- a/pkgs/dart_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_mcp_server/lib/src/server.dart
@@ -19,6 +19,7 @@ import 'mixins/pub_dev_search.dart';
 import 'mixins/roots_fallback_support.dart';
 import 'utils/file_system.dart';
 import 'utils/process_manager.dart';
+import 'utils/sdk.dart';
 
 /// An MCP server for Dart and Flutter tooling.
 final class DartMCPServer extends MCPServer
@@ -33,7 +34,7 @@ final class DartMCPServer extends MCPServer
         PubSupport,
         PubDevSupport,
         DartToolingDaemonSupport
-    implements ProcessManagerSupport, FileSystemSupport {
+    implements ProcessManagerSupport, FileSystemSupport, SdkSupport {
   DartMCPServer(
     super.channel, {
     @visibleForTesting this.processManager = const LocalProcessManager(),

--- a/pkgs/dart_mcp_server/lib/src/utils/sdk.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/sdk.dart
@@ -25,14 +25,14 @@ class Sdk {
 
   /// Creates an [Sdk] from the path to the Dart SDK.
   ///
-  /// If no [dartSdkPath] is given, it will attempt to find it using
-  /// [Platform.resolvedExecutable], and assuming that is the `dart` binary
-  /// under the `bin` dir of the Dart SDK.
+  /// If no [dartSdkPath] is given, this will attempt to find one using
+  /// [Platform.resolvedExecutable], assuming that is the `dart` binary
+  /// under the `bin` dir of a Dart SDK.
   ///
   /// Validates that the path is valid by checking for the `version` file.
   ///
-  /// If no [flutterSdkPath] is given, it will search up to see if it is nested
-  /// inside a Flutter SDK.
+  /// If no [flutterSdkPath] is given, this will search up from the resolved
+  /// Dart SDK path to see if it is nested inside a Flutter SDK.
   factory Sdk.find({String? dartSdkPath, String? flutterSdkPath}) {
     // Assume that we are running from the Dart SDK bin dir if not given any
     // other configuration.

--- a/pkgs/dart_mcp_server/lib/src/utils/sdk.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/sdk.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:path/path.dart' as p;
+
+/// An interface class that provides a single getter of type [Sdk].
+///
+/// This provides information about the Dart and Flutter sdks, if available.
+abstract interface class SdkSupport {
+  Sdk get sdk;
+}
+
+/// Information about the Dart and Flutter SDKs, if available.
+class Sdk {
+  /// The path to the root of the Dart SDK.
+  final String? dartSdkPath;
+
+  /// The path to the root of the Flutter SDK.
+  final String? flutterSdkPath;
+
+  Sdk({required this.dartSdkPath, required this.flutterSdkPath});
+
+  /// The path to the `dart` executable.
+  String? get dartExecutablePath => dartSdkPath?.child('bin').child('dart');
+
+  /// The path to the `flutter` executable.
+  String? get flutterExecutablePath =>
+      flutterSdkPath?.child('bin').child('flutter');
+}
+
+extension on String {
+  String child(String path) => p.join(this, path);
+}

--- a/pkgs/dart_mcp_server/lib/src/utils/sdk.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/sdk.dart
@@ -25,18 +25,25 @@ class Sdk {
 
   /// Creates an [Sdk] from the path to the Dart SDK.
   ///
+  /// If no [dartSdkPath] is given, it will attempt to find it using
+  /// [Platform.resolvedExecutable], and assuming that is the `dart` binary
+  /// under the `bin` dir of the Dart SDK.
+  ///
   /// Validates that the path is valid by checking for the `version` file.
   ///
-  /// If no [flutterSdk] is given, it will search up to see if it is nested
-  /// inside a flutter SDK.
-  factory Sdk.findFromDartSdk(String dartSdkPath, {String? flutterSdk}) {
+  /// If no [flutterSdkPath] is given, it will search up to see if it is nested
+  /// inside a Flutter SDK.
+  factory Sdk.find({String? dartSdkPath, String? flutterSdkPath}) {
+    // Assume that we are running from the Dart SDK bin dir if not given any
+    // other configuration.
+    dartSdkPath ??= p.dirname(p.dirname(Platform.resolvedExecutable));
+
     final versionFile = dartSdkPath.child('version');
     if (!File(versionFile).existsSync()) {
       throw ArgumentError('Invalid Dart SDK path: $dartSdkPath');
     }
 
     // Check if this is nested inside a Flutter SDK.
-    var flutterSdkPath = flutterSdk;
     if (dartSdkPath.parent case final cacheDir
         when cacheDir.basename == 'cache' && flutterSdkPath == null) {
       if (cacheDir.parent case final binDir when binDir.basename == 'bin') {

--- a/pkgs/dart_mcp_server/lib/src/utils/sdk.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/sdk.dart
@@ -27,7 +27,7 @@ class Sdk {
   ///
   /// Validates that the path is valid by checking for the `version` file.
   ///
-  /// If no [flutterSdk] is given, it Will search up to see if it is nested
+  /// If no [flutterSdk] is given, it will search up to see if it is nested
   /// inside a flutter SDK.
   factory Sdk.findFromDartSdk(String dartSdkPath, {String? flutterSdk}) {
     final versionFile = dartSdkPath.child('version');
@@ -37,11 +37,10 @@ class Sdk {
 
     // Check if this is nested inside a Flutter SDK.
     var flutterSdkPath = flutterSdk;
-    if (dartSdkPath.parent.parent case final cacheDir
+    if (dartSdkPath.parent case final cacheDir
         when cacheDir.basename == 'cache' && flutterSdkPath == null) {
-      if (cacheDir.parent case final binDir when binDir.basename == 'flutter') {
-        final flutterBin = binDir.child('bin');
-        final flutterExecutable = flutterBin.child('flutter');
+      if (cacheDir.parent case final binDir when binDir.basename == 'bin') {
+        final flutterExecutable = binDir.child('flutter');
         if (File(flutterExecutable).existsSync()) {
           flutterSdkPath = binDir.parent;
         }

--- a/pkgs/dart_mcp_server/lib/src/utils/sdk.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/sdk.dart
@@ -69,7 +69,7 @@ class Sdk {
       (throw ArgumentError(
         'Flutter SDK location unknown. To work on flutter projects, you must '
         'spawn the server using `dart` from the flutter SDK and not a Dart '
-        'SDK.',
+        'SDK, or set a FLUTTER_SDK environment variable.',
       ));
 }
 

--- a/pkgs/dart_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_mcp_server/test/test_harness.dart
@@ -67,10 +67,9 @@ class TestHarness {
     bool inProcess = false,
     FileSystem? fileSystem,
   }) async {
-    final sdk = Sdk.findFromDartSdk(
-      Platform.environment['DART_SDK'] ??
-          p.dirname(p.dirname(Platform.resolvedExecutable)),
-      flutterSdk: Platform.environment['FLUTTER_SDK'],
+    final sdk = Sdk.find(
+      dartSdkPath: Platform.environment['DART_SDK'],
+      flutterSdkPath: Platform.environment['FLUTTER_SDK'],
     );
     fileSystem ??= const LocalFileSystem();
 

--- a/pkgs/dart_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_mcp_server/test/test_harness.dart
@@ -11,6 +11,7 @@ import 'package:dart_mcp/client.dart';
 import 'package:dart_mcp_server/src/mixins/dtd.dart';
 import 'package:dart_mcp_server/src/server.dart';
 import 'package:dart_mcp_server/src/utils/constants.dart';
+import 'package:dart_mcp_server/src/utils/sdk.dart';
 import 'package:dtd/dtd.dart';
 import 'package:file/file.dart';
 import 'package:file/local.dart';
@@ -34,6 +35,7 @@ class TestHarness {
   final DartToolingMCPClient mcpClient;
   final ServerConnectionPair serverConnectionPair;
   final FileSystem fileSystem;
+  final Sdk sdk;
 
   ServerConnection get mcpServerConnection =>
       serverConnectionPair.serverConnection;
@@ -43,6 +45,7 @@ class TestHarness {
     this.serverConnectionPair,
     this.fakeEditorExtension,
     this.fileSystem,
+    this.sdk,
   );
 
   /// Starts a Dart Tooling Daemon as well as an MCP client and server, and
@@ -64,6 +67,11 @@ class TestHarness {
     bool inProcess = false,
     FileSystem? fileSystem,
   }) async {
+    final sdk = Sdk.findFromDartSdk(
+      Platform.environment['DART_SDK'] ??
+          p.dirname(p.dirname(Platform.resolvedExecutable)),
+      flutterSdk: Platform.environment['FLUTTER_SDK'],
+    );
     fileSystem ??= const LocalFileSystem();
 
     final mcpClient = DartToolingMCPClient();
@@ -73,13 +81,14 @@ class TestHarness {
       mcpClient,
       inProcess,
       fileSystem,
+      sdk,
     );
     final connection = serverConnectionPair.serverConnection;
     connection.onLog.listen((log) {
       printOnFailure('MCP Server Log: $log');
     });
 
-    final fakeEditorExtension = await FakeEditorExtension.connect();
+    final fakeEditorExtension = await FakeEditorExtension.connect(sdk);
     addTearDown(fakeEditorExtension.shutdown);
 
     return TestHarness._(
@@ -87,6 +96,7 @@ class TestHarness {
       serverConnectionPair,
       fakeEditorExtension,
       fileSystem,
+      sdk,
     );
   }
 
@@ -102,6 +112,7 @@ class TestHarness {
       appPath,
       isFlutter: isFlutter,
       args: args,
+      sdk: sdk,
     );
     await fakeEditorExtension.addDebugSession(session);
     final root = rootForPath(projectRoot);
@@ -192,15 +203,20 @@ final class AppDebugSession {
     String appPath, {
     List<String> args = const [],
     required bool isFlutter,
+    required Sdk sdk,
   }) async {
-    final process = await TestProcess.start(isFlutter ? 'flutter' : 'dart', [
-      'run',
-      '--no${isFlutter ? '' : '-serve'}-devtools',
-      if (!isFlutter) '--enable-vm-service=0',
-      if (isFlutter) ...['-d', 'flutter-tester'],
-      appPath,
-      ...args,
-    ], workingDirectory: projectRoot);
+    final process = await TestProcess.start(
+      isFlutter ? sdk.flutterExecutablePath : sdk.dartExecutablePath,
+      [
+        'run',
+        '--no${isFlutter ? '' : '-serve'}-devtools',
+        if (!isFlutter) '--enable-vm-service=0',
+        if (isFlutter) ...['-d', 'flutter-tester'],
+        appPath,
+        ...args,
+      ],
+      workingDirectory: projectRoot,
+    );
 
     addTearDown(() async {
       await kill(process, isFlutter);
@@ -284,8 +300,10 @@ class FakeEditorExtension {
   static int get nextId => ++_nextId;
   static int _nextId = 0;
 
-  static Future<FakeEditorExtension> connect() async {
-    final dtdProcess = await TestProcess.start('dart', ['tooling-daemon']);
+  static Future<FakeEditorExtension> connect(Sdk sdk) async {
+    final dtdProcess = await TestProcess.start(sdk.dartExecutablePath, [
+      'tooling-daemon',
+    ]);
     final dtdUri = await _getDTDUri(dtdProcess);
     final dtd = await DartToolingDaemon.connect(Uri.parse(dtdUri));
     final extension = FakeEditorExtension._(dtd, dtdProcess, dtdUri);
@@ -369,6 +387,7 @@ Future<ServerConnectionPair> _initializeMCPServer(
   MCPClient client,
   bool inProcess,
   FileSystem fileSystem,
+  Sdk sdk,
 ) async {
   ServerConnection connection;
   DartMCPServer? server;
@@ -393,11 +412,12 @@ Future<ServerConnectionPair> _initializeMCPServer(
       serverChannel,
       processManager: TestProcessManager(),
       fileSystem: fileSystem,
+      sdk: sdk,
     );
     addTearDown(server.shutdown);
     connection = client.connectServer(clientChannel);
   } else {
-    connection = await client.connectStdioServer('dart', [
+    connection = await client.connectStdioServer(sdk.dartExecutablePath, [
       'pub', // Using `pub` gives us incremental compilation
       'run',
       'bin/main.dart',
@@ -470,11 +490,8 @@ class _CommandMatcher extends Matcher {
     if (item.workingDirectory != value.workingDirectory) {
       return false;
     }
-    if (item.command.length != value.command.length) {
+    if (!equals(value.command).matches(item.command, matchState)) {
       return false;
-    }
-    for (var i = 0; i < item.command.length; i++) {
-      if (item.command[i] != value.command[i]) return false;
     }
     return true;
   }

--- a/pkgs/dart_mcp_server/test/tools/dart_cli_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dart_cli_test.dart
@@ -76,7 +76,7 @@ dependencies:
       expect(result.isError, isNot(true));
       expect(testProcessManager.commandsRan, [
         equalsCommand((
-          command: ['dart', 'fix', '--apply'],
+          command: [endsWith('dart'), 'fix', '--apply'],
           workingDirectory: exampleFlutterAppRoot.path,
         )),
       ]);
@@ -98,7 +98,7 @@ dependencies:
       expect(result.isError, isNot(true));
       expect(testProcessManager.commandsRan, [
         equalsCommand((
-          command: ['dart', 'format', '.'],
+          command: [endsWith('dart'), 'format', '.'],
           workingDirectory: exampleFlutterAppRoot.path,
         )),
       ]);
@@ -123,7 +123,7 @@ dependencies:
       expect(result.isError, isNot(true));
       expect(testProcessManager.commandsRan, [
         equalsCommand((
-          command: ['dart', 'format', 'foo.dart', 'bar.dart'],
+          command: [endsWith('dart'), 'format', 'foo.dart', 'bar.dart'],
           workingDirectory: exampleFlutterAppRoot.path,
         )),
       ]);
@@ -154,11 +154,16 @@ dependencies:
       expect(result.isError, isNot(true));
       expect(testProcessManager.commandsRan, [
         equalsCommand((
-          command: ['flutter', 'test', 'foo_test.dart', 'bar_test.dart'],
+          command: [
+            endsWith('flutter'),
+            'test',
+            'foo_test.dart',
+            'bar_test.dart',
+          ],
           workingDirectory: exampleFlutterAppRoot.path,
         )),
         equalsCommand((
-          command: ['dart', 'test', 'zip_test.dart'],
+          command: [endsWith('dart'), 'test', 'zip_test.dart'],
           workingDirectory: dartCliAppRoot.path,
         )),
       ]);
@@ -180,7 +185,13 @@ dependencies:
 
         expect(testProcessManager.commandsRan, [
           equalsCommand((
-            command: ['dart', 'create', '--template', 'cli', 'new_app'],
+            command: [
+              endsWith('dart'),
+              'create',
+              '--template',
+              'cli',
+              'new_app',
+            ],
             workingDirectory: dartCliAppRoot.path,
           )),
         ]);
@@ -201,7 +212,13 @@ dependencies:
 
         expect(testProcessManager.commandsRan, [
           equalsCommand((
-            command: ['flutter', 'create', '--template', 'app', 'new_app'],
+            command: [
+              endsWith('flutter'),
+              'create',
+              '--template',
+              'app',
+              'new_app',
+            ],
             workingDirectory: exampleFlutterAppRoot.path,
           )),
         ]);

--- a/pkgs/dart_mcp_server/test/tools/pub_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/pub_test.dart
@@ -68,7 +68,7 @@ void main() {
           expect(result.isError, isNot(true));
           expect(testProcessManager.commandsRan, [
             equalsCommand((
-              command: [appKind, 'pub', 'add', 'foo'],
+              command: [endsWith(appKind), 'pub', 'add', 'foo'],
               workingDirectory: fakeAppPath,
             )),
           ]);
@@ -91,7 +91,7 @@ void main() {
           expect(result.isError, isNot(true));
           expect(testProcessManager.commandsRan, [
             equalsCommand((
-              command: [appKind, 'pub', 'remove', 'foo'],
+              command: [endsWith(appKind), 'pub', 'remove', 'foo'],
               workingDirectory: fakeAppPath,
             )),
           ]);
@@ -113,7 +113,7 @@ void main() {
           expect(result.isError, isNot(true));
           expect(testProcessManager.commandsRan, [
             equalsCommand((
-              command: [appKind, 'pub', 'get'],
+              command: [endsWith(appKind), 'pub', 'get'],
               workingDirectory: fakeAppPath,
             )),
           ]);
@@ -135,7 +135,7 @@ void main() {
           expect(result.isError, isNot(true));
           expect(testProcessManager.commandsRan, [
             equalsCommand((
-              command: [appKind, 'pub', 'upgrade'],
+              command: [endsWith(appKind), 'pub', 'upgrade'],
               workingDirectory: fakeAppPath,
             )),
           ]);

--- a/pkgs/dart_mcp_server/test/utils/cli_utils_test.dart
+++ b/pkgs/dart_mcp_server/test/utils/cli_utils_test.dart
@@ -5,6 +5,7 @@
 import 'package:dart_mcp/server.dart';
 import 'package:dart_mcp_server/src/utils/cli_utils.dart';
 import 'package:dart_mcp_server/src/utils/constants.dart';
+import 'package:dart_mcp_server/src/utils/sdk.dart';
 import 'package:file/memory.dart';
 import 'package:process/process.dart';
 import 'package:test/fake.dart';
@@ -35,12 +36,13 @@ void main() {
             ],
           },
         ),
-        commandForRoot: (_, _) => 'testCommand',
+        commandForRoot: (_, _, _) => 'testCommand',
         arguments: ['a', 'b'],
         commandDescription: '',
         processManager: processManager,
         knownRoots: [Root(uri: 'file:///bar/')],
         fileSystem: fileSystem,
+        sdk: Sdk(),
       );
       expect(result.isError, isNot(true));
       expect(processManager.commandsRan, [
@@ -63,11 +65,12 @@ void main() {
               ],
             },
           ),
-          commandForRoot: (_, _) => 'testCommand',
+          commandForRoot: (_, _, _) => 'testCommand',
           commandDescription: '',
           processManager: processManager,
           knownRoots: [Root(uri: 'file:///bar/')],
           fileSystem: fileSystem,
+          sdk: Sdk(),
         );
         expect(result.isError, isNot(true));
         expect(processManager.commandsRan, [
@@ -94,11 +97,12 @@ void main() {
               ],
             },
           ),
-          commandForRoot: (_, _) => 'fake',
+          commandForRoot: (_, _, _) => 'fake',
           commandDescription: '',
           processManager: processManager,
           knownRoots: [Root(uri: 'file:///foo/')],
           fileSystem: fileSystem,
+          sdk: Sdk(),
         );
         expect(result.isError, isTrue);
         expect(
@@ -130,11 +134,12 @@ void main() {
             ],
           },
         ),
-        commandForRoot: (_, _) => 'fake',
+        commandForRoot: (_, _, _) => 'fake',
         commandDescription: '',
         processManager: processManager,
         knownRoots: [Root(uri: 'file:///foo/')],
         fileSystem: fileSystem,
+        sdk: Sdk(),
       );
       expect(result.isError, isTrue);
       expect(


### PR DESCRIPTION
Closes https://github.com/dart-lang/ai/issues/33

Adds --dart-sdk and --flutter-sdk arguments to the CLI, falling back on DART_SDK and FLUTTER_SDK environment variables, and finally `Platform.resolvedExecutable`.

The flutter SDK will also be looked up relative to the Dart SDK, if a location is not given by command line arg or environment.