### PR TITLE
move static argParser variable to a createArgParser function

### DIFF
--- a/pkgs/dart_mcp_server/lib/arg_parser.dart
+++ b/pkgs/dart_mcp_server/lib/arg_parser.dart
@@ -2,4 +2,4 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export 'src/arg_parser.dart' show argParser;
+export 'src/arg_parser.dart' show createArgParser;

--- a/pkgs/dart_mcp_server/lib/src/arg_parser.dart
+++ b/pkgs/dart_mcp_server/lib/src/arg_parser.dart
@@ -4,37 +4,54 @@
 
 import 'package:args/args.dart';
 
-final argParser = ArgParser(allowTrailingOptions: false)
-  ..addOption(
-    dartSdkOption,
-    help:
-        'The path to the root of the desired Dart SDK. Defaults to the '
-        'DART_SDK environment variable.',
-  )
-  ..addOption(
-    flutterSdkOption,
-    help:
-        'The path to the root of the desired Flutter SDK. Defaults to '
-        'the FLUTTER_SDK environment variable, then searching up from '
-        'the Dart SDK.',
-  )
-  ..addFlag(
-    forceRootsFallbackFlag,
-    negatable: true,
-    defaultsTo: false,
-    help:
-        'Forces a behavior for project roots which uses MCP tools '
-        'instead of the native MCP roots. This can be helpful for '
-        'clients like cursor which claim to have roots support but do '
-        'not actually support it.',
-  )
-  ..addOption(
-    logFileOption,
-    help:
-        'Path to a file to log all MPC protocol traffic to. File will be '
-        'overwritten if it exists.',
-  )
-  ..addFlag(helpFlag, abbr: 'h', help: 'Show usage text');
+/// Creates an arg parser for th MCP server.
+///
+/// The `--help` option is only included if [includeHelp] is `true`.
+///
+/// Passing no options results in the default arg parser.
+ArgParser createArgParser({
+  bool includeHelp = true,
+  bool allowTrailingOptions = false,
+  int? usageLineLength,
+}) {
+  final parser =
+      ArgParser(
+          allowTrailingOptions: allowTrailingOptions,
+          usageLineLength: usageLineLength,
+        )
+        ..addOption(
+          dartSdkOption,
+          help:
+              'The path to the root of the desired Dart SDK. Defaults to the '
+              'DART_SDK environment variable.',
+        )
+        ..addOption(
+          flutterSdkOption,
+          help:
+              'The path to the root of the desired Flutter SDK. Defaults to '
+              'the FLUTTER_SDK environment variable, then searching up from '
+              'the Dart SDK.',
+        )
+        ..addFlag(
+          forceRootsFallbackFlag,
+          negatable: true,
+          defaultsTo: false,
+          help:
+              'Forces a behavior for project roots which uses MCP tools '
+              'instead of the native MCP roots. This can be helpful for '
+              'clients like cursor which claim to have roots support but do '
+              'not actually support it.',
+        )
+        ..addOption(
+          logFileOption,
+          help:
+              'Path to a file to log all MPC protocol traffic to. File will be '
+              'overwritten if it exists.',
+        );
+
+  if (includeHelp) parser.addFlag(helpFlag, abbr: 'h', help: 'Show usage text');
+  return parser;
+}
 
 const dartSdkOption = 'dart-sdk';
 const flutterSdkOption = 'flutter-sdk';

--- a/pkgs/dart_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_mcp_server/lib/src/server.dart
@@ -144,6 +144,9 @@ final class DartMCPServer extends MCPServer
     }
   }
 
+  /// The default arg parser for the MCP Server.
+  static final argParser = createArgParser();
+
   @override
   final LocalProcessManager processManager;
 


### PR DESCRIPTION
The dart tool actually wants to set a few variables and needs to exclude the help command otherwise it is duplicated.