### PR TITLE
run tests on windows, fix executable paths for dart/flutter

### DIFF
--- a/.github/workflows/dart_mcp.yaml
+++ b/.github/workflows/dart_mcp.yaml
@@ -21,14 +21,17 @@ defaults:
 
 jobs:
   build:
-    runs-on:
-      - ubuntu-latest
-      - windows-latest
-      - macos-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        sdk: [stable, dev]
+        sdk:
+          - stable
+          - dev
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c

--- a/.github/workflows/dart_mcp.yaml
+++ b/.github/workflows/dart_mcp.yaml
@@ -21,7 +21,10 @@ defaults:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on:
+      - ubuntu-latest
+      - windows-latest
+      - macos-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/dart_mcp.yaml
+++ b/.github/workflows/dart_mcp.yaml
@@ -31,7 +31,6 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macos-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c

--- a/.github/workflows/dart_mcp_server.yaml
+++ b/.github/workflows/dart_mcp_server.yaml
@@ -33,7 +33,6 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macos-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       # We need the flutter SDK in order to run the counter app for integration

--- a/.github/workflows/dart_mcp_server.yaml
+++ b/.github/workflows/dart_mcp_server.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk:
+        flutterSdk:
           - stable
           - master
         os:

--- a/.github/workflows/dart_mcp_server.yaml
+++ b/.github/workflows/dart_mcp_server.yaml
@@ -23,7 +23,10 @@ defaults:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on:
+      - ubuntu-latest
+      - windows-latest
+      - macos-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/dart_mcp_server.yaml
+++ b/.github/workflows/dart_mcp_server.yaml
@@ -23,14 +23,17 @@ defaults:
 
 jobs:
   build:
-    runs-on:
-      - ubuntu-latest
-      - windows-latest
-      - macos-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        flutterSdk: [stable, master]
+        sdk:
+          - stable
+          - master
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       # We need the flutter SDK in order to run the counter app for integration

