### PR TITLE
Add failure reasons to tool call analytics events

### DIFF
--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Change tools that accept multiple roots to not return immediately on the first
   failure.
+* Add failure reason field to analytics events so we can know why tool calls are
+  failing.
 
 # 0.1.0 (Dart SDK 3.9.0)
 

--- a/pkgs/dart_mcp_server/lib/src/mixins/analyzer.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/analyzer.dart
@@ -13,6 +13,7 @@ import 'package:language_server_protocol/protocol_generated.dart' as lsp;
 import 'package:meta/meta.dart';
 
 import '../lsp/wire_format.dart';
+import '../utils/analytics.dart';
 import '../utils/constants.dart';
 import '../utils/sdk.dart';
 
@@ -474,7 +475,7 @@ base mixin DartAnalyzerSupport
             'tool.',
       ),
     ],
-  );
+  )..failureReason = CallToolFailureReason.noRootsSet;
 }
 
 /// Common schema for tools that require a file URI, line, and column.

--- a/pkgs/dart_mcp_server/lib/src/mixins/dash_cli.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dash_cli.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 import 'package:dart_mcp/server.dart';
 import 'package:path/path.dart' as p;
 
+import '../utils/analytics.dart';
 import '../utils/cli_utils.dart';
 import '../utils/constants.dart';
 import '../utils/file_system.dart';
@@ -141,7 +142,7 @@ base mixin DashCliSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
           for (final error in errors) Content.text(text: error.toErrorString()),
         ],
         isError: true,
-      );
+      )..failureReason = CallToolFailureReason.argumentError;
     }
 
     final template = args[ParameterNames.template] as String?;

--- a/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
@@ -199,7 +199,7 @@ base mixin DartToolingDaemonSupport
             text: 'Connection failed, make sure your DTD Uri is up to date.',
           ),
         ],
-      );
+      )..failureReason = CallToolFailureReason.webSocketException;
     } catch (e) {
       return CallToolResult(
         isError: true,
@@ -532,7 +532,7 @@ base mixin DartToolingDaemonSupport
                 'boolean.',
           ),
         ],
-      );
+      )..failureReason = CallToolFailureReason.argumentError;
     }
 
     return _callOnVmService(
@@ -750,7 +750,7 @@ base mixin DartToolingDaemonSupport
             'connect to Dart and Flutter applications.',
       ),
     ],
-  );
+  )..failureReason = CallToolFailureReason.connectedAppServiceNotSupported;
 
   static final _dtdNotConnected = CallToolResult(
     isError: true,
@@ -761,7 +761,7 @@ base mixin DartToolingDaemonSupport
             '"${connectTool.name}" first.',
       ),
     ],
-  );
+  )..failureReason = CallToolFailureReason.dtdNotConnected;
 
   static final _dtdAlreadyConnected = CallToolResult(
     isError: true,
@@ -772,14 +772,14 @@ base mixin DartToolingDaemonSupport
             '"${connectTool.name}" again.',
       ),
     ],
-  );
+  )..failureReason = CallToolFailureReason.dtdAlreadyConnected;
 
   static final _noActiveDebugSession = CallToolResult(
     content: [
       TextContent(text: 'No active debug session to take a screenshot'),
     ],
     isError: true,
-  );
+  )..failureReason = CallToolFailureReason.noActiveDebugSession;
 
   static final runtimeErrorsScheme = 'runtime-errors';
 }

--- a/pkgs/dart_mcp_server/lib/src/mixins/pub.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/pub.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:dart_mcp/server.dart';
 
+import '../utils/analytics.dart';
 import '../utils/cli_utils.dart';
 import '../utils/constants.dart';
 import '../utils/file_system.dart';
@@ -47,7 +48,7 @@ base mixin PubSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
           ),
         ],
         isError: true,
-      );
+      )..failureReason ??= CallToolFailureReason.noSuchCommand;
     }
 
     final packageName =
@@ -62,7 +63,7 @@ base mixin PubSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
           ),
         ],
         isError: true,
-      );
+      )..failureReason ??= CallToolFailureReason.argumentError;
     }
 
     return runCommandInRoots(

--- a/pkgs/dart_mcp_server/lib/src/mixins/pub_dev_search.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/pub_dev_search.dart
@@ -9,6 +9,7 @@ import 'package:dart_mcp/server.dart';
 import 'package:http/http.dart';
 import 'package:pool/pool.dart';
 
+import '../utils/analytics.dart';
 import '../utils/json.dart';
 
 /// Limit the number of concurrent requests.
@@ -36,7 +37,7 @@ base mixin PubDevSupport on ToolsSupport {
       return CallToolResult(
         content: [TextContent(text: 'Missing required argument `query`.')],
         isError: true,
-      );
+      )..failureReason = CallToolFailureReason.argumentError;
     }
     final searchUrl = Uri.https('pub.dev', 'api/search', {'q': query});
     final Object? result;
@@ -54,7 +55,6 @@ base mixin PubDevSupport on ToolsSupport {
               text: 'No packages matched the query, consider simplifying it.',
             ),
           ],
-          isError: true,
         );
       }
 

--- a/pkgs/dart_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_mcp_server/lib/src/server.dart
@@ -198,6 +198,7 @@ final class DartMCPServer extends MCPServer
                         tool: request.name,
                         success: result != null && result.isError != true,
                         elapsedMilliseconds: watch.elapsedMilliseconds,
