### PR TITLE
Mark "root" as required.

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Update the tool calling example to include progress notifications.
 - Remove a reference to "screenshot" for a generic error that occurs for more
   than just screenshots.
+- Mark the "root" parameter for create_project required.
 
 ## 0.3.3
 

--- a/pkgs/dart_mcp_server/lib/src/mixins/dash_cli.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dash_cli.dart
@@ -253,7 +253,11 @@ base mixin DashCliSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
               'boilerplate and example code. Defaults to true.',
         ),
       },
-      required: [ParameterNames.directory, ParameterNames.projectType],
+      required: [
+        ParameterNames.directory,
+        ParameterNames.projectType,
+        ParameterNames.root,
+      ],
     ),
   );
 


### PR DESCRIPTION
# Description

This marks the "root" parameter for the `create_project` command as required, which it is, but wasn't previously marked as such.