### PR TITLE
Allow multiple package arguments to pub commands

### DIFF
--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -1,57 +1,58 @@
 # 0.1.1 (Dart SDK 3.10.0) - WIP
 
-- Change tools that accept multiple roots to not return immediately on the first
+* Change tools that accept multiple roots to not return immediately on the first
   failure.
-- Add failure reason field to analytics events so we can know why tool calls are
+* Add failure reason field to analytics events so we can know why tool calls are
   failing.
-- Modified argument to `pub` tool to allow for multiple package arguments to `pub add` and `pub remove`.
+* Allow for multiple package arguments to `pub add` and `pub remove`.
 
 # 0.1.0 (Dart SDK 3.9.0)
 
-- Add documentation/homepage/repository links to pub results.
-- Handle relative paths under roots without trailing slashes.
-- Fix executable paths for dart/flutter on windows.
-- Pass the provided root instead of the resolved root for project type detection.
-- Be more flexible about roots by comparing canonicalized paths.
-- Create the working dir if it doesn't exist.
-- Add the --platform and --empty arguments to the flutter create tool.
-- Invoke dart/flutter in a more robust way.
-- Remove qualifiedNames from the pub dev api search.
-- Flutter/Dart create tool.
-- Limit the tokens returned by the runtime errors tool/resource.
-- Add RootsFallbackSupport mixin.
-- Fix error handling around stream listeners.
-- Add a 'pub-dev-search' mcp tool.
-- Drop pubspec-parse, use yaml instead.
-- Handle failing to listen to vm service streams during startup.
-- Add tool for enabling/disabling the widget selector.
-- Add a tool to get the active cursor location.
-- Add hover tool support.
-- Add a test command and project detection.
-- Add signature_help tool.
-- Add runtime errors resource and tool to clear errors.
-- Require roots for all CLI tools.
-- Require roots to be set for analyzer tools.
-- Add debug logs for when DTD sees Editor.getDebugSessions get registered.
-- Add tool annotations to tools.
-- Implement a tool to resolve workspace symbols based on a query.
-- Add a dart pub tool.
-- Update analyze tool to use LSP, simplify tool.
-- Add tool for getting the selected widget.
-- Handle missing roots capability better.
-- Add `get_widget_tree` tool.
-- Add a tool for getting runtime errors.
-- Add Dart CLI tool support.
-- Add a hot reload tool.
-- Add basic analysis support.
-- Add the beginnings of a Dart tooling MCP server.
-- Instruct clients to prefer MCP tools over running tools in the shell.
-- Reduce output size of `run_tests` tool to save on input tokens.
-- Add `--log-file` argument to log all protocol traffic to a file.
-- Improve error text for failed DTD connections as well as the tool description.
-- Add support for injecting an `Analytics` instance to track usage.
-- Listen to the new DTD `ConnectedApp` service instead of the `Editor.DebugSessions`
+* Add documentation/homepage/repository links to pub results.
+* Handle relative paths under roots without trailing slashes.
+* Fix executable paths for dart/flutter on windows.
+* Pass the provided root instead of the resolved root for project type detection.
+* Be more flexible about roots by comparing canonicalized paths.
+* Create the working dir if it doesn't exist.
+* Add the --platform and --empty arguments to the flutter create tool.
+* Invoke dart/flutter in a more robust way.
+* Remove qualifiedNames from the pub dev api search.
+* Flutter/Dart create tool.
+* Limit the tokens returned by the runtime errors tool/resource.
+* Add RootsFallbackSupport mixin.
+* Fix error handling around stream listeners.
+* Add a 'pub-dev-search' mcp tool.
+* Drop pubspec-parse, use yaml instead.
+* Handle failing to listen to vm service streams during startup.
+* Add tool for enabling/disabling the widget selector.
+* Add a tool to get the active cursor location.
+* Add hover tool support.
+* Add a test command and project detection.
+* Add signature_help tool.
+* Add runtime errors resource and tool to clear errors.
+* Require roots for all CLI tools.
+* Require roots to be set for analyzer tools.
+* Add debug logs for when DTD sees Editor.getDebugSessions get registered.
+* Add tool annotations to tools.
+* Implement a tool to resolve workspace symbols based on a query.
+* Add a dart pub tool.
+* Update analyze tool to use LSP, simplify tool.
+* Add tool for getting the selected widget.
+* Handle missing roots capability better.
+* Add `get_widget_tree` tool.
+* Add a tool for getting runtime errors.
+* Add Dart CLI tool support.
+* Add a hot reload tool.
+* Add basic analysis support.
+* Add the beginnings of a Dart tooling MCP server.
+* Instruct clients to prefer MCP tools over running tools in the shell.
+* Reduce output size of `run_tests` tool to save on input tokens.
+* Add `--log-file` argument to log all protocol traffic to a file.
+* Improve error text for failed DTD connections as well as the tool description.
+* Add support for injecting an `Analytics` instance to track usage.
+* Listen to the new DTD `ConnectedApp` service instead of the `Editor.DebugSessions`
   service, when available.