+                        failureReason: result?.failureReason,
                       ),
                     ),
                   );

--- a/pkgs/dart_mcp_server/lib/src/utils/analytics.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/analytics.dart
@@ -88,11 +88,19 @@ extension WithFailureReason on CallToolResult {
 
 /// Known reasons for failed tool calls.
 enum CallToolFailureReason {
+  argumentError,
+  connectedAppServiceNotSupported,
+  dtdAlreadyConnected,
+  dtdNotConnected,
   invalidPath,
   invalidRootPath,
   invalidRootScheme,
+  noActiveDebugSession,
   noRootGiven,
+  noRootsSet,
+  noSuchCommand,
   nonZeroExitCode,
+  webSocketException,
 }
 
 const _elapsedMilliseconds = 'elapsedMilliseconds';

--- a/pkgs/dart_mcp_server/lib/src/utils/analytics.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/analytics.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:dart_mcp/server.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
 /// An interface class that provides a access to an [Analytics] instance, if
@@ -53,10 +54,14 @@ final class CallToolMetrics extends CustomMetrics {
   /// The time it took to invoke the tool.
   final int elapsedMilliseconds;
 
+  /// The reason for the failure, if [success] is `false`.
+  final CallToolFailureReason? failureReason;
+
   CallToolMetrics({
     required this.tool,
     required this.success,
     required this.elapsedMilliseconds,
+    required this.failureReason,
   });
 
   @override
@@ -64,12 +69,34 @@ final class CallToolMetrics extends CustomMetrics {
     _tool: tool,
     _success: success,
     _elapsedMilliseconds: elapsedMilliseconds,
+    _failureReason: ?failureReason?.name,
   };
 }
 
 enum ResourceKind { runtimeErrors }
 
+/// Extension which tracks failure reasons for [CallToolResult] objects in an
+/// [Expando].
+extension WithFailureReason on CallToolResult {
+  static final _expando = Expando<CallToolFailureReason>();
+
+  CallToolFailureReason? get failureReason => _expando[this as Object];
+
+  set failureReason(CallToolFailureReason? value) =>
+      _expando[this as Object] = value;
+}
+
+/// Known reasons for failed tool calls.
+enum CallToolFailureReason {
+  invalidPath,
+  invalidRootPath,
+  invalidRootScheme,
+  noRootGiven,
+  nonZeroExitCode,
+}
+
 const _elapsedMilliseconds = 'elapsedMilliseconds';
+const _failureReason = 'failureReason';
 const _kind = 'kind';
 const _length = 'length';
 const _success = 'success';

--- a/pkgs/dart_mcp_server/lib/src/utils/cli_utils.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/cli_utils.dart
@@ -10,6 +10,7 @@ import 'package:file/file.dart';
 import 'package:process/process.dart';
 import 'package:yaml/yaml.dart';
 
+import 'analytics.dart';
 import 'constants.dart';
 import 'sdk.dart';
 
@@ -158,7 +159,7 @@ Future<CallToolResult> runCommandInRoot(
         TextContent(text: 'Invalid root configuration: missing `root` key.'),
       ],
       isError: true,
-    );
+    )..failureReason ??= CallToolFailureReason.noRootGiven;
   }
 
   final root = knownRoots.firstWhereOrNull(
@@ -174,7 +175,7 @@ Future<CallToolResult> runCommandInRoot(
         ),
       ],
       isError: true,
-    );
+    )..failureReason ??= CallToolFailureReason.invalidRootPath;
   }
 
   final rootUri = Uri.parse(rootUriString);
@@ -188,7 +189,7 @@ Future<CallToolResult> runCommandInRoot(
         ),
       ],
       isError: true,
-    );
+    )..failureReason ??= CallToolFailureReason.invalidRootScheme;
   }
   final projectRoot = fileSystem.directory(rootUri);
 
@@ -212,7 +213,7 @@ Future<CallToolResult> runCommandInRoot(
         ),
       ],
       isError: true,
-    );
+    )..failureReason ??= CallToolFailureReason.invalidPath;
   }
   commandWithPaths.addAll(paths);
 
@@ -237,7 +238,7 @@ Future<CallToolResult> runCommandInRoot(
         ),
       ],
       isError: true,
-    );
+    )..failureReason ??= CallToolFailureReason.nonZeroExitCode;
   }
   return CallToolResult(
     content: [

--- a/pkgs/dart_mcp_server/test/tools/pub_dev_search_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/pub_dev_search_test.dart
@@ -175,7 +175,7 @@ void main() {
     );
   });
 
-  test('No matching packages gets reported as an error', () async {
+  test('No matching packages gets special handling', () async {
     await runWithClient(
       () async {
         await runWithHarness((testHarness, pubDevSearchTool) async {
@@ -187,9 +187,8 @@ void main() {
           final result = await testHarness.callToolWithRetry(
             request,
             maxTries: 1,
-            expectError: true,
           );
-          expect(result.isError, isTrue);
+          expect(result.isError, isNot(true));
           expect(
             (result.content[0] as TextContent).text,
             contains('No packages matched the query, consider simplifying it'),


### PR DESCRIPTION
This should help us to understand why tool calls fail, instead of just seeing that they failed.

In particular for tests as an example, we can discard the ones that fail due to a non-zero exit code.