### PR TITLE
Started omitting instructions if they are null.

### DIFF
--- a/pkgs/dart_mcp/lib/src/api/initialization.dart
+++ b/pkgs/dart_mcp/lib/src/api/initialization.dart
@@ -56,12 +56,17 @@ extension type InitializeResult.fromMap(Map<String, Object?> _value)
     required ServerCapabilities serverCapabilities,
     required Implementation serverInfo,
     String? instructions,
-  }) => InitializeResult.fromMap({
-    'protocolVersion': protocolVersion.versionString,
-    'capabilities': serverCapabilities,
-    'serverInfo': serverInfo,
-    'instructions': instructions,
-  });
+  }) {
+    final map = {
+      'protocolVersion': protocolVersion.versionString,
+      'capabilities': serverCapabilities,
+      'serverInfo': serverInfo,
+    };
+    if (instructions != null) {
+      map['instructions'] = instructions;
+    }
+    return InitializeResult.fromMap(map);
+  }
 
   /// The version of the Model Context Protocol that the server wants to use.
   ///

--- a/pkgs/dart_mcp/test/api/initialization_test.dart
+++ b/pkgs/dart_mcp/test/api/initialization_test.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:js_interop';
+
+import 'package:dart_mcp/server.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('null instructions', () async {
+    final result = InitializeResult(
+      protocolVersion: ProtocolVersion.latestSupported,
+      serverCapabilities: ServerCapabilities(),
+      serverInfo: Implementation(name: 'name', version: 'version'),
+    );
+
+    final map = result as Map<String, Object?>;
+    expect(map.containsKey('instructions'), isFalse);
+  });
+
+  test('nonnull instructions', () async {
+    final result = InitializeResult(
+      protocolVersion: ProtocolVersion.latestSupported,
+      serverCapabilities: ServerCapabilities(),
+      serverInfo: Implementation(name: 'name', version: 'version'),
+      instructions: 'foo',
+    );
+
+    final map = result as Map<String, Object?>;
+    expect(map['instructions'], equals('foo'));
+  });
+}


### PR DESCRIPTION
fixes https://github.com/dart-lang/ai/issues/196

This makes sure that the map for the InitializationResult doesn't include a `instructions` entry if the value is null.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
