### PR TITLE
remove qualifiedNames from the pub dev api search

### DIFF
--- a/pkgs/dart_mcp_server/test/tools/pub_dev_search_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/pub_dev_search_test.dart
@@ -82,9 +82,6 @@ void main() {
             'license:osi-approved',
           ],
           'publisher': 'publisher:google.dev',
-          'api': {
-            'qualifiedNames': containsAll(['retry', 'retry.RetryOptions']),
-          },
         });
       });
     }, _GoldenResponseClient.new);
@@ -161,7 +158,7 @@ void main() {
           expect(result.isError, isTrue);
           expect(
             (result.content[0] as TextContent).text,
-            contains('No packages mached the query, consider simplifying it'),
+            contains('No packages matched the query, consider simplifying it'),
           );
         });
       },


### PR DESCRIPTION
Closes https://github.com/dart-lang/ai/issues/145

I did some testing myself and we easily get >10k tokens added to the context for a single query which is definitely too much for the value provided here.