### PR TITLE
Add build_runner build tool.

### DIFF
--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -1,66 +1,67 @@
 # 0.1.1 (Dart SDK 3.10.0) - WIP
 
-* Change tools that accept multiple roots to not return immediately on the first
+- Change tools that accept multiple roots to not return immediately on the first
   failure.
-* Add failure reason field to analytics events so we can know why tool calls are
+- Add failure reason field to analytics events so we can know why tool calls are
   failing.
-* Add a flutter_driver command for executing flutter driver commands on a device.
-* Allow for multiple package arguments to `pub add` and `pub remove`.
-* Require dart_mcp version 0.3.1.
-* Add support for the flutter_driver screenshot command.
-* Change the widget tree to the full version instead of the summary. The summary
+- Add a flutter_driver command for executing flutter driver commands on a device.
+- Allow for multiple package arguments to `pub add` and `pub remove`.
+- Require dart_mcp version 0.3.1.
+- Add support for the flutter_driver screenshot command.
+- Change the widget tree to the full version instead of the summary. The summary
   tends to hide nested text widgets which makes it difficult to find widgets
   based on their text values.
-* Add an `--exclude-tool` command line flag to exclude tools by name.
-* Add the abillity to limit the output of `analyze_files` to a set of paths.
-* Stop reporting non-zero exit codes from command line tools as tool errors.
+- Add an `--exclude-tool` command line flag to exclude tools by name.
+- Add the abillity to limit the output of `analyze_files` to a set of paths.
+- Stop reporting non-zero exit codes from command line tools as tool errors.
+- Add support for a tool that runs `dart run build_runner build`.
 
 # 0.1.0 (Dart SDK 3.9.0)
 
-* Add documentation/homepage/repository links to pub results.
-* Handle relative paths under roots without trailing slashes.
-* Fix executable paths for dart/flutter on windows.
-* Pass the provided root instead of the resolved root for project type detection.
-* Be more flexible about roots by comparing canonicalized paths.
-* Create the working dir if it doesn't exist.
-* Add the --platform and --empty arguments to the flutter create tool.
-* Invoke dart/flutter in a more robust way.
-* Remove qualifiedNames from the pub dev api search.
-* Flutter/Dart create tool.
-* Limit the tokens returned by the runtime errors tool/resource.
-* Add RootsFallbackSupport mixin.
-* Fix error handling around stream listeners.
-* Add a 'pub-dev-search' mcp tool.
-* Drop pubspec-parse, use yaml instead.
-* Handle failing to listen to vm service streams during startup.
-* Add tool for enabling/disabling the widget selector.
-* Add a tool to get the active cursor location.
-* Add hover tool support.
-* Add a test command and project detection.
-* Add signature_help tool.
-* Add runtime errors resource and tool to clear errors.
-* Require roots for all CLI tools.
-* Require roots to be set for analyzer tools.
-* Add debug logs for when DTD sees Editor.getDebugSessions get registered.
-* Add tool annotations to tools.
-* Implement a tool to resolve workspace symbols based on a query.
-* Add a dart pub tool.
-* Update analyze tool to use LSP, simplify tool.
-* Add tool for getting the selected widget.
-* Handle missing roots capability better.
-* Add `get_widget_tree` tool.
-* Add a tool for getting runtime errors.
-* Add Dart CLI tool support.
-* Add a hot reload tool.
-* Add basic analysis support.
-* Add the beginnings of a Dart tooling MCP server.
-* Instruct clients to prefer MCP tools over running tools in the shell.
-* Reduce output size of `run_tests` tool to save on input tokens.
-* Add `--log-file` argument to log all protocol traffic to a file.
-* Improve error text for failed DTD connections as well as the tool description.
-* Add support for injecting an `Analytics` instance to track usage.
-* Listen to the new DTD `ConnectedApp` service instead of the `Editor.DebugSessions`
+- Add documentation/homepage/repository links to pub results.
+- Handle relative paths under roots without trailing slashes.
+- Fix executable paths for dart/flutter on windows.
+- Pass the provided root instead of the resolved root for project type detection.
+- Be more flexible about roots by comparing canonicalized paths.
+- Create the working dir if it doesn't exist.
+- Add the --platform and --empty arguments to the flutter create tool.
+- Invoke dart/flutter in a more robust way.
+- Remove qualifiedNames from the pub dev api search.
+- Flutter/Dart create tool.
+- Limit the tokens returned by the runtime errors tool/resource.
+- Add RootsFallbackSupport mixin.
+- Fix error handling around stream listeners.
+- Add a 'pub-dev-search' mcp tool.
+- Drop pubspec-parse, use yaml instead.
+- Handle failing to listen to vm service streams during startup.
+- Add tool for enabling/disabling the widget selector.
+- Add a tool to get the active cursor location.
+- Add hover tool support.
+- Add a test command and project detection.
+- Add signature_help tool.
+- Add runtime errors resource and tool to clear errors.
+- Require roots for all CLI tools.
+- Require roots to be set for analyzer tools.
+- Add debug logs for when DTD sees Editor.getDebugSessions get registered.
+- Add tool annotations to tools.
+- Implement a tool to resolve workspace symbols based on a query.
+- Add a dart pub tool.
+- Update analyze tool to use LSP, simplify tool.
+- Add tool for getting the selected widget.
+- Handle missing roots capability better.
+- Add `get_widget_tree` tool.
+- Add a tool for getting runtime errors.
+- Add Dart CLI tool support.
+- Add a hot reload tool.
+- Add basic analysis support.
+- Add the beginnings of a Dart tooling MCP server.
+- Instruct clients to prefer MCP tools over running tools in the shell.
+- Reduce output size of `run_tests` tool to save on input tokens.
+- Add `--log-file` argument to log all protocol traffic to a file.
+- Improve error text for failed DTD connections as well as the tool description.
+- Add support for injecting an `Analytics` instance to track usage.
+- Listen to the new DTD `ConnectedApp` service instead of the `Editor.DebugSessions`
   service, when available.
