### PR TITLE
Add error checks for accessing Request members

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Add `clientInfo` field to `MCPServer`, assigned during initialization.
 - Move the `done` future from the `ServerConnection` into `MCPBase` so it is
   available to the `MPCServer` class as well.
+- Added error checking to required fields of all `Request` subclasses so that
+  they will throw helpful errors when accessed and not set.
 
 ## 0.2.1
 

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.3-wip
+
+- Added error checking to required fields of all `Request` subclasses so that
+  they will throw helpful errors when accessed and not set.
+
 ## 0.2.2
 
 - Refactor `ClientImplementation` and `ServerImplementation` to the shared
@@ -6,8 +11,6 @@
 - Add `clientInfo` field to `MCPServer`, assigned during initialization.
 - Move the `done` future from the `ServerConnection` into `MCPBase` so it is
   available to the `MPCServer` class as well.
-- Added error checking to required fields of all `Request` subclasses so that
-  they will throw helpful errors when accessed and not set.
 
 ## 0.2.1
 

--- a/pkgs/dart_mcp/lib/src/api/completions.dart
+++ b/pkgs/dart_mcp/lib/src/api/completions.dart
@@ -41,12 +41,11 @@ extension type CompleteRequest.fromMap(Map<String, Object?> _value)
 
   /// The argument's information.
   CompletionArgument get argument {
-    if (_value['argument'] == null) {
+    final argument = _value['argument'] as Map?;
+    if (argument == null) {
       throw ArgumentError('Missing argument field in $CompleteRequest.');
-    } else {
-      return (_value['argument'] as Map).cast<String, Object?>()
-          as CompletionArgument;
     }
+    return argument.cast<String, Object?>() as CompletionArgument;
   }
 }
 

--- a/pkgs/dart_mcp/lib/src/api/completions.dart
+++ b/pkgs/dart_mcp/lib/src/api/completions.dart
@@ -27,11 +27,21 @@ extension type CompleteRequest.fromMap(Map<String, Object?> _value)
   ///
   /// In the case of a [ResourceReference], it must refer to a
   /// [ResourceTemplate].
-  Reference get ref => _value['ref'] as Reference;
+  Reference get ref {
+    if (_value['ref'] == null) {
+      throw ArgumentError('Missing ref field in $CompleteRequest.');
+    }
+    return _value['ref'] as Reference;
+  }
 
   /// The argument's information.
-  CompletionArgument get argument =>
-      (_value['argument'] as Map).cast<String, Object?>() as CompletionArgument;
+  CompletionArgument get argument {
+    if (_value['argument'] == null) {
+      throw ArgumentError('Missing argument field in $CompleteRequest.');
+    }
+    return (_value['argument'] as Map).cast<String, Object?>()
+        as CompletionArgument;
+  }
 }
 
 /// The server's response to a completion/complete request

--- a/pkgs/dart_mcp/lib/src/api/completions.dart
+++ b/pkgs/dart_mcp/lib/src/api/completions.dart
@@ -28,11 +28,11 @@ extension type CompleteRequest.fromMap(Map<String, Object?> _value)
   /// In the case of a [ResourceReference], it must refer to a
   /// [ResourceTemplate].
   Reference get ref {
-    final ref = _value['ref'];
+    final ref = _value['ref'] as Reference?;
     if (ref == null) {
       throw ArgumentError('Missing ref field in $CompleteRequest.');
     }
-    return ref as Reference;
+    return ref;
   }
 
   /// The argument's information.

