### PR TITLE
create the working dir if it doesn't exist

### DIFF
--- a/pkgs/dart_mcp_server/lib/src/utils/cli_utils.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/cli_utils.dart
@@ -210,9 +210,12 @@ Future<CallToolResult> runCommandInRoot(
   }
   commandWithPaths.addAll(paths);
 
+  final workingDir = fileSystem.directory(projectRoot.path);
+  await workingDir.create(recursive: true);
+
   final result = await processManager.run(
     commandWithPaths,
-    workingDirectory: projectRoot.path,
+    workingDirectory: workingDir.path,
     runInShell: true,
   );
 

--- a/pkgs/dart_mcp_server/test/utils/cli_utils_test.dart
+++ b/pkgs/dart_mcp_server/test/utils/cli_utils_test.dart
@@ -54,6 +54,7 @@ void main() {
     test(
       'can run commands with roots that are subdirectories of known roots',
       () async {
+        expect(fileSystem.directory('/bar/baz').existsSync(), false);
         final result = await runCommandInRoots(
           CallToolRequest(
             name: 'foo',
@@ -76,6 +77,7 @@ void main() {
             workingDirectory: '/bar/baz/',
           )),
         ]);
+        expect(fileSystem.directory('/bar/baz').existsSync(), true);
       },
     );
   });


### PR DESCRIPTION
You can't set a working dir if it doesn't exist, this ensures the dir does actually exist. LLMs like to sometimes set a root that is a subdirectory of an actual root, which is generally fine, but we need to make sure to create it.