-- Screenshot tool disabled until
+* Screenshot tool disabled until
   https://github.com/flutter/flutter/issues/170357 is resolved.
-- Add `arg_parser.dart` public library with minimal deps to be used by the dart tool.
+* Add `arg_parser.dart` public library with minimal deps to be used by the dart tool.
+

--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -1,56 +1,57 @@
 # 0.1.1 (Dart SDK 3.10.0) - WIP
 
-* Change tools that accept multiple roots to not return immediately on the first
+- Change tools that accept multiple roots to not return immediately on the first
   failure.
-* Add failure reason field to analytics events so we can know why tool calls are
+- Add failure reason field to analytics events so we can know why tool calls are
   failing.
+- Modified argument to `pub` tool to allow for multiple package arguments to `pub add` and `pub remove`.
 
 # 0.1.0 (Dart SDK 3.9.0)
 
-* Add documentation/homepage/repository links to pub results.
-* Handle relative paths under roots without trailing slashes.
-* Fix executable paths for dart/flutter on windows.
-* Pass the provided root instead of the resolved root for project type detection.
-* Be more flexible about roots by comparing canonicalized paths.
-* Create the working dir if it doesn't exist.
-* Add the --platform and --empty arguments to the flutter create tool.
-* Invoke dart/flutter in a more robust way.
-* Remove qualifiedNames from the pub dev api search.
-* Flutter/Dart create tool.
-* Limit the tokens returned by the runtime errors tool/resource.
-* Add RootsFallbackSupport mixin.
-* Fix error handling around stream listeners.
-* Add a 'pub-dev-search' mcp tool.
-* Drop pubspec-parse, use yaml instead.
-* Handle failing to listen to vm service streams during startup.
-* Add tool for enabling/disabling the widget selector.
-* Add a tool to get the active cursor location.
-* Add hover tool support.
-* Add a test command and project detection.
-* Add signature_help tool.
-* Add runtime errors resource and tool to clear errors.
-* Require roots for all CLI tools.
-* Require roots to be set for analyzer tools.
-* Add debug logs for when DTD sees Editor.getDebugSessions get registered.
-* Add tool annotations to tools.
-* Implement a tool to resolve workspace symbols based on a query.
-* Add a dart pub tool.
-* Update analyze tool to use LSP, simplify tool.
-* Add tool for getting the selected widget.
-* Handle missing roots capability better.
-* Add `get_widget_tree` tool.
-* Add a tool for getting runtime errors.
-* Add Dart CLI tool support.
-* Add a hot reload tool.
-* Add basic analysis support.
-* Add the beginnings of a Dart tooling MCP server.
-* Instruct clients to prefer MCP tools over running tools in the shell.
-* Reduce output size of `run_tests` tool to save on input tokens.
-* Add `--log-file` argument to log all protocol traffic to a file.
-* Improve error text for failed DTD connections as well as the tool description.
-* Add support for injecting an `Analytics` instance to track usage.
-* Listen to the new DTD `ConnectedApp` service instead of the `Editor.DebugSessions`
+- Add documentation/homepage/repository links to pub results.
+- Handle relative paths under roots without trailing slashes.
+- Fix executable paths for dart/flutter on windows.
+- Pass the provided root instead of the resolved root for project type detection.
+- Be more flexible about roots by comparing canonicalized paths.
+- Create the working dir if it doesn't exist.
+- Add the --platform and --empty arguments to the flutter create tool.
+- Invoke dart/flutter in a more robust way.
+- Remove qualifiedNames from the pub dev api search.
+- Flutter/Dart create tool.
+- Limit the tokens returned by the runtime errors tool/resource.
+- Add RootsFallbackSupport mixin.
+- Fix error handling around stream listeners.
+- Add a 'pub-dev-search' mcp tool.
+- Drop pubspec-parse, use yaml instead.
+- Handle failing to listen to vm service streams during startup.
+- Add tool for enabling/disabling the widget selector.
+- Add a tool to get the active cursor location.
+- Add hover tool support.
+- Add a test command and project detection.
+- Add signature_help tool.
+- Add runtime errors resource and tool to clear errors.
+- Require roots for all CLI tools.
+- Require roots to be set for analyzer tools.
+- Add debug logs for when DTD sees Editor.getDebugSessions get registered.
+- Add tool annotations to tools.
+- Implement a tool to resolve workspace symbols based on a query.
+- Add a dart pub tool.
+- Update analyze tool to use LSP, simplify tool.
+- Add tool for getting the selected widget.
+- Handle missing roots capability better.
+- Add `get_widget_tree` tool.
+- Add a tool for getting runtime errors.
+- Add Dart CLI tool support.
+- Add a hot reload tool.
+- Add basic analysis support.
+- Add the beginnings of a Dart tooling MCP server.
+- Instruct clients to prefer MCP tools over running tools in the shell.
+- Reduce output size of `run_tests` tool to save on input tokens.
+- Add `--log-file` argument to log all protocol traffic to a file.
+- Improve error text for failed DTD connections as well as the tool description.
+- Add support for injecting an `Analytics` instance to track usage.
+- Listen to the new DTD `ConnectedApp` service instead of the `Editor.DebugSessions`
   service, when available.
