### PR TITLE
Add flutter driver tool

### DIFF
--- a/mcp_examples/bin/workflow_client.dart
+++ b/mcp_examples/bin/workflow_client.dart
@@ -14,11 +14,7 @@ import 'package:google_generative_ai/google_generative_ai.dart' as gemini;
 
 /// The list of Gemini models that are accepted as a "--model" argument.
 /// Defaults to the first one in the list.
-const List<String> allowedGeminiModels = [
-  'gemini-2.5-pro-preview-03-25',
-  'gemini-2.0-flash',
-  'gemini-2.5-flash-preview-04-17',
-];
+const List<String> allowedGeminiModels = ['gemini-2.5-pro', 'gemini-2.5-flash'];
 
 void main(List<String> args) {
   final geminiApiKey = Platform.environment['GEMINI_API_KEY'];
@@ -160,8 +156,6 @@ final class WorkflowClient extends MCPClient with RootsSupport {
       StreamSinkTransformer.fromHandlers(
         handleData: (String data, EventSink<List<int>> innerSink) {
           innerSink.add(utf8.encode(data));
-          // It's a log, so we want to make sure it's always up-to-date.
-          fileByteSink.flush();
         },
         handleError: (
           Object error,
@@ -550,6 +544,13 @@ final class WorkflowClient extends MCPClient with RootsSupport {
         );
       case JsonType.bool:
         return gemini.Schema.boolean(
+          description: description,
+          nullable: nullable,
+        );
+      case JsonType.enumeration:
+        final schema = inputSchema as EnumSchema;
+        return gemini.Schema.enumString(
+          enumValues: schema.values.toList(),
           description: description,
           nullable: nullable,
         );

--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -4,6 +4,7 @@
   failure.
 * Add failure reason field to analytics events so we can know why tool calls are
   failing.
+* Add a flutter_driver command for executing flutter driver commands on a device.
 
 # 0.1.0 (Dart SDK 3.9.0)
 

--- a/pkgs/dart_mcp_server/README.md
+++ b/pkgs/dart_mcp_server/README.md
@@ -147,5 +147,6 @@ For more information, see the official VS Code documentation for
 | `get_active_location` | `editor` | Gets the active cursor position in the connected editor (if available). |
 | `run_tests` | `static tool` | Runs tests for the given project roots. |
 | `create_project` | `static tool` | Creates a new Dart or Flutter project. |
+| `flutter_driver` | `runtime tool` | Enables executing flutter driver commands against the connected app. |
 
 > *Experimental: may be removed.

--- a/pkgs/dart_mcp_server/lib/src/utils/analytics.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/analytics.dart
@@ -92,6 +92,7 @@ enum CallToolFailureReason {
   connectedAppServiceNotSupported,
   dtdAlreadyConnected,
   dtdNotConnected,
+  flutterDriverNotEnabled,
   invalidPath,
   invalidRootPath,
   invalidRootScheme,

--- a/pkgs/dart_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dtd_test.dart
@@ -614,6 +614,70 @@ void main() {
         // Clean up
         await testHarness.stopDebugSession(debugSession);
       });
+
+      group('Flutter driver', () {
+        test('can get text and tap buttons', () async {
+          final debugSession = await testHarness.startDebugSession(
+            counterAppPath,
+            'lib/driver_main.dart',
+            isFlutter: true,
+          );
+          var result = await testHarness.callToolWithRetry(
+            CallToolRequest(
+              name: DartToolingDaemonSupport.flutterDriverTool.name,
+              arguments: {
+                'command': 'get_text',
+                'finderType': 'ByValueKey',
+                'keyValueString': 'counter',
+                'keyValueType': 'String',
+              },
+            ),
+          );
+          expect(
+            result.content.first,
+            isA<TextContent>().having(
+              (c) => c.text,
+              'text',
+              contains('"text":"0"'),
+            ),
+          );
+
+          result = await testHarness.callToolWithRetry(
+            CallToolRequest(
+              name: DartToolingDaemonSupport.flutterDriverTool.name,
+              arguments: {
+                'command': 'tap',
+                'finderType': 'ByTooltipMessage',
+                'text': 'Increment',
+              },
+            ),
+          );
+          expect(result.isError, isNot(true));
+
+          result = await testHarness.callToolWithRetry(
+            CallToolRequest(
+              name: DartToolingDaemonSupport.flutterDriverTool.name,
+              arguments: {
+                'command': 'get_text',
+                'finderType': 'ByValueKey',
+                'keyValueString': 'counter',
+                'keyValueType': 'String',
+              },
+            ),
+          );
+          expect(
+            result.content.first,
+            isA<TextContent>().having(
+              (c) => c.text,
+              'text',
+              contains('"text":"1"'),
+            ),
+          );
+
+          // Clean up
+          await testHarness.stopDebugSession(debugSession);
+        });
+      });
     });
   });
 

--- a/pkgs/dart_mcp_server/test_fixtures/counter_app/lib/driver_main.dart
+++ b/pkgs/dart_mcp_server/test_fixtures/counter_app/lib/driver_main.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_driver/driver_extension.dart';
+
+import 'main.dart' as app;
+
+void main() {
+  enableFlutterDriverExtension();
+  app.main();
+}

--- a/pkgs/dart_mcp_server/test_fixtures/counter_app/lib/main.dart
+++ b/pkgs/dart_mcp_server/test_fixtures/counter_app/lib/main.dart
@@ -71,6 +71,7 @@ class _MyHomePageState extends State<MyHomePage> {
             Text(
               '$_counter',
               style: Theme.of(context).textTheme.headlineMedium,
+              key: const Key('counter'),
             ),
           ],
         ),

--- a/pkgs/dart_mcp_server/test_fixtures/counter_app/pubspec.yaml
+++ b/pkgs/dart_mcp_server/test_fixtures/counter_app/pubspec.yaml
@@ -12,6 +12,8 @@ dependencies:
 
   flutter:
     sdk: flutter
+  flutter_driver:
+    sdk: flutter
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Towards https://github.com/dart-lang/ai/issues/222 (could close it, but probably we should do some more work to validate it works well).

Adds the flutter driver tool, with a curated set of available commands. I decided to expose this as just a single tool, which mirrors exactly the flutter driver extension method.

The schema for this is pretty weird and complex - but in general Gemini seems to do OK with it.

Note that I only tested the tap/get_text commands, I think that is likely sufficient (really we just need to test we are forwarding commands through, we aren't doing anything special).

Also updates the workflow client to handle enums and use updated model names.