### PR TITLE
Remove VS Code mcp instructions in favor of Dart-Code setting.

### DIFF
--- a/pkgs/dart_mcp_server/README.md
+++ b/pkgs/dart_mcp_server/README.md
@@ -117,7 +117,7 @@ By adding this setting, the Dart VS Code extension will register the Dart MCP Se
 configuration with VS Code so that you don't have to manually configure the server.
 Copilot will then automatically configure the Dart MCP server on your behalf. This is
 a global setting. If you'd only like the setting to apply to a specific workspace, add
-the entry to your workspace settings file: `.vscode/settings.json`.
+the entry to your workspace settings (Command Palette > **Preferences: Open Workspace Settings**).
 
 For more information, see the official VS Code documentation for
 [enabling MCP support](https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_enable-mcp-support-in-vs-code).

--- a/pkgs/dart_mcp_server/README.md
+++ b/pkgs/dart_mcp_server/README.md
@@ -116,28 +116,8 @@ to your VS Code user settings:
 By adding this setting, the Dart VS Code extension will register the Dart MCP Server
 configuration with VS Code so that you don't have to manually configure the server.
 Copilot will then automatically configure the Dart MCP server on your behalf. This is
-a global setting.
-
-Alternatively, you can click the "Add to VS Code" button below to manually configure the server
-in your VS Code user settings.
-
-[![Add to VS Code](_docs/add_to_vs_code.png)](https://vscode.dev/redirect?url=vscode:mcp/install?%7B%22name%22%3A%22dart%22%2C%22command%22%3A%22dart%22%2C%22args%22%3A%5B%22mcp-server%22%2C%22--experimental-mcp%22%5D%7D)
-
-Or, you can manually edit the `.vscode/mcp.json` file in your workspace,
-which will only configure the Dart MCP server for the local workspace:
-
-```json
-"servers": {
-  "dart": {
-    "type": "stdio",
-    "command": "dart",
-    "args": [
-      "mcp-server",
-      "--experimental-mcp-server", // Can be removed for Dart 3.9.0 or later
-    ]
-  }
-}
-```
+a global setting. If you'd only like the setting to apply to a specific workspace, add
+the entry to your workspace settings file: `.vscode/settings.json`.
 
 For more information, see the official VS Code documentation for
 [enabling MCP support](https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_enable-mcp-support-in-vs-code).

--- a/pkgs/dart_mcp_server/README.md
+++ b/pkgs/dart_mcp_server/README.md
@@ -6,6 +6,8 @@ WIP. This package is still experimental and is likely to evolve quickly.
 
 ## Set up your MCP client
 
+> Note: all of the following set up instructions require Dart 3.9.0 or later (current beta channel).
+
 <!-- Note: since many of our tools require access to the Dart Tooling Daemon, we may want
 to be cautious about recommending tools where access to the Dart Tooling Daemon does not exist. -->
 
@@ -105,6 +107,8 @@ For more information, see the official Cursor documentation for
 to provide a deep link to the Dart Extension Settings UI for users to
 enable the server. See docs: https://code.visualstudio.com/docs/configure/settings#_settings-editor.
 This may be preferable to adding the deep link button to VS Code's mcp settings. -->
+
+> Note: requires Dart-Code VS Code extension v3.114 or later.
 
 To configure the Dart MCP server with Copilot or any other AI agent that supports the
 [VS Code MCP API](https://code.visualstudio.com/api/extension-guides/mcp), add the following

--- a/pkgs/dart_mcp_server/README.md
+++ b/pkgs/dart_mcp_server/README.md
@@ -108,7 +108,7 @@ This may be preferable to adding the deep link button to VS Code's mcp settings.
 
 To configure the Dart MCP server with Copilot or any other AI agent that supports the
 [VS Code MCP API](https://code.visualstudio.com/api/extension-guides/mcp), add the following
-to your VS Code user settings:
+to your VS Code user settings (Command Palette > **Preferences: Open User Settings (JSON)**):
 ```json
 "dart.mcpServer": true
 ```
@@ -116,8 +116,9 @@ to your VS Code user settings:
 By adding this setting, the Dart VS Code extension will register the Dart MCP Server
 configuration with VS Code so that you don't have to manually configure the server.
 Copilot will then automatically configure the Dart MCP server on your behalf. This is
-a global setting. If you'd only like the setting to apply to a specific workspace, add
-the entry to your workspace settings (Command Palette > **Preferences: Open Workspace Settings**).
+a global setting. If you'd like the setting to apply only to a specific workspace, add
+the entry to your workspace settings (Command Palette > **Preferences: Open Workspace Settings (JSON)**)
+instead.
 
 For more information, see the official VS Code documentation for
 [enabling MCP support](https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_enable-mcp-support-in-vs-code).

--- a/pkgs/dart_mcp_server/README.md
+++ b/pkgs/dart_mcp_server/README.md
@@ -6,7 +6,7 @@ WIP. This package is still experimental and is likely to evolve quickly.
 
 ## Set up your MCP client
 
-> Note: all of the following set up instructions require Dart 3.9.0 or later (current beta channel).
+> Note: all of the following set up instructions require Dart 3.9.0-163.0.dev or later.
 
 <!-- Note: since many of our tools require access to the Dart Tooling Daemon, we may want
 to be cautious about recommending tools where access to the Dart Tooling Daemon does not exist. -->


### PR DESCRIPTION
@dantup this addresses your comments on https://github.com/dart-lang/ai/pull/201#discussion_r2172757237. Please let me know if there are other changes you'd like me to make to the docs.