### PR TITLE
release dart_mcp 0.3.1

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.1-wip
+## 0.3.1
 
 - Fixes communication problem when a `MCPServer` is instantiated without
   instructions.

--- a/pkgs/dart_mcp/README.md
+++ b/pkgs/dart_mcp/README.md
@@ -74,6 +74,8 @@ from `ServerConnection.initialize`.
 ## Supported Protocol Versions
 
 [2024-11-05](https://spec.modelcontextprotocol.io/specification/2024-11-05/)
+[2025-03-26](https://spec.modelcontextprotocol.io/specification/2025-03-26/)
+[2025-06-18](https://spec.modelcontextprotocol.io/specification/2025-06-18/)
 
 If support for a given protocol version is dropped, that will be released as a
 breaking change in this package.

--- a/pkgs/dart_mcp/pubspec.yaml
+++ b/pkgs/dart_mcp/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_mcp
-version: 0.3.1-wip
+version: 0.3.1
 description: A package for making MCP servers and clients.
 repository: https://github.com/dart-lang/ai/tree/main/pkgs/dart_mcp
 issue_tracker: https://github.com/dart-lang/ai/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Adart_mcp


### PR DESCRIPTION
Bug fixes, improved examples, and some deprecated APIs and minor cleanup.