-* Screenshot tool disabled until
+- Screenshot tool disabled until
   https://github.com/flutter/flutter/issues/170357 is resolved.
-* Add `arg_parser.dart` public library with minimal deps to be used by the dart tool.
+- Add `arg_parser.dart` public library with minimal deps to be used by the dart tool.

--- a/pkgs/dart_mcp_server/lib/src/mixins/pub.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/pub.dart
@@ -51,14 +51,15 @@ base mixin PubSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
       )..failureReason ??= CallToolFailureReason.noSuchCommand;
     }
 
-    final packageName =
-        request.arguments?[ParameterNames.packageName] as String?;
-    if (matchingCommand.requiresPackageName && packageName == null) {
+    final packageNames =
+        (request.arguments?[ParameterNames.packageNames] as List?)
+            ?.cast<String>();
+    if (matchingCommand.requiresPackageNames && packageNames == null) {
       return CallToolResult(
         content: [
           TextContent(
             text:
-                'Missing required argument `packageName` for the `$command` '
+                'Missing required argument `packageNames` for the `$command` '
                 'command.',
           ),
         ],
@@ -68,9 +69,7 @@ base mixin PubSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
 
     return runCommandInRoots(
       request,
-      // TODO(https://github.com/dart-lang/ai/issues/81): conditionally use
-      //  flutter when appropriate.
-      arguments: ['pub', command, if (packageName != null) packageName],
+      arguments: ['pub', command, if (packageNames != null) ...packageNames],
       commandDescription: 'dart|flutter pub $command',
       processManager: processManager,
       knownRoots: await roots,
@@ -92,11 +91,16 @@ base mixin PubSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
           description:
               'Currently only ${SupportedPubCommand.listAll} are supported.',
         ),
-        ParameterNames.packageName: Schema.string(
-          title: 'The package name to run the command for.',
+        ParameterNames.packageNames: Schema.list(
+          title: 'The package names to run the command for.',
           description:
               'This is required for the '
-              '${SupportedPubCommand.listAllThatRequirePackageName} commands.',
+              '${SupportedPubCommand.listAllThatRequirePackageName} commands. ',
+          items: Schema.string(
+            title: 'A package to run the command for.',
+            description:
+                'Prefix with "dev:" to add the package as a dev dependency.',
+          ),
         ),
         ParameterNames.roots: rootsSchema(),
       },
@@ -110,18 +114,18 @@ enum SupportedPubCommand {
   // This is supported in a simplified form: `dart pub add <package-name>`.
   // TODO(https://github.com/dart-lang/ai/issues/77): add support for adding
   //  dev dependencies.
-  add(requiresPackageName: true),
+  add(requiresPackageNames: true),
 
   get,
 
   // This is supported in a simplified form: `dart pub remove <package-name>`.
-  remove(requiresPackageName: true),
+  remove(requiresPackageNames: true),
 
   upgrade;
 
-  const SupportedPubCommand({this.requiresPackageName = false});
+  const SupportedPubCommand({this.requiresPackageNames = false});
 
-  final bool requiresPackageName;
+  final bool requiresPackageNames;
 
   static SupportedPubCommand? fromName(String name) {
     for (final command in SupportedPubCommand.values) {
@@ -138,7 +142,7 @@ enum SupportedPubCommand {
 
   static String get listAllThatRequirePackageName {
     return _writeCommandsAsList(
-      SupportedPubCommand.values.where((c) => c.requiresPackageName).toList(),
+      SupportedPubCommand.values.where((c) => c.requiresPackageNames).toList(),
     );
   }
 

--- a/pkgs/dart_mcp_server/lib/src/mixins/pub.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/pub.dart
@@ -99,7 +99,8 @@ base mixin PubSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
           items: Schema.string(
             title: 'A package to run the command for.',
             description:
-                'Prefix with "dev:" to add the package as a dev dependency.',
+                'When used with "add", prefix with "dev:" to add the package '
+                'as a dev dependency.',
           ),
         ),
         ParameterNames.roots: rootsSchema(),

--- a/pkgs/dart_mcp_server/lib/src/utils/cli_utils.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/cli_utils.dart
@@ -291,7 +291,7 @@ bool _isUnderRoot(Root root, String uri, FileSystem fileSystem) {
 
 /// The schema for the `roots` parameter for any tool that accepts it.
 ListSchema rootsSchema({bool supportsPaths = false}) => Schema.list(
-  title: 'All projects roots to run this tool in.',
+  title: 'The project roots to run this tool in.',
   items: Schema.object(
     properties: {
       ParameterNames.root: rootSchema,

--- a/pkgs/dart_mcp_server/lib/src/utils/constants.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/constants.dart
@@ -12,7 +12,7 @@ extension ParameterNames on Never {
   static const empty = 'empty';
   static const line = 'line';
   static const name = 'name';
-  static const packageName = 'packageName';
+  static const packageNames = 'packageNames';
   static const paths = 'paths';
   static const platform = 'platform';
   static const position = 'position';

--- a/pkgs/dart_mcp_server/test/tools/pub_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/pub_test.dart
@@ -69,7 +69,7 @@ void main() {
             name: dartPubTool.name,
             arguments: {
               ParameterNames.command: 'add',
-              ParameterNames.packageName: 'foo',
+              ParameterNames.packageNames: ['foo', 'bar'],
               ParameterNames.roots: [
                 {ParameterNames.root: testRoot.uri},
               ],
@@ -81,7 +81,7 @@ void main() {
           expect(result.isError, isNot(true));
           expect(testProcessManager.commandsRan, [
             equalsCommand((
-              command: [endsWith(executableName), 'pub', 'add', 'foo'],
+              command: [endsWith(executableName), 'pub', 'add', 'foo', 'bar'],
               workingDirectory: testRoot.path,
             )),
           ]);
@@ -92,7 +92,7 @@ void main() {
             name: dartPubTool.name,
             arguments: {
               ParameterNames.command: 'remove',
-              ParameterNames.packageName: 'foo',
+              ParameterNames.packageNames: ['foo', 'bar'],
               ParameterNames.roots: [
                 {ParameterNames.root: testRoot.uri},
               ],
@@ -104,7 +104,13 @@ void main() {
           expect(result.isError, isNot(true));
           expect(testProcessManager.commandsRan, [
             equalsCommand((
-              command: [endsWith(executableName), 'pub', 'remove', 'foo'],
+              command: [
+                endsWith(executableName),
+                'pub',
+                'remove',
+                'foo',
+                'bar',
+              ],
               workingDirectory: testRoot.path,
             )),
           ]);
@@ -214,7 +220,7 @@ void main() {
           });
 
           for (final command in SupportedPubCommand.values.where(
-            (c) => c.requiresPackageName,
+            (c) => c.requiresPackageNames,
           )) {
             test('for missing package name: $command', () async {
               final request = CallToolRequest(
@@ -228,7 +234,7 @@ void main() {
 
               expect(
                 (result.content.single as TextContent).text,
-                'Missing required argument `packageName` for the '
+                'Missing required argument `packageNames` for the '
                 '`${command.name}` command.',
               );
               expect(testProcessManager.commandsRan, isEmpty);


### PR DESCRIPTION
## Description

This allows `pub add` and `pub remove` to take multiple packages at once, and provides guidance for dev dependencies.

## Related Issues
 - Fixes https://github.com/dart-lang/ai/issues/225
 - Fixes https://github.com/dart-lang/ai/issues/77

## Tests
 - Modified tests for multiple package names.