--- a/pkgs/dart_mcp_server/lib/src/utils/sdk.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/sdk.dart
@@ -65,7 +65,7 @@ class Sdk {
   String get dartExecutablePath =>
       dartSdkPath
           ?.child('bin')
-          .child('dart${Platform.isWindows ? '.bat' : ''}') ??
+          .child('dart${Platform.isWindows ? '.exe' : ''}') ??
       (throw ArgumentError(
         'Dart SDK location unknown, try setting the DART_SDK environment '
         'variable.',

--- a/pkgs/dart_mcp_server/lib/src/utils/sdk.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/sdk.dart
@@ -47,7 +47,9 @@ class Sdk {
     if (dartSdkPath.parent case final cacheDir
         when cacheDir.basename == 'cache' && flutterSdkPath == null) {
       if (cacheDir.parent case final binDir when binDir.basename == 'bin') {
-        final flutterExecutable = binDir.child('flutter');
+        final flutterExecutable = binDir.child(
+          'flutter${Platform.isWindows ? '.bat' : ''}',
+        );
         if (File(flutterExecutable).existsSync()) {
           flutterSdkPath = binDir.parent;
         }
@@ -61,7 +63,9 @@ class Sdk {
   ///
   /// Throws an [ArgumentError] if [dartSdkPath] is `null`.
   String get dartExecutablePath =>
-      dartSdkPath?.child('bin').child('dart') ??
+      dartSdkPath
+          ?.child('bin')
+          .child('dart${Platform.isWindows ? '.bat' : ''}') ??
       (throw ArgumentError(
         'Dart SDK location unknown, try setting the DART_SDK environment '
         'variable.',
@@ -71,7 +75,9 @@ class Sdk {
   ///
   /// Throws an [ArgumentError] if [flutterSdkPath] is `null`.
   String get flutterExecutablePath =>
-      flutterSdkPath?.child('bin').child('flutter') ??
+      flutterSdkPath
+          ?.child('bin')
+          .child('flutter${Platform.isWindows ? '.bat' : ''}') ??
       (throw ArgumentError(
         'Flutter SDK location unknown. To work on flutter projects, you must '
         'spawn the server using `dart` from the flutter SDK and not a Dart '

--- a/pkgs/dart_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_mcp_server/test/test_harness.dart
@@ -498,6 +498,6 @@ class _CommandMatcher extends Matcher {
 }
 
 extension RootPath on Root {
-  // Get the OS specific file path for this root.
+  /// Get the OS specific file path for this root.
   String get path => io.File.fromUri(Uri.parse(uri)).path;
 }

--- a/pkgs/dart_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_mcp_server/test/test_harness.dart
@@ -257,7 +257,7 @@ final class AppDebugSession {
       await process.shouldExit(0);
     } else {
       unawaited(process.kill());
-      await process.shouldExit(anyOf(0, -9));
+      await process.shouldExit(anyOf(0, Platform.isWindows ? -1 : -9));
     }
   }
 

--- a/pkgs/dart_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_mcp_server/test/test_harness.dart
@@ -4,7 +4,8 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
+import 'dart:io' hide File;
+import 'dart:io' as io show File;
 
 import 'package:async/async.dart';
 import 'package:dart_mcp/client.dart';
@@ -497,5 +498,6 @@ class _CommandMatcher extends Matcher {
 }
 
 extension RootPath on Root {
-  String get path => Uri.parse(uri).path;
+  // Get the OS specific file path for this root.
+  String get path => io.File.fromUri(Uri.parse(uri)).path;
 }

--- a/pkgs/dart_mcp_server/test/tools/analyzer_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/analyzer_test.dart
@@ -75,14 +75,18 @@ void main() {
     });
 
     test('can look up symbols in a workspace', () async {
-      final currentRoot = testHarness.rootForPath(Directory.current.path);
-      testHarness.mcpClient.addRoot(currentRoot);
+      final example = d.dir('lib', [
+        d.file('awesome_class.dart', 'class MyAwesomeClass {}'),
+      ]);
+      await example.create();
+      final exampleRoot = testHarness.rootForPath(example.io.path);
+      testHarness.mcpClient.addRoot(exampleRoot);
       await pumpEventQueue();
 
       final result = await testHarness.callToolWithRetry(
         CallToolRequest(
           name: DartAnalyzerSupport.resolveWorkspaceSymbolTool.name,
-          arguments: {ParameterNames.query: 'DartAnalyzerSupport'},
+          arguments: {ParameterNames.query: 'MyAwesomeClass'},
         ),
       );
       expect(result.isError, isNot(true));
@@ -92,7 +96,7 @@ void main() {
         isA<TextContent>().having(
           (t) => t.text,
           'text',
-          contains('analyzer.dart'),
+          contains('awesome_class.dart'),
         ),
       );
     });

--- a/pkgs/dart_mcp_server/test/tools/analyzer_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/analyzer_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:dart_mcp/server.dart';
 import 'package:dart_mcp_server/src/mixins/analyzer.dart';
 import 'package:dart_mcp_server/src/utils/constants.dart';

--- a/pkgs/dart_mcp_server/test/tools/dart_cli_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dart_cli_test.dart
@@ -17,7 +17,7 @@ void main() {
   late TestProcessManager testProcessManager;
   late Root exampleFlutterAppRoot;
   late Root dartCliAppRoot;
-  final dartExecutableName = 'dart${Platform.isWindows ? '.bat' : ''}';
+  final dartExecutableName = 'dart${Platform.isWindows ? '.exe' : ''}';
   final flutterExecutableName = 'flutter${Platform.isWindows ? '.bat' : ''}';
 
   // TODO: Use setUpAll, currently this fails due to an apparent TestProcess

--- a/pkgs/dart_mcp_server/test/tools/dart_cli_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dart_cli_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:dart_mcp/server.dart';
 import 'package:dart_mcp_server/src/mixins/dash_cli.dart';
 import 'package:dart_mcp_server/src/utils/constants.dart';
@@ -15,6 +17,8 @@ void main() {
   late TestProcessManager testProcessManager;
   late Root exampleFlutterAppRoot;
   late Root dartCliAppRoot;
+  final dartExecutableName = 'dart${Platform.isWindows ? '.bat' : ''}';
+  final flutterExecutableName = 'flutter${Platform.isWindows ? '.bat' : ''}';
 
   // TODO: Use setUpAll, currently this fails due to an apparent TestProcess
   // issue.
@@ -76,7 +80,7 @@ dependencies:
       expect(result.isError, isNot(true));
       expect(testProcessManager.commandsRan, [
         equalsCommand((
-          command: [endsWith('dart'), 'fix', '--apply'],
+          command: [endsWith(dartExecutableName), 'fix', '--apply'],
           workingDirectory: exampleFlutterAppRoot.path,
         )),
       ]);
@@ -98,7 +102,7 @@ dependencies:
       expect(result.isError, isNot(true));
       expect(testProcessManager.commandsRan, [
         equalsCommand((
-          command: [endsWith('dart'), 'format', '.'],
+          command: [endsWith(dartExecutableName), 'format', '.'],
           workingDirectory: exampleFlutterAppRoot.path,
         )),
       ]);
@@ -123,7 +127,12 @@ dependencies:
       expect(result.isError, isNot(true));
       expect(testProcessManager.commandsRan, [
         equalsCommand((
-          command: [endsWith('dart'), 'format', 'foo.dart', 'bar.dart'],
+          command: [
+            endsWith(dartExecutableName),
+            'format',
+            'foo.dart',
+            'bar.dart',
+          ],
           workingDirectory: exampleFlutterAppRoot.path,
         )),
       ]);
@@ -155,7 +164,7 @@ dependencies:
       expect(testProcessManager.commandsRan, [
         equalsCommand((
           command: [
-            endsWith('flutter'),
+            endsWith(flutterExecutableName),
             'test',
             'foo_test.dart',
             'bar_test.dart',
@@ -163,7 +172,7 @@ dependencies:
           workingDirectory: exampleFlutterAppRoot.path,
         )),
         equalsCommand((
-          command: [endsWith('dart'), 'test', 'zip_test.dart'],
+          command: [endsWith(dartExecutableName), 'test', 'zip_test.dart'],
           workingDirectory: dartCliAppRoot.path,
         )),
       ]);
@@ -186,7 +195,7 @@ dependencies:
         expect(testProcessManager.commandsRan, [
           equalsCommand((
             command: [
-              endsWith('dart'),
+              endsWith(dartExecutableName),
               'create',
               '--template',
               'cli',
@@ -213,7 +222,7 @@ dependencies:
         expect(testProcessManager.commandsRan, [
           equalsCommand((
             command: [
-              endsWith('flutter'),
+              endsWith(flutterExecutableName),
               'create',
               '--template',
               'app',
@@ -243,7 +252,7 @@ dependencies:
         expect(testProcessManager.commandsRan, [
           equalsCommand((
             command: [
-              endsWith('flutter'),
+              endsWith(flutterExecutableName),
               'create',
               '--template',
               'app',

--- a/pkgs/dart_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dtd_test.dart
@@ -97,7 +97,7 @@ void main() {
         test('can perform a hot reload', () async {
           final exampleApp = await Directory.systemTemp.createTemp('dart_app');
           addTearDown(() async {
-            await exampleApp.delete(recursive: true);
+            await _deleteWithRetry(exampleApp);
           });
           final mainFile = File.fromUri(
             exampleApp.uri.resolve('bin/main.dart'),
@@ -165,7 +165,7 @@ void main() {
         setUp(() async {
           appDir = await Directory.systemTemp.createTemp('dart_app');
           addTearDown(() async {
-            await appDir.delete(recursive: true);
+            await _deleteWithRetry(appDir);
           });
           final mainFile = File.fromUri(appDir.uri.resolve(appPath));
           await mainFile.create(recursive: true);
@@ -306,7 +306,7 @@ void main() {
         setUp(() async {
           appDir = await Directory.systemTemp.createTemp('dart_app');
           addTearDown(() async {
-            await appDir.delete(recursive: true);
+            await _deleteWithRetry(appDir);
           });
           final mainFile = File.fromUri(appDir.uri.resolve(appPath));
           await mainFile.create(recursive: true);
@@ -659,3 +659,18 @@ void action() {
   print('hello');
 }
 ''';
+
+/// Tries to delete [dir] up to 5 times, waiting 200ms between each.
+///
+/// Necessary for windows tests.
+Future<void> _deleteWithRetry(Directory dir) async {
+  var i = 0;
+  while (++i <= 5) {
+    try {
+      await dir.delete(recursive: true);
+      return;
+    } catch (_) {
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+    }
+  }
+}

--- a/pkgs/dart_mcp_server/test/tools/pub_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/pub_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:dart_mcp/server.dart';
 import 'package:dart_mcp_server/src/mixins/pub.dart';
 import 'package:dart_mcp_server/src/utils/constants.dart';
@@ -22,6 +24,7 @@ void main() {
   final fakeAppPath = '/fake_app/';
 
   for (final appKind in const ['dart', 'flutter']) {
+    final executableName = '$appKind${Platform.isWindows ? '.bat' : ''}';
     group('$appKind app', () {
       // TODO: Use setUpAll, currently this fails due to an apparent TestProcess
       // issue.
@@ -68,7 +71,7 @@ void main() {
           expect(result.isError, isNot(true));
           expect(testProcessManager.commandsRan, [
             equalsCommand((
-              command: [endsWith(appKind), 'pub', 'add', 'foo'],
+              command: [endsWith(executableName), 'pub', 'add', 'foo'],
               workingDirectory: fakeAppPath,
             )),
           ]);
@@ -91,7 +94,7 @@ void main() {
           expect(result.isError, isNot(true));
           expect(testProcessManager.commandsRan, [
             equalsCommand((
-              command: [endsWith(appKind), 'pub', 'remove', 'foo'],
+              command: [endsWith(executableName), 'pub', 'remove', 'foo'],
               workingDirectory: fakeAppPath,
             )),
           ]);
@@ -113,7 +116,7 @@ void main() {
           expect(result.isError, isNot(true));
           expect(testProcessManager.commandsRan, [
             equalsCommand((
-              command: [endsWith(appKind), 'pub', 'get'],
+              command: [endsWith(executableName), 'pub', 'get'],
               workingDirectory: fakeAppPath,
             )),
           ]);
@@ -135,7 +138,7 @@ void main() {
           expect(result.isError, isNot(true));
           expect(testProcessManager.commandsRan, [
             equalsCommand((
-              command: [endsWith(appKind), 'pub', 'upgrade'],
+              command: [endsWith(executableName), 'pub', 'upgrade'],
               workingDirectory: fakeAppPath,
             )),
           ]);

--- a/pkgs/dart_mcp_server/test/tools/pub_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/pub_test.dart
@@ -176,7 +176,7 @@ void main() {
           expect(result.isError, isNot(true));
           expect(testProcessManager.commandsRan, [
             equalsCommand((
-              command: [endsWith(appKind), 'pub', 'get'],
+              command: [endsWith(executableName), 'pub', 'get'],
               workingDirectory: p.join(fakeAppPath, 'subdir'),
             )),
           ]);

--- a/pkgs/dart_mcp_server/test/tools/pub_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/pub_test.dart
@@ -2,7 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
+import 'dart:io' hide File;
+import 'dart:io' as io show File;
 
 import 'package:dart_mcp/server.dart';
 import 'package:dart_mcp_server/src/mixins/pub.dart';
@@ -21,7 +22,7 @@ void main() {
   late Tool dartPubTool;
   late FileSystem fileSystem;
 
-  final fakeAppPath = '/fake_app/';
+  final fakeAppPath = io.File.fromUri(Uri.parse('/fake_app/')).path;
 
   for (final appKind in const ['dart', 'flutter']) {
     final executableName =
@@ -34,7 +35,12 @@ void main() {
       // TODO: Use setUpAll, currently this fails due to an apparent TestProcess
       // issue.
       setUp(() async {
-        fileSystem = MemoryFileSystem();
+        fileSystem = MemoryFileSystem(
+          style:
+              Platform.isWindows
+                  ? FileSystemStyle.windows
+                  : FileSystemStyle.posix,
+        );
         fileSystem.file(p.join(fakeAppPath, 'pubspec.yaml'))
           ..createSync(recursive: true)
           ..writeAsStringSync(
@@ -77,7 +83,7 @@ void main() {
           expect(testProcessManager.commandsRan, [
             equalsCommand((
               command: [endsWith(executableName), 'pub', 'add', 'foo'],
-              workingDirectory: fakeAppPath,
+              workingDirectory: testRoot.path,
             )),
           ]);
         });
@@ -100,7 +106,7 @@ void main() {
           expect(testProcessManager.commandsRan, [
             equalsCommand((
               command: [endsWith(executableName), 'pub', 'remove', 'foo'],
-              workingDirectory: fakeAppPath,
+              workingDirectory: testRoot.path,
             )),
           ]);
         });
@@ -122,7 +128,7 @@ void main() {
           expect(testProcessManager.commandsRan, [
             equalsCommand((
               command: [endsWith(executableName), 'pub', 'get'],
-              workingDirectory: fakeAppPath,
+              workingDirectory: testRoot.path,
             )),
           ]);
         });
@@ -144,7 +150,7 @@ void main() {
           expect(testProcessManager.commandsRan, [
             equalsCommand((
               command: [endsWith(executableName), 'pub', 'upgrade'],
-              workingDirectory: fakeAppPath,
+              workingDirectory: testRoot.path,
             )),
           ]);
         });

--- a/pkgs/dart_mcp_server/test/tools/pub_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/pub_test.dart
@@ -24,7 +24,12 @@ void main() {
   final fakeAppPath = '/fake_app/';
 
   for (final appKind in const ['dart', 'flutter']) {
-    final executableName = '$appKind${Platform.isWindows ? '.bat' : ''}';
+    final executableName =
+        '$appKind${Platform.isWindows
+            ? appKind == 'dart'
+                ? '.exe'
+                : '.bat'
+            : ''}';
     group('$appKind app', () {
       // TODO: Use setUpAll, currently this fails due to an apparent TestProcess
       // issue.


### PR DESCRIPTION
Closes https://github.com/dart-lang/ai/issues/32

I believe this should just work now that we are using headless flutter

Initially also added macos tests but those bots tend to wait queued for a long time, so I have removed them.