--- a/pkgs/dart_mcp/lib/src/api/completions.dart
+++ b/pkgs/dart_mcp/lib/src/api/completions.dart
@@ -28,19 +28,25 @@ extension type CompleteRequest.fromMap(Map<String, Object?> _value)
   /// In the case of a [ResourceReference], it must refer to a
   /// [ResourceTemplate].
   Reference get ref {
-    if (_value['ref'] == null) {
-      throw ArgumentError('Missing ref field in $CompleteRequest.');
-    }
-    return _value['ref'] as Reference;
+    final ref = _value['ref'];
+    return switch (ref) {
+      Reference _ => ref,
+      null => throw ArgumentError('Missing ref field in $CompleteRequest.'),
+      _ =>
+        throw ArgumentError(
+          'Invalid ref field in $CompleteRequest, expected a $Reference.',
+        ),
+    };
   }
 
   /// The argument's information.
   CompletionArgument get argument {
     if (_value['argument'] == null) {
       throw ArgumentError('Missing argument field in $CompleteRequest.');
+    } else {
+      return (_value['argument'] as Map).cast<String, Object?>()
+          as CompletionArgument;
     }
-    return (_value['argument'] as Map).cast<String, Object?>()
-        as CompletionArgument;
   }
 }
 

--- a/pkgs/dart_mcp/lib/src/api/completions.dart
+++ b/pkgs/dart_mcp/lib/src/api/completions.dart
@@ -37,11 +37,11 @@ extension type CompleteRequest.fromMap(Map<String, Object?> _value)
 
   /// The argument's information.
   CompletionArgument get argument {
-    final argument = _value['argument'] as Map?;
+    final argument = _value['argument'] as CompletionArgument?;
     if (argument == null) {
       throw ArgumentError('Missing argument field in $CompleteRequest.');
     }
-    return argument.cast<String, Object?>() as CompletionArgument;
+    return argument;
   }
 }
 

--- a/pkgs/dart_mcp/lib/src/api/completions.dart
+++ b/pkgs/dart_mcp/lib/src/api/completions.dart
@@ -29,14 +29,10 @@ extension type CompleteRequest.fromMap(Map<String, Object?> _value)
   /// [ResourceTemplate].
   Reference get ref {
     final ref = _value['ref'];
-    return switch (ref) {
-      Reference _ => ref,
-      null => throw ArgumentError('Missing ref field in $CompleteRequest.'),
-      _ =>
-        throw ArgumentError(
-          'Invalid ref field in $CompleteRequest, expected a $Reference.',
-        ),
-    };
+    if (ref == null) {
+      throw ArgumentError('Missing ref field in $CompleteRequest.');
+    }
+    return ref as Reference;
   }
 
   /// The argument's information.

--- a/pkgs/dart_mcp/lib/src/api/initialization.dart
+++ b/pkgs/dart_mcp/lib/src/api/initialization.dart
@@ -31,17 +31,19 @@ extension type InitializeRequest._fromMap(Map<String, Object?> _value)
       ProtocolVersion.tryParse(_value['protocolVersion'] as String);
 
   ClientCapabilities get capabilities {
-    if (_value['capabilities'] == null) {
+    final capabilities = _value['capabilities'] as ClientCapabilities?;
+    if (capabilities == null) {
       throw ArgumentError('Missing capabilities field in $InitializeRequest.');
     }
-    return _value['capabilities'] as ClientCapabilities;
+    return capabilities;
   }
 
   Implementation get clientInfo {
     if (_value['clientInfo'] == null) {
       throw ArgumentError('Missing clientInfo field in $InitializeRequest.');
+    } else {
+      return _value['clientInfo'] as Implementation;
     }
-    return _value['clientInfo'] as Implementation;
   }
 }
 

--- a/pkgs/dart_mcp/lib/src/api/initialization.dart
+++ b/pkgs/dart_mcp/lib/src/api/initialization.dart
@@ -39,11 +39,11 @@ extension type InitializeRequest._fromMap(Map<String, Object?> _value)
   }
 
   Implementation get clientInfo {
-    if (_value['clientInfo'] == null) {
+    final clientInfo = _value['clientInfo'] as Implementation?;
+    if (clientInfo == null) {
       throw ArgumentError('Missing clientInfo field in $InitializeRequest.');
-    } else {
-      return _value['clientInfo'] as Implementation;
     }
+    return clientInfo;
   }
 }
 

--- a/pkgs/dart_mcp/lib/src/api/initialization.dart
+++ b/pkgs/dart_mcp/lib/src/api/initialization.dart
@@ -15,12 +15,15 @@ extension type InitializeRequest._fromMap(Map<String, Object?> _value)
     required ClientCapabilities capabilities,
     required Implementation clientInfo,
     MetaWithProgressToken? meta,
