### PR TITLE
Fix ping request handling from non-dart clients.

### DIFF
--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -225,9 +225,11 @@ extension type RequestId( /*String|int*/ Parameter _) {}
 ///
 /// The receiver must promptly respond, or else may be disconnected.
 ///
-/// The request itself has no parameters and should always be just `null`.
-extension type PingRequest._(Null _) {
+/// The request itself has no parameters.
+extension type PingRequest._(Map<String, Object?> _) implements Request {
   static const methodName = 'ping';
+
+  factory PingRequest() => PingRequest._(const {});
 }
 
 /// An out-of-band notification used to inform the receiver of a progress

--- a/pkgs/dart_mcp/lib/src/shared.dart
+++ b/pkgs/dart_mcp/lib/src/shared.dart
@@ -131,8 +131,6 @@ base class MCPBase {
 
   /// The peer may ping us at any time, and we should respond with an empty
   /// response.
-  ///
-  /// Note that [PingRequest] is always actually just `null`.
   EmptyResult _handlePing([PingRequest? _]) => EmptyResult();
 
   /// Handles [ProgressNotification]s and forwards them to the streams returned

--- a/pkgs/dart_mcp/test/client_and_server_test.dart
+++ b/pkgs/dart_mcp/test/client_and_server_test.dart
@@ -127,6 +127,39 @@ void main() {
     );
   });
 
+  // Regression test for https://github.com/dart-lang/ai/issues/238.
+  test('client and server can handle ping with null parameters', () async {
+    final environment = TestEnvironment(TestMCPClient(), TestMCPServer.new);
+    await environment.initializeServer();
+
+    await expectLater(
+      environment.serverConnection.sendRequest(PingRequest.methodName, null),
+      completes,
+    );
+    await expectLater(
+      environment.server.sendRequest(PingRequest.methodName, null),
+      completes,
+    );
+  });
+
+  // Regression test for https://github.com/dart-lang/ai/issues/238.
+  test('client and server can handle ping with no parameters', () async {
+    final environment = TestEnvironment(TestMCPClient(), TestMCPServer.new);
+    await environment.initializeServer();
+
+    await expectLater(
+      environment.serverConnection.sendRequest(
+        PingRequest.methodName,
+        _EmptyRequest(),
+      ),
+      completes,
+    );
+    await expectLater(
+      environment.server.sendRequest(PingRequest.methodName, _EmptyRequest()),
+      completes,
+    );
+  });
+
   test(
     'server can handle initialized notification with null parameters',
     () async {
@@ -437,4 +470,8 @@ final class TestUnrecognizedVersionMcpServer extends TestMCPServer {
     (response as Map<String, Object?>)['protocolVersion'] = 'fooBar';
     return response;
   }
+}
+
+extension type _EmptyRequest._(Map<String, Object?> _) implements Request {
+  factory _EmptyRequest() => _EmptyRequest._(const {});
 }


### PR DESCRIPTION
Fixes https://github.com/dart-lang/ai/issues/238

- Updates `PingRequest` to wrap `Map<String, Object?>` instead of `Null` to allow empty parameters handling from non-Dart clients.

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
