### PR TITLE
Stop reporting errors for non-zero exits

### DIFF
--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -13,6 +13,7 @@
   based on their text values.
 * Add an `--exclude-tool` command line flag to exclude tools by name.
 * Add the abillity to limit the output of `analyze_files` to a set of paths.
+* Stop reporting non-zero exit codes from command line tools as tool errors.
 
 # 0.1.0 (Dart SDK 3.9.0)
 

--- a/pkgs/dart_mcp_server/lib/src/utils/analytics.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/analytics.dart
@@ -130,7 +130,6 @@ enum CallToolFailureReason {
   noRootGiven,
   noRootsSet,
   noSuchCommand,
-  nonZeroExitCode,
   webSocketException,
 }
 

--- a/pkgs/dart_mcp_server/lib/src/utils/cli_utils.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/cli_utils.dart
@@ -238,12 +238,14 @@ Future<CallToolResult> runCommandInRoot(
       content: [
         TextContent(
           text:
-              '$commandDescription failed in ${projectRoot.path}:\n'
+              '$commandDescription returned a non-zero exit code in '
+              '${projectRoot.path}:\n'
               '$output${errors.isEmpty ? '' : '\nErrors:\n$errors'}',
         ),
+        // Returning a non-zero exit code is not considered an "error" in the
+        // "isError" sense.
       ],
-      isError: true,
-    )..failureReason ??= CallToolFailureReason.nonZeroExitCode;
+    );
   }
   return CallToolResult(
     content: [

--- a/pkgs/dart_mcp_server/test/dart_tooling_mcp_server_test.dart
+++ b/pkgs/dart_mcp_server/test/dart_tooling_mcp_server_test.dart
@@ -60,43 +60,35 @@ void main() {
     });
 
     test('sends analytics for failed tool calls', () async {
-      for (var reason in [null, CallToolFailureReason.nonZeroExitCode]) {
-        analytics.sentEvents.clear();
+      analytics.sentEvents.clear();
 
-        final tool = Tool(
-          name: 'hello${reason?.name ?? ''}',
-          inputSchema: Schema.object(),
-        );
-        server.registerTool(
-          tool,
-          (_) =>
-              CallToolResult(isError: true, content: [])
-                ..failureReason = reason,
-        );
-        final result = await testHarness.mcpServerConnection.callTool(
-          CallToolRequest(name: tool.name),
-        );
-        expect(result.isError, true);
-        expect(
-          analytics.sentEvents.single,
-          isA<Event>()
-              .having((e) => e.eventName, 'eventName', DashEvent.dartMCPEvent)
-              .having(
-                (e) => e.eventData,
-                'eventData',
-                equals({
-                  'client': server.clientInfo.name,
-                  'clientVersion': server.clientInfo.version,
-                  'serverVersion': server.implementation.version,
-                  'type': AnalyticsEvent.callTool.name,
-                  'tool': tool.name,
-                  'success': false,
-                  'elapsedMilliseconds': isA<int>(),
-                  'failureReason': ?reason?.name,
-                }),
-              ),
-        );
-      }
+      final tool = Tool(name: 'hello', inputSchema: Schema.object());
+      server.registerTool(
+        tool,
+        (_) => CallToolResult(isError: true, content: [])..failureReason = null,
+      );
+      final result = await testHarness.mcpServerConnection.callTool(
+        CallToolRequest(name: tool.name),
+      );
+      expect(result.isError, true);
+      expect(
+        analytics.sentEvents.single,
+        isA<Event>()
+            .having((e) => e.eventName, 'eventName', DashEvent.dartMCPEvent)
+            .having(
+              (e) => e.eventData,
+              'eventData',
+              equals({
+                'client': server.clientInfo.name,
+                'clientVersion': server.clientInfo.version,
+                'serverVersion': server.implementation.version,
+                'type': AnalyticsEvent.callTool.name,
+                'tool': tool.name,
+                'success': false,
+                'elapsedMilliseconds': isA<int>(),
+              }),
+            ),
+      );
     });
 
     group('are sent for prompts', () {


### PR DESCRIPTION
## Description

This stops reporting command line tools that return non-zero exit codes as "isError" failures of the tool, so that the LLM won't interpret failed tests or formatting of files as a failure to run the tool.

## Related Issues
 -  Fixes #261

## Tests
 - Updated tests.