-* Screenshot tool disabled until
+- Screenshot tool disabled until
   https://github.com/flutter/flutter/issues/170357 is resolved.
-* Add `arg_parser.dart` public library with minimal deps to be used by the dart tool.
+- Add `arg_parser.dart` public library with minimal deps to be used by the dart tool.

--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -1,67 +1,67 @@
 # 0.1.1 (Dart SDK 3.10.0) - WIP
 
-- Change tools that accept multiple roots to not return immediately on the first
+* Change tools that accept multiple roots to not return immediately on the first
   failure.
-- Add failure reason field to analytics events so we can know why tool calls are
+* Add failure reason field to analytics events so we can know why tool calls are
   failing.
-- Add a flutter_driver command for executing flutter driver commands on a device.
-- Allow for multiple package arguments to `pub add` and `pub remove`.
-- Require dart_mcp version 0.3.1.
-- Add support for the flutter_driver screenshot command.
-- Change the widget tree to the full version instead of the summary. The summary
+* Add a flutter_driver command for executing flutter driver commands on a device.
+* Allow for multiple package arguments to `pub add` and `pub remove`.
+* Require dart_mcp version 0.3.1.
+* Add support for the flutter_driver screenshot command.
+* Change the widget tree to the full version instead of the summary. The summary
   tends to hide nested text widgets which makes it difficult to find widgets
   based on their text values.
-- Add an `--exclude-tool` command line flag to exclude tools by name.
-- Add the abillity to limit the output of `analyze_files` to a set of paths.
-- Stop reporting non-zero exit codes from command line tools as tool errors.
-- Add support for a tool that runs `dart run build_runner build`.
+* Add an `--exclude-tool` command line flag to exclude tools by name.
+* Add the abillity to limit the output of `analyze_files` to a set of paths.
+* Stop reporting non-zero exit codes from command line tools as tool errors.
+* Add support for a tool that runs `dart run build_runner build`.
 
 # 0.1.0 (Dart SDK 3.9.0)
 
