### PR TITLE
don't bail early when running in multiple roots

### DIFF
--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -1,4 +1,9 @@
-# 0.1.0 (Dart SDK 3.8.0) - WP
+# 0.1.1 (Dart SDK 3.10.0) - WIP
+
+* Change tools that accept multiple roots to not return immediately on the first
+  failure.
+
+# 0.1.0 (Dart SDK 3.9.0)
 
 * Add documentation/homepage/repository links to pub results.
 * Handle relative paths under roots without trailing slashes.

--- a/pkgs/dart_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_mcp_server/lib/src/server.dart
@@ -58,7 +58,7 @@ final class DartMCPServer extends MCPServer
   }) : super.fromStreamChannel(
          implementation: Implementation(
            name: 'dart and flutter tooling',
-           version: '0.1.0',
+           version: '0.1.1',
          ),
          instructions:
              'This server helps to connect Dart and Flutter developers to '

--- a/pkgs/dart_mcp_server/lib/src/utils/cli_utils.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/cli_utils.dart
@@ -96,6 +96,7 @@ Future<CallToolResult> runCommandInRoots(
   }
 
   final outputs = <Content>[];
+  var isError = false;
   for (var rootConfig in rootConfigs) {
     final result = await runCommandInRoot(
       request,
@@ -109,10 +110,10 @@ Future<CallToolResult> runCommandInRoots(
       defaultPaths: defaultPaths,
       sdk: sdk,
     );
-    if (result.isError == true) return result;
+    isError = isError || result.isError == true;
     outputs.addAll(result.content);
   }
-  return CallToolResult(content: outputs);
+  return CallToolResult(content: outputs, isError: isError);
 }
 
 /// Runs [commandForRoot] in a single project root specified in the
@@ -233,7 +234,7 @@ Future<CallToolResult> runCommandInRoot(
         TextContent(
           text:
               '$commandDescription failed in ${projectRoot.path}:\n'
-              '$output\n\nErrors\n$errors',
+              '$output${errors.isEmpty ? '' : '\nErrors:\n$errors'}',
         ),
       ],
       isError: true,


### PR DESCRIPTION
Previously if a tool was ran in multiple roots and one of them failed, it would immediately return with just that failure output.