### PR TITLE
disable the screenshots tool by default

### DIFF
--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -42,3 +42,5 @@
 * Add `--log-file` argument to log all protocol traffic to a file.
 * Improve error text for failed DTD connections as well as the tool description.
 * Add support for injecting an `Analytics` instance to track usage.
+* Screenshot tool disabled until
+  https://github.com/flutter/flutter/issues/170357 is resolved.

--- a/pkgs/dart_mcp_server/README.md
+++ b/pkgs/dart_mcp_server/README.md
@@ -74,7 +74,7 @@ for configuring the server in Android Studio. -->
 [![Add to Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=dart&config=eyJ0eXBlIjoic3RkaW8iLCJjb21tYW5kIjoiZGFydCBtY3Atc2VydmVyIC0tZXhwZXJpbWVudGFsLW1jcC1zZXJ2ZXIgLS1mb3JjZS1yb290cy1mYWxsYmFjayJ9)
 
 The easiest way to configure the Dart MCP server with Cursor is by clicking the "Add to Cursor"
-button above. 
+button above.
 
 Alternatively, you can configure the server manually. Go to **Cursor -> Settings -> Cursor Settings > Tools & Integrations**, and then click **"Add Custom MCP"** or **"New MCP Server"**
 depending on whether you already have other MCP servers configured. Edit the `.cursor/mcp.json` file in your local project (configuration will only apply to this project) or
@@ -155,7 +155,6 @@ For more information, see the official VS Code documentation for
 | `pub` | `static tool` | Runs a `dart pub` command for the given project roots. |
 | `pub_dev_search` | `package search` | Searches pub.dev for packages relevant to a given search query. |
 | `get_runtime_errors` | `runtime analysis` | Retrieves the list of runtime errors that have occurred in the active Dart or Flutter application. |
-| `take_screenshot` | `runtime analysis` | Takes a screenshot of the active Flutter application in its current state. |
 | `get_widget_tree` | `runtime analysis` | Retrieves the widget tree from the active Flutter application. |
 | `get_selected_widget` | `runtime analysis` | Retrieves the selected widget from the active Flutter application. |
 | `hot_reload` | `runtime tool` | Performs a hot reload of the active Flutter application. |

--- a/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
@@ -61,6 +61,9 @@ base mixin DartToolingDaemonSupport
   /// for full list of available Flutter Widget Inspector service extensions.
   static const _inspectorServiceExtensionPrefix = 'ext.flutter.inspector';
 
+  /// Whether or not to enable the screenshot tool.
+  bool get enableScreenshots;
+
   /// Called when the DTD connection is lost, resets all associated state.
   Future<void> _resetDtd() async {
     _dtd = null;
@@ -165,7 +168,7 @@ base mixin DartToolingDaemonSupport
     // they should return an error when used against a pure Dart app (or a
     // Flutter app that does not support the operation, e.g. hot reload is not
     // supported in profile mode).
-    registerTool(screenshotTool, takeScreenshot);
+    if (enableScreenshots) registerTool(screenshotTool, takeScreenshot);
     registerTool(hotReloadTool, hotReload);
     registerTool(getWidgetTreeTool, widgetTree);
     registerTool(getSelectedWidgetTool, selectedWidget);

--- a/pkgs/dart_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_mcp_server/lib/src/server.dart
@@ -52,6 +52,7 @@ final class DartMCPServer extends MCPServer
     @visibleForTesting this.processManager = const LocalProcessManager(),
     @visibleForTesting this.fileSystem = const LocalFileSystem(),
     this.forceRootsFallback = false,
+    // Disabled due to https://github.com/flutter/flutter/issues/170357
     this.enableScreenshots = false,
     super.protocolLogSink,
   }) : super.fromStreamChannel(

--- a/pkgs/dart_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_mcp_server/lib/src/server.dart
@@ -52,6 +52,7 @@ final class DartMCPServer extends MCPServer
     @visibleForTesting this.processManager = const LocalProcessManager(),
     @visibleForTesting this.fileSystem = const LocalFileSystem(),
     this.forceRootsFallback = false,
+    this.enableScreenshots = false,
     super.protocolLogSink,
   }) : super.fromStreamChannel(
          implementation: Implementation(
@@ -155,6 +156,9 @@ final class DartMCPServer extends MCPServer
 
   @override
   final Analytics? analytics;
+
+  @override
+  final bool enableScreenshots;
 
   @override
   /// Automatically logs all tool calls via analytics by wrapping the [impl],

--- a/pkgs/dart_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_mcp_server/test/test_harness.dart
@@ -445,6 +445,8 @@ Future<ServerConnectionPair> _initializeMCPServer(
       fileSystem: fileSystem,
       sdk: sdk,
       analytics: analytics,
+      // So we can test them.
+      enableScreenshots: true,
     );
     addTearDown(server.shutdown);
     connection = client.connectServer(clientChannel);

--- a/pkgs/dart_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dtd_test.dart
@@ -32,27 +32,6 @@ void main() {
       });
 
       group('flutter tests', () {
-        test('can take a screenshot', () async {
-          await testHarness.startDebugSession(
-            counterAppPath,
-            'lib/main.dart',
-            isFlutter: true,
-          );
-          final tools =
-              (await testHarness.mcpServerConnection.listTools()).tools;
-          final screenshotTool = tools.singleWhere(
-            (t) => t.name == DartToolingDaemonSupport.screenshotTool.name,
-          );
-          final screenshotResult = await testHarness.callToolWithRetry(
-            CallToolRequest(name: screenshotTool.name),
-          );
-          expect(screenshotResult.content.single, {
-            'data': anything,
-            'mimeType': 'image/png',
-            'type': ImageContent.expectedType,
-          });
-        });
-
         test('can get the widget tree', () async {
           await testHarness.startDebugSession(
             counterAppPath,
@@ -222,6 +201,26 @@ void main() {
           await testHarness.stopDebugSession(debugSession);
           await pumpEventQueue();
           expect(server.activeVmServices, isEmpty);
+        });
+      });
+
+      test('can take a screenshot', () async {
+        await testHarness.startDebugSession(
+          counterAppPath,
+          'lib/main.dart',
+          isFlutter: true,
+        );
+        final tools = (await testHarness.mcpServerConnection.listTools()).tools;
+        final screenshotTool = tools.singleWhere(
+          (t) => t.name == DartToolingDaemonSupport.screenshotTool.name,
+        );
+        final screenshotResult = await testHarness.callToolWithRetry(
+          CallToolRequest(name: screenshotTool.name),
+        );
+        expect(screenshotResult.content.single, {
+          'data': anything,
+          'mimeType': 'image/png',
+          'type': ImageContent.expectedType,
         });
       });
 


### PR DESCRIPTION
Disabling due to https://github.com/flutter/flutter/issues/170357 - this only works today by default on the desktop environment.

We could fall back on full device screenshots but are holding off on that for now as we have to evaluate some extra potential privacy concerns with exposing the entire screen as opposed to just the flutter drawn pixels.