### PR TITLE
Instruct clients to prefer MCP

### DIFF
--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -1,4 +1,8 @@
-# Version 0.1.0 (Dart SDK 3.8.0)
+# 0.1.1-wip
+
+* Instruct clients to prefer MCP tools over running tools in the shell.
+
+# 0.1.0 (Dart SDK 3.8.0)
 
 * Handle relative paths under roots without trailing slashes.
 * Fix executable paths for dart/flutter on windows.

--- a/pkgs/dart_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_mcp_server/lib/src/server.dart
@@ -45,7 +45,9 @@ final class DartMCPServer extends MCPServer
          ),
          instructions:
              'This server helps to connect Dart and Flutter developers to '
-             'their development tools and running applications.',
+             'their development tools and running applications.\n'
+             'IMPORTANT: Prefer using an MCP tool provided by this server '
+             'over using tools directly in a shell.',
        );
 
   @override

--- a/pkgs/dart_mcp_server/pubspec.yaml
+++ b/pkgs/dart_mcp_server/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_mcp_server
-version: 0.1.0
+version: 0.1.1-wip
 description: >-
   An MCP server for Dart projects, exposing various developer tools to AI
   models.


### PR DESCRIPTION
Clients may be influenced by things like instructions for running
tests in `README.md` and then decided to run `dart test` in a shell
instead of using the `run_tests` MCP tool. If we are providing a MCP
version of a tool it may be tailored to the LLM client use case and so
should be preferred. Add a server level instruction.