-  }) => InitializeRequest._fromMap({
-    'protocolVersion': protocolVersion.versionString,
-    'capabilities': capabilities,
-    'clientInfo': clientInfo,
-    if (meta != null) '_meta': meta,
-  });
+  }) {
+    print('Made it!');
+    return InitializeRequest._fromMap({
+      'protocolVersion': protocolVersion.versionString,
+      'capabilities': capabilities,
+      'clientInfo': clientInfo,
+      if (meta != null) '_meta': meta,
+    });
+  }
 
   /// The latest version of the Model Context Protocol that the client supports.
   ///
@@ -30,10 +33,19 @@ extension type InitializeRequest._fromMap(Map<String, Object?> _value)
   ProtocolVersion? get protocolVersion =>
       ProtocolVersion.tryParse(_value['protocolVersion'] as String);
 
-  ClientCapabilities get capabilities =>
-      _value['capabilities'] as ClientCapabilities;
+  ClientCapabilities get capabilities {
+    if (_value['capabilities'] == null) {
+      throw ArgumentError('Missing capabilities field in $InitializeRequest.');
+    }
+    return _value['capabilities'] as ClientCapabilities;
+  }
 
-  Implementation get clientInfo => _value['clientInfo'] as Implementation;
+  Implementation get clientInfo {
+    if (_value['clientInfo'] == null) {
+      throw ArgumentError('Missing clientInfo field in $InitializeRequest.');
+    }
+    return _value['clientInfo'] as Implementation;
+  }
 }
 
 /// After receiving an initialize request from the client, the server sends

--- a/pkgs/dart_mcp/lib/src/api/initialization.dart
+++ b/pkgs/dart_mcp/lib/src/api/initialization.dart
@@ -15,15 +15,12 @@ extension type InitializeRequest._fromMap(Map<String, Object?> _value)
     required ClientCapabilities capabilities,
     required Implementation clientInfo,
     MetaWithProgressToken? meta,
-  }) {
-    print('Made it!');
-    return InitializeRequest._fromMap({
-      'protocolVersion': protocolVersion.versionString,
-      'capabilities': capabilities,
-      'clientInfo': clientInfo,
-      if (meta != null) '_meta': meta,
-    });
-  }
+  }) => InitializeRequest._fromMap({
+    'protocolVersion': protocolVersion.versionString,
+    'capabilities': capabilities,
+    'clientInfo': clientInfo,
+    if (meta != null) '_meta': meta,
+  });
 
   /// The latest version of the Model Context Protocol that the client supports.
   ///

--- a/pkgs/dart_mcp/lib/src/api/logging.dart
+++ b/pkgs/dart_mcp/lib/src/api/logging.dart
@@ -26,8 +26,18 @@ extension type SetLevelRequest.fromMap(Map<String, Object?> _value)
   ///
   /// The server should send all logs at this level and higher (i.e., more
   /// severe) to the client as notifications/message.
-  LoggingLevel get level =>
-      LoggingLevel.values.firstWhere((level) => level.name == _value['level']);
+  LoggingLevel get level {
+    final foundLevel = LoggingLevel.values.firstWhereOrNull(
+      (level) => level.name == _value['level'],
+    );
+    if (foundLevel == null) {
+      throw ArgumentError(
+        "Invalid level field in SetLevelRequest: didn't find level "
+        '${_value['level']}',
+      );
+    }
+    return foundLevel;
+  }
 }
 
 /// Notification of a log message passed from server to client.

