### PR TITLE
add analytics tracking for prompts

### DIFF
--- a/pkgs/dart_mcp_server/lib/src/utils/analytics.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/analytics.dart
@@ -14,7 +14,7 @@ abstract interface class AnalyticsSupport {
   Analytics? get analytics;
 }
 
-enum AnalyticsEvent { callTool, readResource }
+enum AnalyticsEvent { callTool, readResource, getPrompt }
 
 /// The metrics for a resources/read MCP handler.
 final class ReadResourceMetrics extends CustomMetrics {
@@ -40,6 +40,36 @@ final class ReadResourceMetrics extends CustomMetrics {
     _kind: kind.name,
     _length: length,
     _elapsedMilliseconds: elapsedMilliseconds,
+  };
+}
+
+/// The metrics for a prompts/get MCP handler.
+final class GetPromptMetrics extends CustomMetrics {
+  /// The name of the prompt that was retrieved.
+  final String name;
+
+  /// Whether or not the prompt was given with arguments.
+  final bool withArguments;
+
+  /// The time it took to generate the prompt.
+  final int elapsedMilliseconds;
+
+  /// Whether or not the prompt call succeeded.
+  final bool success;
+
+  GetPromptMetrics({
+    required this.name,
+    required this.withArguments,
+    required this.elapsedMilliseconds,
+    required this.success,
+  });
+
+  @override
+  Map<String, Object> toMap() => {
+    _name: name,
+    _withArguments: withArguments,
+    _elapsedMilliseconds: elapsedMilliseconds,
+    _success: success,
   };
 }
 
@@ -108,5 +138,7 @@ const _elapsedMilliseconds = 'elapsedMilliseconds';
 const _failureReason = 'failureReason';
 const _kind = 'kind';
 const _length = 'length';
+const _name = 'name';
 const _success = 'success';
 const _tool = 'tool';
+const _withArguments = 'withArguments';

--- a/pkgs/dart_mcp_server/test/dart_tooling_mcp_server_test.dart
+++ b/pkgs/dart_mcp_server/test/dart_tooling_mcp_server_test.dart
@@ -47,7 +47,7 @@ void main() {
                 'client': server.clientInfo.name,
                 'clientVersion': server.clientInfo.version,
                 'serverVersion': server.implementation.version,
-                'type': 'callTool',
+                'type': AnalyticsEvent.callTool.name,
                 'tool': 'hello',
                 'success': true,
                 'elapsedMilliseconds': isA<int>(),
@@ -85,7 +85,7 @@ void main() {
                   'client': server.clientInfo.name,
                   'clientVersion': server.clientInfo.version,
                   'serverVersion': server.implementation.version,
-                  'type': 'callTool',
+                  'type': AnalyticsEvent.callTool.name,
                   'tool': tool.name,
                   'success': false,
                   'elapsedMilliseconds': isA<int>(),
@@ -94,6 +94,125 @@ void main() {
               ),
         );
       }
+    });
+
+    group('are sent for prompts', () {
+      final helloPrompt = Prompt(
+        name: 'hello',
+        arguments: [PromptArgument(name: 'name', required: false)],
+      );
+      GetPromptResult getHelloPrompt(GetPromptRequest request) {
+        assert(request.name == helloPrompt.name);
+        if (request.arguments?['throw'] == true) {
+          throw StateError('Oh no!');
+        }
+        return GetPromptResult(
+          messages: [
+            PromptMessage(
+              role: Role.user,
+              content: Content.text(text: 'hello'),
+            ),
+            if (request.arguments?['name'] case final name?)
+              PromptMessage(
+                role: Role.user,
+                content: Content.text(text: ', my name is $name'),
+              ),
+          ],
+        );
+      }
+
+      setUp(() {
+        server.addPrompt(Prompt(name: 'hello'), getHelloPrompt);
+      });
+
+      test('with no arguments', () async {
+        final result = await testHarness.getPrompt(
+          GetPromptRequest(name: helloPrompt.name),
+        );
+        expect((result.messages.single.content as TextContent).text, 'hello');
+        expect(result.messages.single.role, Role.user);
+        expect(
+          analytics.sentEvents.single,
+          isA<Event>()
+              .having((e) => e.eventName, 'eventName', DashEvent.dartMCPEvent)
+              .having(
+                (e) => e.eventData,
+                'eventData',
+                equals({
+                  'client': server.clientInfo.name,
+                  'clientVersion': server.clientInfo.version,
+                  'serverVersion': server.implementation.version,
+                  'type': AnalyticsEvent.getPrompt.name,
+                  'name': helloPrompt.name,
+                  'success': true,
+                  'elapsedMilliseconds': isA<int>(),
+                  'withArguments': false,
+                }),
+              ),
+        );
+      });
+
+      test('with arguments', () async {
+        final result = await testHarness.getPrompt(
+          GetPromptRequest(name: helloPrompt.name, arguments: {'name': 'Bob'}),
+        );
+        expect((result.messages[0].content as TextContent).text, 'hello');
+        expect(result.messages[0].role, Role.user);
+        expect(
+          (result.messages[1].content as TextContent).text,
+          ', my name is Bob',
+        );
+        expect(result.messages[1].role, Role.user);
+        expect(
+          analytics.sentEvents.single,
+          isA<Event>()
+              .having((e) => e.eventName, 'eventName', DashEvent.dartMCPEvent)
+              .having(
+                (e) => e.eventData,
+                'eventData',
+                equals({
+                  'client': server.clientInfo.name,
+                  'clientVersion': server.clientInfo.version,
+                  'serverVersion': server.implementation.version,
+                  'type': AnalyticsEvent.getPrompt.name,
+                  'name': helloPrompt.name,
+                  'success': true,
+                  'elapsedMilliseconds': isA<int>(),
+                  'withArguments': true,
+                }),
+              ),
+        );
+      });
+
+      test('even if they throw', () async {
+        try {
+          await testHarness.getPrompt(
+            GetPromptRequest(
+              name: helloPrompt.name,
+              arguments: {'throw': true},
+            ),
+          );
+        } catch (_) {}
+        expect(
+          analytics.sentEvents.single,
+          isA<Event>()
+              .having((e) => e.eventName, 'eventName', DashEvent.dartMCPEvent)
+              .having(
+                (e) => e.eventData,
+                'eventData',
+                equals({
+                  'client': server.clientInfo.name,
+                  'clientVersion': server.clientInfo.version,
+                  'serverVersion': server.implementation.version,
+                  'type': AnalyticsEvent.getPrompt.name,
+                  'name': helloPrompt.name,
+                  'success': false,
+                  'elapsedMilliseconds': isA<int>(),
+                  'withArguments': true,
+                }),
+              ),
+        );
+      });
     });
 
     test('Changelog version matches dart server version', () {

--- a/pkgs/dart_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_mcp_server/test/test_harness.dart
@@ -196,6 +196,10 @@ class TestHarness {
       await Future<void>.delayed(Duration(milliseconds: 100 * tryCount));
     }
   }
+
+  /// Calls [getPrompt] on the [mcpServerConnection].
+  Future<GetPromptResult> getPrompt(GetPromptRequest request) =>
+      mcpServerConnection.getPrompt(request);
 }
 
 /// The debug session for a single app.


### PR DESCRIPTION
Intercepts all prompts added with `addPrompt` and adds analytics tracking if an analytics instance is configured.