### PR TITLE
update MCPClient.connectStdioServer to operate on streams and sinks

### DIFF
--- a/.github/workflows/dart_mcp.yaml
+++ b/.github/workflows/dart_mcp.yaml
@@ -44,4 +44,4 @@ jobs:
       - run: dart format --output=none --set-exit-if-changed .
         if: ${{ matrix.sdk == 'dev' }}
 
-      - run: dart test
+      - run: dart test -p chrome,vm -c dart2wasm,dart2js,kernel,exe

--- a/mcp_examples/bin/workflow_client.dart
+++ b/mcp_examples/bin/workflow_client.dart
@@ -409,11 +409,16 @@ final class WorkflowClient extends MCPClient with RootsSupport {
     for (var server in serverCommands) {
       final parts = server.split(' ');
       try {
+        final process = await Process.start(
+          parts.first,
+          parts.skip(1).toList(),
+        );
         serverConnections.add(
-          await connectStdioServer(
-            parts.first,
-            parts.skip(1).toList(),
+          connectStdioServer(
+            process.stdin,
+            process.stdout,
             protocolLogSink: logSink,
+            onDone: process.kill,
           ),
         );
       } catch (e) {

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -10,13 +10,16 @@
     `propertyNamesInvalid`, `propertyValueInvalid`, `itemInvalid` and
     `prefixItemInvalid`.
 - Added a `custom` validation error type.
-- Auto-validate schemas for all tools by default. This can be disabled by
-  passing `validateArguments: false` to `registerTool`.
-  - This is breaking since this method is overridden by the Dart MCP server.
+- **Breaking**: Auto-validate schemas for all tools by default. This can be
+  disabled by passing `validateArguments: false` to `registerTool`.
 - Updates to the latest MCP spec, [2025-06-08](https://modelcontextprotocol.io/specification/2025-06-18/changelog)
   - Adds support for Elicitations to allow the server to ask the user questions.
   - Adds `ResourceLink` as a tool return content type.
   - Adds support for structured tool output.
+- **Breaking**: Change `MCPClient.connectStdioServer` signature to accept stdin
+  and stdout streams instead of starting processes itself. This enables custom
+  process spawning (such as using package:process), and also enables the client
+  to run in browser environments.
 
 ## 0.2.2
 

--- a/pkgs/dart_mcp/dart_test.yaml
+++ b/pkgs/dart_mcp/dart_test.yaml
@@ -1,0 +1,4 @@
+override_platforms:
+  chrome:
+    settings:
+      headless: true

--- a/pkgs/dart_mcp/example/simple_client.dart
+++ b/pkgs/dart_mcp/example/simple_client.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:dart_mcp/client.dart';
 
 void main() async {
@@ -9,10 +11,16 @@ void main() async {
     Implementation(name: 'example dart client', version: '0.1.0'),
   );
   print('connecting to server');
-  final server = await client.connectStdioServer('dart', [
+
+  final process = await Process.start('dart', [
     'run',
     'example/simple_server.dart',
   ]);
+  final server = client.connectStdioServer(
+    process.stdin,
+    process.stdout,
+    onDone: process.kill,
+  );
   print('server started');
 
   print('initializing server');


### PR DESCRIPTION
Updated MCPClient.connectStdioServer to take a stdin and stdout stream instead of a binary name and arguments. It no longer spawns processes on its own. This removes the `dart:io` dependency and allows more flexibility for how processes are spawned (can use package:process or even no process at all).

The migration is pretty easy, just launch your own process and pass in stdin/stdout from that.

- Closes https://github.com/dart-lang/ai/issues/195
- Enables the client to run on the web
- Run all tests on the web, with wasm and dart2js, as well as AOT and kernel (these tests are all very fast)