### PR TITLE
rename ElicitationHandler.reject to ElicitationHandler.decline

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -1,6 +1,13 @@
 ## 0.3.3-wip
 
 - Fix `PingRequest` handling when it is sent from a non-Dart client.
+- Deprecate `ElicitationAction.reject` and replace it with
+  `ElicitationAction.decline`.
+  - In the initial elicitations schema this was incorrectly listed as `reject`.
+  - This package still allows `reject` and treats it as an alias for`decline`.
+  - The old `reject` enum value was replaced with a static constant equal
+    exactly to `decline`, so switches are not affected.
+
 
 ## 0.3.2
 

--- a/pkgs/dart_mcp/example/elicitations_client.dart
+++ b/pkgs/dart_mcp/example/elicitations_client.dart
@@ -67,12 +67,12 @@ final class TestMCPClientWithElicitationSupport extends MCPClient
     print('''
 Elicitation received from server: ${request.message}
 
-Do you want to accept (a), reject (r), or cancel (c) the elicitation?
+Do you want to accept (a), decline (d), or cancel (c) the elicitation?
 ''');
     final answer = stdin.readLineSync();
     final action = switch (answer) {
       'a' => ElicitationAction.accept,
-      'r' => ElicitationAction.reject,
+      'd' => ElicitationAction.decline,
       'c' => ElicitationAction.cancel,
       _ => throw ArgumentError('Invalid answer: $answer'),
     };

--- a/pkgs/dart_mcp/example/elicitations_server.dart
+++ b/pkgs/dart_mcp/example/elicitations_server.dart
@@ -56,8 +56,8 @@ base class MCPServerWithElicitation extends MCPServer
           'Hello $name! I see that you are $age years '
           'old and identify as $gender',
         );
-      case ElicitationAction.reject:
-        log(LoggingLevel.warning, 'Request for name was rejected');
+      case ElicitationAction.decline:
+        log(LoggingLevel.warning, 'Request for name was declined');
       case ElicitationAction.cancel:
         log(LoggingLevel.warning, 'Request for name was cancelled');
     }

--- a/pkgs/dart_mcp/lib/src/api/elicitation.dart
+++ b/pkgs/dart_mcp/lib/src/api/elicitation.dart
@@ -105,14 +105,19 @@ extension type ElicitResult.fromMap(Map<String, Object?> _value)
   ///
   /// - [ElicitationAction.accept]: The user accepted the request and provided
   ///   the requested information.
-  /// - [ElicitationAction.reject]: The user explicitly declined the action.
+  /// - [ElicitationAction.decline]: The user explicitly declined the action.
   /// - [ElicitationAction.cancel]: The user dismissed without making an
   ///   explicit choice.
   ElicitationAction get action {
-    final action = _value['action'] as String?;
+    var action = _value['action'] as String?;
     if (action == null) {
       throw ArgumentError('Missing required action field in $ElicitResult');
     }
+    // There was a bug in the initial schema, where the `decline` action was
+    // named `reject` instead. Handle using that as an alias for `decline` in
+    // case some clients use the old name.
+    if (action == 'reject') action = 'decline';
+
     return ElicitationAction.values.byName(action);
   }
 
@@ -131,8 +136,11 @@ enum ElicitationAction {
   accept,
 
   /// The user explicitly declined the action.
-  reject,
+  decline,
 
   /// The user dismissed without making an explicit choice.
-  cancel,
+  cancel;
+
+  @Deprecated('Use `ElicitationAction.decline` instead.')
+  static const reject = decline;
 }


### PR DESCRIPTION
There was initially a discrepancy between the Typescript and JSON schemas - looks like they reconciled that by going with the typescript version, so this aligns to that.