--- a/pkgs/dart_mcp/lib/src/api/logging.dart
+++ b/pkgs/dart_mcp/lib/src/api/logging.dart
@@ -27,13 +27,13 @@ extension type SetLevelRequest.fromMap(Map<String, Object?> _value)
   /// The server should send all logs at this level and higher (i.e., more
   /// severe) to the client as notifications/message.
   LoggingLevel get level {
+    final levelName = _value['level'];
     final foundLevel = LoggingLevel.values.firstWhereOrNull(
-      (level) => level.name == _value['level'],
+      (level) => level.name == levelName,
     );
     if (foundLevel == null) {
       throw ArgumentError(
-        "Invalid level field in SetLevelRequest: didn't find level "
-        '${_value['level']}',
+        "Invalid level field in $SetLevelRequest: didn't find level $levelName",
       );
     }
     return foundLevel;

--- a/pkgs/dart_mcp/lib/src/api/prompts.dart
+++ b/pkgs/dart_mcp/lib/src/api/prompts.dart
@@ -49,7 +49,12 @@ extension type GetPromptRequest.fromMap(Map<String, Object?> _value)
   });
 
   /// The name of the prompt or prompt template.
-  String get name => _value['name'] as String;
+  String get name {
+    if (_value['name'] == null) {
+      throw ArgumentError('Missing name field in $GetPromptRequest.');
+    }
+    return _value['name'] as String;
+  }
 
   /// Arguments to use for templating the prompt.
   Map<String, Object?>? get arguments =>

--- a/pkgs/dart_mcp/lib/src/api/prompts.dart
+++ b/pkgs/dart_mcp/lib/src/api/prompts.dart
@@ -50,11 +50,11 @@ extension type GetPromptRequest.fromMap(Map<String, Object?> _value)
 
   /// The name of the prompt or prompt template.
   String get name {
-    if (_value['name'] == null) {
+    final name = _value['name'] as String?;
+    if (name == null) {
       throw ArgumentError('Missing name field in $GetPromptRequest.');
-    } else {
-      return _value['name'] as String;
     }
+    return name;
   }
 
   /// Arguments to use for templating the prompt.

--- a/pkgs/dart_mcp/lib/src/api/prompts.dart
+++ b/pkgs/dart_mcp/lib/src/api/prompts.dart
@@ -52,8 +52,9 @@ extension type GetPromptRequest.fromMap(Map<String, Object?> _value)
   String get name {
     if (_value['name'] == null) {
       throw ArgumentError('Missing name field in $GetPromptRequest.');
+    } else {
+      return _value['name'] as String;
     }
-    return _value['name'] as String;
   }
 
   /// Arguments to use for templating the prompt.

--- a/pkgs/dart_mcp/lib/src/api/resources.dart
+++ b/pkgs/dart_mcp/lib/src/api/resources.dart
@@ -81,10 +81,11 @@ extension type ReadResourceRequest.fromMap(Map<String, Object?> _value)
   /// The URI of the resource to read. The URI can use any protocol; it is
   /// up to the server how to interpret it.
   String get uri {
-    if (_value['uri'] == null) {
+    final uri = _value['uri'] as String?;
+    if (uri == null) {
       throw ArgumentError('Missing uri field in $ReadResourceRequest.');
     }
-    return _value['uri'] as String;
+    return uri;
   }
 }
 
@@ -134,10 +135,11 @@ extension type SubscribeRequest.fromMap(Map<String, Object?> _value)
   /// The URI of the resource to subscribe to. The URI can use any protocol;
   /// it is up to the server how to interpret it.
   String get uri {
-    if (_value['uri'] == null) {
+    final uri = _value['uri'] as String?;
+    if (uri == null) {
       throw ArgumentError('Missing uri field in $SubscribeRequest.');
     }
-    return _value['uri'] as String;
+    return uri;
   }
 }
 
@@ -157,10 +159,11 @@ extension type UnsubscribeRequest.fromMap(Map<String, Object?> _value)
 
   /// The URI of the resource to unsubscribe from.
   String get uri {
-    if (_value['uri'] == null) {
+    final uri = _value['uri'] as String?;
+    if (uri == null) {
       throw ArgumentError('Missing uri field in $UnsubscribeRequest.');
     }
-    return _value['uri'] as String;
+    return uri;
   }
 }
 

--- a/pkgs/dart_mcp/lib/src/api/resources.dart
+++ b/pkgs/dart_mcp/lib/src/api/resources.dart
@@ -80,7 +80,12 @@ extension type ReadResourceRequest.fromMap(Map<String, Object?> _value)
 
   /// The URI of the resource to read. The URI can use any protocol; it is
   /// up to the server how to interpret it.
-  String get uri => _value['uri'] as String;
+  String get uri {
+    if (_value['uri'] == null) {
+      throw ArgumentError('Missing uri field in $ReadResourceRequest.');
+    }
+    return _value['uri'] as String;
+  }
 }
 
 /// The server's response to a resources/read request from the client.
