### PR TITLE
Deprecate the WithElicitationhandler interface

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Add new `package:dart_mcp/stdio.dart` library with a `stdioChannel` utility
   for creating a stream channel that separates messages by newlines.
 - Added more examples.
+- Deprecated the `WithElicitationHandler` interface - the method this required
+  is now defined directly on the `ElicitationSupport` mixin which matches the
+  pattern used by other mixins in this package.
 
 ## 0.3.0
 

--- a/pkgs/dart_mcp/lib/src/client/elicitation_support.dart
+++ b/pkgs/dart_mcp/lib/src/client/elicitation_support.dart
@@ -4,19 +4,27 @@
 
 part of 'client.dart';
 
-/// The interface for handling elicitation requests.
-///
-/// Any client using [ElicitationSupport] must implement this interface.
+@Deprecated(
+  'This interface is going away, the method will exist directly on the '
+  'ElicitationSupport mixin instead',
+)
 abstract interface class WithElicitationHandler {
   FutureOr<ElicitResult> handleElicitation(ElicitRequest request);
 }
 
 /// A mixin that adds support for the `elicitation` capability to an
 /// [MCPClient].
+// ignore: deprecated_member_use_from_same_package
 base mixin ElicitationSupport on MCPClient implements WithElicitationHandler {
   @override
   void initialize() {
     capabilities.elicitation ??= ElicitationCapability();
     super.initialize();
   }
+
+  /// The method for handling elicitation requests.
+  ///
+  /// Any client using [ElicitationSupport] must implement this interface.
+  @override
+  FutureOr<ElicitResult> handleElicitation(ElicitRequest request);
 }


### PR DESCRIPTION
This extra type wasn't necessary - now this follows the pattern of the other support mixins, just defining the abstract method on the mixin itself.