### PR TITLE
release dart_mcp version 0.3.2

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.2-wip
+## 0.3.2
 
 - Deprecate the `EnumSchema` type in favor of the `StringSchema` with an
   `enumValues` parameter. The `EnumSchema` type was not MCP spec compatible.

--- a/pkgs/dart_mcp/pubspec.yaml
+++ b/pkgs/dart_mcp/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_mcp
-version: 0.3.2-wip
+version: 0.3.2
 description: A package for making MCP servers and clients.
 repository: https://github.com/dart-lang/ai/tree/main/pkgs/dart_mcp
 issue_tracker: https://github.com/dart-lang/ai/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Adart_mcp


### PR DESCRIPTION
This pushes out the enum changes which the Dart MCP server relies on to work with Gemini CLI (and probably other agents).