-- Add documentation/homepage/repository links to pub results.
-- Handle relative paths under roots without trailing slashes.
-- Fix executable paths for dart/flutter on windows.
-- Pass the provided root instead of the resolved root for project type detection.
-- Be more flexible about roots by comparing canonicalized paths.
-- Create the working dir if it doesn't exist.
-- Add the --platform and --empty arguments to the flutter create tool.
-- Invoke dart/flutter in a more robust way.
-- Remove qualifiedNames from the pub dev api search.
-- Flutter/Dart create tool.
-- Limit the tokens returned by the runtime errors tool/resource.
-- Add RootsFallbackSupport mixin.
-- Fix error handling around stream listeners.
-- Add a 'pub-dev-search' mcp tool.
-- Drop pubspec-parse, use yaml instead.
-- Handle failing to listen to vm service streams during startup.
-- Add tool for enabling/disabling the widget selector.
-- Add a tool to get the active cursor location.
-- Add hover tool support.
-- Add a test command and project detection.
-- Add signature_help tool.
-- Add runtime errors resource and tool to clear errors.
-- Require roots for all CLI tools.
-- Require roots to be set for analyzer tools.
-- Add debug logs for when DTD sees Editor.getDebugSessions get registered.
-- Add tool annotations to tools.
-- Implement a tool to resolve workspace symbols based on a query.
-- Add a dart pub tool.
-- Update analyze tool to use LSP, simplify tool.
-- Add tool for getting the selected widget.
-- Handle missing roots capability better.
-- Add `get_widget_tree` tool.
-- Add a tool for getting runtime errors.
-- Add Dart CLI tool support.
-- Add a hot reload tool.
-- Add basic analysis support.
-- Add the beginnings of a Dart tooling MCP server.
-- Instruct clients to prefer MCP tools over running tools in the shell.
-- Reduce output size of `run_tests` tool to save on input tokens.
-- Add `--log-file` argument to log all protocol traffic to a file.
-- Improve error text for failed DTD connections as well as the tool description.
-- Add support for injecting an `Analytics` instance to track usage.
-- Listen to the new DTD `ConnectedApp` service instead of the `Editor.DebugSessions`
+* Add documentation/homepage/repository links to pub results.
+* Handle relative paths under roots without trailing slashes.
+* Fix executable paths for dart/flutter on windows.
+* Pass the provided root instead of the resolved root for project type detection.
+* Be more flexible about roots by comparing canonicalized paths.
+* Create the working dir if it doesn't exist.
+* Add the --platform and --empty arguments to the flutter create tool.
+* Invoke dart/flutter in a more robust way.
+* Remove qualifiedNames from the pub dev api search.
+* Flutter/Dart create tool.
+* Limit the tokens returned by the runtime errors tool/resource.
+* Add RootsFallbackSupport mixin.
+* Fix error handling around stream listeners.
+* Add a 'pub-dev-search' mcp tool.
+* Drop pubspec-parse, use yaml instead.
+* Handle failing to listen to vm service streams during startup.
+* Add tool for enabling/disabling the widget selector.
+* Add a tool to get the active cursor location.
+* Add hover tool support.
+* Add a test command and project detection.
+* Add signature_help tool.
+* Add runtime errors resource and tool to clear errors.
+* Require roots for all CLI tools.
+* Require roots to be set for analyzer tools.
+* Add debug logs for when DTD sees Editor.getDebugSessions get registered.
+* Add tool annotations to tools.
+* Implement a tool to resolve workspace symbols based on a query.
+* Add a dart pub tool.
+* Update analyze tool to use LSP, simplify tool.
+* Add tool for getting the selected widget.
+* Handle missing roots capability better.
+* Add `get_widget_tree` tool.
+* Add a tool for getting runtime errors.
+* Add Dart CLI tool support.
+* Add a hot reload tool.
+* Add basic analysis support.
+* Add the beginnings of a Dart tooling MCP server.
+* Instruct clients to prefer MCP tools over running tools in the shell.
+* Reduce output size of `run_tests` tool to save on input tokens.
+* Add `--log-file` argument to log all protocol traffic to a file.
+* Improve error text for failed DTD connections as well as the tool description.
+* Add support for injecting an `Analytics` instance to track usage.
+* Listen to the new DTD `ConnectedApp` service instead of the `Editor.DebugSessions`
   service, when available.
-- Screenshot tool disabled until
+* Screenshot tool disabled until
   https://github.com/flutter/flutter/issues/170357 is resolved.
-- Add `arg_parser.dart` public library with minimal deps to be used by the dart tool.
+* Add `arg_parser.dart` public library with minimal deps to be used by the dart tool.

--- a/pkgs/dart_mcp_server/README.md
+++ b/pkgs/dart_mcp_server/README.md
@@ -150,6 +150,7 @@ For more information, see the official VS Code documentation for
 | `dart_format` | Dart format | Runs `dart format .` for the given project roots. |
 | `run_tests` | Run tests | Run Dart or Flutter tests with an agent centric UX. ALWAYS use instead of `dart test` or `flutter test` shell commands. |
 | `create_project` | Create project | Creates a new Dart or Flutter project. |
+| `build_runner` | Run build_runner | Runs `dart run build_runner build` for the given project roots. For this to succeed, the build_runner package must be a dev dependency of the package it is run on. |
 | `pub` | pub | Runs a pub command for the given project roots, like `dart pub get` or `flutter pub add`. |
 | `analyze_files` | Analyze projects | Analyzes specific paths, or the entire project, for errors. |
 | `resolve_workspace_symbol` | Project search | Look up a symbol or symbols in all workspaces by name. Can be used to validate that a symbol exists or discover small spelling mistakes, since the search is fuzzy. |

--- a/pkgs/dart_mcp_server/lib/src/utils/constants.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/constants.dart
@@ -8,6 +8,7 @@ import 'package:dart_mcp/server.dart';
 extension ParameterNames on Never {
   static const column = 'column';
   static const command = 'command';
+  static const deleteConflictingOutputs = 'delete-conflicting-outputs';
   static const directory = 'directory';
   static const empty = 'empty';
   static const line = 'line';

--- a/pkgs/dart_mcp_server/pubspec.yaml
+++ b/pkgs/dart_mcp_server/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
   yaml: ^3.1.3
 
 dev_dependencies:
-  analyzer: ^7.5.2
+  analyzer: ^8.1.1
   dart_flutter_team_lints: ^3.2.1
   pub_semver: ^2.2.0
   test: ^1.25.15


### PR DESCRIPTION
# Description

This adds a tool to be able to run the [`build_runner`](https://pub.dev/packages/build_runner) package's build function.  This is a common code generation package, and having it as a tool will allow it to be approved separately from command line execution in many agents, and it gives the LLM a clear way to invoke `build_runner` to build generated code for common packages like `json_serializable` or `freezed`.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