@@ -128,7 +133,12 @@ extension type SubscribeRequest.fromMap(Map<String, Object?> _value)
 
   /// The URI of the resource to subscribe to. The URI can use any protocol;
   /// it is up to the server how to interpret it.
-  String get uri => _value['uri'] as String;
+  String get uri {
+    if (_value['uri'] == null) {
+      throw ArgumentError('Missing uri field in $SubscribeRequest.');
+    }
+    return _value['uri'] as String;
+  }
 }
 
 /// Sent from the client to request cancellation of resources/updated
@@ -146,7 +156,12 @@ extension type UnsubscribeRequest.fromMap(Map<String, Object?> _value)
       UnsubscribeRequest.fromMap({'uri': uri, if (meta != null) '_meta': meta});
 
   /// The URI of the resource to unsubscribe from.
-  String get uri => _value['uri'] as String;
+  String get uri {
+    if (_value['uri'] == null) {
+      throw ArgumentError('Missing uri field in $UnsubscribeRequest.');
+    }
+    return _value['uri'] as String;
+  }
 }
 
 /// A notification from the server to the client, informing it that a resource

--- a/pkgs/dart_mcp/lib/src/api/roots.dart
+++ b/pkgs/dart_mcp/lib/src/api/roots.dart
@@ -35,7 +35,7 @@ extension type ListRootsResult.fromMap(Map<String, Object?> _value)
 
   List<Root> get roots {
     if (_value['roots'] == null) {
-      throw ArgumentError('Missing roots field in ListRootsResult.');
+      throw ArgumentError('Missing roots field in $ListRootsResult.');
     }
     return (_value['roots'] as List).cast<Root>();
   }

--- a/pkgs/dart_mcp/lib/src/api/roots.dart
+++ b/pkgs/dart_mcp/lib/src/api/roots.dart
@@ -34,10 +34,11 @@ extension type ListRootsResult.fromMap(Map<String, Object?> _value)
       });
 
   List<Root> get roots {
-    if (_value['roots'] == null) {
+    final roots = _value['roots'] as List?;
+    if (roots == null) {
       throw ArgumentError('Missing roots field in $ListRootsResult.');
     }
-    return (_value['roots'] as List).cast<Root>();
+    return roots.cast<Root>();
   }
 }
 

--- a/pkgs/dart_mcp/lib/src/api/roots.dart
+++ b/pkgs/dart_mcp/lib/src/api/roots.dart
@@ -33,7 +33,12 @@ extension type ListRootsResult.fromMap(Map<String, Object?> _value)
         if (meta != null) '_meta': meta,
       });
 
-  List<Root> get roots => (_value['roots'] as List).cast<Root>();
+  List<Root> get roots {
+    if (_value['roots'] == null) {
+      throw ArgumentError('Missing roots field in ListRootsResult.');
+    }
+    return (_value['roots'] as List).cast<Root>();
+  }
 }
 
 /// Represents a root directory or file that the server can operate on.

--- a/pkgs/dart_mcp/lib/src/api/sampling.dart
+++ b/pkgs/dart_mcp/lib/src/api/sampling.dart
@@ -39,8 +39,12 @@ extension type CreateMessageRequest.fromMap(Map<String, Object?> _value)
   });
 
   /// The messages to send to the LLM.
-  List<SamplingMessage> get messages =>
-      (_value['messages'] as List).cast<SamplingMessage>();
+  List<SamplingMessage> get messages {
+    if (_value['messages'] == null) {
+      throw ArgumentError('Missing messages field in $CreateMessageRequest.');
+    }
+    return (_value['messages'] as List).cast<SamplingMessage>();
+  }
 
   /// The server's preferences for which model to select.
   ///
