### PR TITLE
Require dart_mcp version 0.3.1

### DIFF
--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add failure reason field to analytics events so we can know why tool calls are
   failing.
 * Allow for multiple package arguments to `pub add` and `pub remove`.
+* Require dart_mcp version 0.3.1.
 
 # 0.1.0 (Dart SDK 3.9.0)
 
@@ -55,4 +56,3 @@
 * Screenshot tool disabled until
   https://github.com/flutter/flutter/issues/170357 is resolved.
 * Add `arg_parser.dart` public library with minimal deps to be used by the dart tool.
-

--- a/pkgs/dart_mcp_server/pubspec.yaml
+++ b/pkgs/dart_mcp_server/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   args: ^2.7.0
   async: ^2.13.0
   collection: ^1.19.1
-  dart_mcp: ^0.3.0
+  dart_mcp: ^0.3.1
   dds_service_extensions: ^2.0.1
   devtools_shared: ^12.0.0
   dtd: ^4.0.0


### PR DESCRIPTION
We are relying on the new `stdioChannel` utility.