### PR TITLE
Always use the failures-only reporter for testing

### DIFF
--- a/pkgs/dart_mcp_server/lib/src/mixins/dash_cli.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dash_cli.dart
@@ -68,7 +68,7 @@ base mixin DashCliSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
   Future<CallToolResult> _runTests(CallToolRequest request) async {
     return runCommandInRoots(
       request,
-      arguments: ['test'],
+      arguments: ['test', '--reporter=failures-only'],
       commandDescription: 'dart|flutter test',
       processManager: processManager,
       knownRoots: await roots,

--- a/pkgs/dart_mcp_server/test/tools/dart_cli_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dart_cli_test.dart
@@ -166,13 +166,19 @@ dependencies:
           command: [
             endsWith(flutterExecutableName),
             'test',
+            '--reporter=failures-only',
             'foo_test.dart',
             'bar_test.dart',
           ],
           workingDirectory: exampleFlutterAppRoot.path,
         )),
         equalsCommand((
-          command: [endsWith(dartExecutableName), 'test', 'zip_test.dart'],
+          command: [
+            endsWith(dartExecutableName),
+            'test',
+            '--reporter=failures-only',
+            'zip_test.dart',
+          ],
           workingDirectory: dartCliAppRoot.path,
         )),
       ]);


### PR DESCRIPTION
The default reporter has verbose output which is not useful but eats up
a lot of input tokens once it's in the history. Always run tests with
`--reporter=failures-only` to reduce the output size. This output format
still includes a count of passing tests.