@@ -69,7 +73,12 @@ extension type CreateMessageRequest.fromMap(Map<String, Object?> _value)
   /// The maximum number of tokens to sample, as requested by the server.
   ///
   /// The client MAY choose to sample fewer tokens than requested.
-  int get maxTokens => _value['maxTokens'] as int;
+  int get maxTokens {
+    if (_value['maxTokens'] == null) {
+      throw ArgumentError('Missing maxTokens field in $CreateMessageRequest.');
+    }
+    return _value['maxTokens'] as int;
+  }
 
   /// Note: This has no documentation in the specification or schema.
   List<String>? get stopSequences =>

--- a/pkgs/dart_mcp/lib/src/api/sampling.dart
+++ b/pkgs/dart_mcp/lib/src/api/sampling.dart
@@ -40,10 +40,11 @@ extension type CreateMessageRequest.fromMap(Map<String, Object?> _value)
 
   /// The messages to send to the LLM.
   List<SamplingMessage> get messages {
-    if (_value['messages'] == null) {
+    final messages = _value['messages'] as List?;
+    if (messages == null) {
       throw ArgumentError('Missing messages field in $CreateMessageRequest.');
     }
-    return (_value['messages'] as List).cast<SamplingMessage>();
+    return messages.cast<SamplingMessage>();
   }
 
   /// The server's preferences for which model to select.
@@ -74,10 +75,11 @@ extension type CreateMessageRequest.fromMap(Map<String, Object?> _value)
   ///
   /// The client MAY choose to sample fewer tokens than requested.
   int get maxTokens {
-    if (_value['maxTokens'] == null) {
+    final maxTokens = _value['maxTokens'] as int?;
+    if (maxTokens == null) {
       throw ArgumentError('Missing maxTokens field in $CreateMessageRequest.');
     }
-    return _value['maxTokens'] as int;
+    return maxTokens;
   }
 
   /// Note: This has no documentation in the specification or schema.

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -80,7 +80,12 @@ extension type CallToolRequest._fromMap(Map<String, Object?> _value)
   });
 
   /// The name of the method to invoke.
-  String get name => _value['name'] as String;
+  String get name {
+    if (_value['name'] == null) {
+      throw ArgumentError('Missing name field in $CallToolRequest');
+    }
+    return _value['name'] as String;
+  }
 
   /// The arguments to pass to the method.
   Map<String, Object?>? get arguments =>

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -81,10 +81,11 @@ extension type CallToolRequest._fromMap(Map<String, Object?> _value)
 
   /// The name of the method to invoke.
   String get name {
-    if (_value['name'] == null) {
+    final name = _value['name'] as String?;
+    if (name == null) {
       throw ArgumentError('Missing name field in $CallToolRequest');
     }
-    return _value['name'] as String;
+    return name;
   }
 
   /// The arguments to pass to the method.

--- a/pkgs/dart_mcp/lib/src/shared.dart
+++ b/pkgs/dart_mcp/lib/src/shared.dart
@@ -80,7 +80,7 @@ base class MCPBase {
     String name,
     FutureOr<R> Function(T) impl,
   ) => _peer.registerMethod(name, (Parameters p) {
-    if (p.value is! Map?) {
+    if (p.value != null && p.value is! Map) {
       throw ArgumentError(
         'Request to $name must be a Map or null. Instead, got '
         '${p.value.runtimeType}',

--- a/pkgs/dart_mcp/lib/src/shared.dart
+++ b/pkgs/dart_mcp/lib/src/shared.dart
@@ -79,10 +79,15 @@ base class MCPBase {
   void registerRequestHandler<T extends Request?, R extends Result?>(
     String name,
     FutureOr<R> Function(T) impl,
-  ) => _peer.registerMethod(
-    name,
-    (Parameters p) => impl((p.value as Map?)?.cast<String, Object?>() as T),
-  );
+  ) => _peer.registerMethod(name, (Parameters p) {
+    if (p.value is! Map?) {
+      throw ArgumentError(
+        'Request to $name must be a Map or null. Instead, got '
+        '${p.value.runtimeType}',
+      );
+    }
+    return impl((p.value as Map?)?.cast<String, Object?>() as T);
+  });
 
   /// Registers a notification handler named [name] on this server.
   void registerNotificationHandler<T extends Notification?>(

--- a/pkgs/dart_mcp/pubspec.yaml
+++ b/pkgs/dart_mcp/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_mcp
-version: 0.2.2
+version: 0.2.3-wip
 description: A package for making MCP servers and clients.
 repository: https://github.com/dart-lang/ai/tree/main/pkgs/dart_mcp
 issue_tracker: https://github.com/dart-lang/ai/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Adart_mcp
@@ -10,7 +10,7 @@ environment:
 dependencies:
   async: ^2.13.0
   collection: ^1.19.1
-  json_rpc_2: '>=3.0.3 <5.0.0'
+  json_rpc_2: ">=3.0.3 <5.0.0"
   meta: ^1.16.0
   stream_channel: ^2.1.4
   stream_transform: ^2.1.1

--- a/pkgs/dart_mcp/test/api/api_test.dart
+++ b/pkgs/dart_mcp/test/api/api_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:dart_mcp/client.dart';
+import 'package:dart_mcp/src/api/api.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -58,5 +59,51 @@ void main() {
       false,
     );
   });
-  
+
+  group('API object validation', () {
+    test('throws when required fields are missing', () {
+      final empty = <String, Object?>{};
+
+      // Initialization
+      expect(
+        () => (empty as InitializeRequest).capabilities,
+        throwsArgumentError,
+      );
+      expect(
+        () => (empty as InitializeRequest).clientInfo,
+        throwsArgumentError,
+      );
+
+      // Tools
+      expect(() => (empty as CallToolRequest).name, throwsArgumentError);
+
+      // Resources
+      expect(() => (empty as ReadResourceRequest).uri, throwsArgumentError);
+      expect(() => (empty as SubscribeRequest).uri, throwsArgumentError);
+      expect(() => (empty as UnsubscribeRequest).uri, throwsArgumentError);
+
+      // Roots
+      expect(() => (empty as ListRootsResult).roots, throwsArgumentError);
+
+      // Prompts
+      expect(() => (empty as GetPromptRequest).name, throwsArgumentError);
+
+      // Completions
+      expect(() => (empty as CompleteRequest).ref, throwsArgumentError);
+      expect(() => (empty as CompleteRequest).argument, throwsArgumentError);
+
+      // Logging
+      expect(() => (empty as SetLevelRequest).level, throwsArgumentError);
+
+      // Sampling
+      expect(
+        () => (empty as CreateMessageRequest).messages,
+        throwsArgumentError,
+      );
+      expect(
+        () => (empty as CreateMessageRequest).maxTokens,
+        throwsArgumentError,
+      );
+    });
+  });
 }

--- a/pkgs/dart_mcp/test/api/api_test.dart
+++ b/pkgs/dart_mcp/test/api/api_test.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:dart_mcp/client.dart';
-import 'package:dart_mcp/src/api/api.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/pkgs/dart_mcp/test/api/api_test.dart
+++ b/pkgs/dart_mcp/test/api/api_test.dart
@@ -58,4 +58,5 @@ void main() {
       false,
     );
   });
+  
 }


### PR DESCRIPTION
## Description

This adds error checking and throws `ArgumentError` for `Request` subclasses which have required fields.  This is because in `shared.dart`, in `registerRequestHandler`, it casts the argument's value to a Map<String, Object?>, but it doesn't do any argument checking because creating those request objects don't go through the constructors, they are just cast:

```dart
    return impl((p.value as Map?)?.cast<String, Object?>() as T);
```

So I added error checking to all of the accessors for required members of `Request` objects, so that when they are accessed they will throw.

I ran across this when a client tried to send a malformed initialization request that didn't include capabilities, and the stack trace it sent was less than helpful.  This will at least send clearer errors.

## Tests
 - Added a test to check that these all throw.  Not sure how useful that is, really, but it at least keeps them from being removed accidentally.