### PR TITLE
[Feat] Add `hot_restart` support to `dart_mcp_server`

### DIFF
--- a/pkgs/dart_mcp_server/lib/src/mixins/flutter_launcher.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/flutter_launcher.dart
@@ -40,6 +40,7 @@ base mixin FlutterLauncherSupport
     registerTool(listDevicesTool, _listDevices);
     registerTool(getAppLogsTool, _getAppLogs);
     registerTool(listRunningAppsTool, _listRunningApps);
+    registerTool(hotRestartTool, _hotRestart);
     return super.initialize(request);
   }
 

--- a/pkgs/dart_mcp_server/lib/src/mixins/flutter_launcher.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/flutter_launcher.dart
@@ -478,6 +478,49 @@ base mixin FlutterLauncherSupport
     ),
   );
 
+  Future<CallToolResult> _hotRestart(CallToolRequest request) async {
+    final pid = request.arguments!['pid'] as int;
+    log(LoggingLevel.info, 'Attempting hot restart for application PID: $pid');
+    final app = _runningApps[pid];
+
+    if (app == null) {
+      log(LoggingLevel.error, 'Application with PID $pid not found.');
+      return CallToolResult(
+        isError: true,
+        content: [TextContent(text: 'Application with PID $pid not found.')],
+      );
+    }
+
+    try {
+      app.process.stdin.writeln('R');
+      await app.process.stdin.flush();
+      log(LoggingLevel.info, 'Hot restart command sent to application $pid.');
+
+      return CallToolResult(
+        content: [
+          TextContent(
+            text: 'Hot restart initiated for application with PID $pid.',
+          ),
+        ],
+        structuredContent: {'success': true},
+      );
+    } catch (e, s) {
+      log(
+        LoggingLevel.error,
+        'Error performing hot restart for application $pid: $e\n$s',
+      );
+      return CallToolResult(
+        isError: true,
+        content: [
+          TextContent(
+            text: 'Failed to perform hot restart for application $pid: $e',
+          ),
+        ],
+        structuredContent: {'success': false},
+      );
+    }
+  }
+
   @override
   Future<void> shutdown() {
     log(LoggingLevel.info, 'Shutting down server, killing all processes.');

--- a/pkgs/dart_mcp_server/lib/src/mixins/flutter_launcher.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/flutter_launcher.dart
@@ -454,6 +454,30 @@ base mixin FlutterLauncherSupport
     );
   }
 
+  /// A tool to perform a hot restart on a running Flutter application.
+  final hotRestartTool = Tool(
+    name: 'hot_restart',
+    description:
+        'Performs a hot restart on a running Flutter application. This restarts the app while maintaining the current session.',
+    inputSchema: Schema.object(
+      properties: {
+        'pid': Schema.int(
+          description:
+              'The process ID of the flutter run process to hot restart.',
+        ),
+      },
+      required: ['pid'],
+    ),
+    outputSchema: Schema.object(
+      properties: {
+        'success': Schema.bool(
+          description: 'Whether the hot restart was successful.',
+        ),
+      },
+      required: ['success'],
+    ),
+  );
+
   @override
   Future<void> shutdown() {
     log(LoggingLevel.info, 'Shutting down server, killing all processes.');

--- a/pkgs/dart_mcp_server/test/tools/flutter_launcher_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/flutter_launcher_test.dart
@@ -323,6 +323,9 @@ class MockProcess implements Process {
 
   bool killed = false;
 
+  @override
+  late final IOSink stdin = _MockIOSink();
+
   MockProcess({
     required this.stdout,
     required this.stderr,
@@ -340,7 +343,61 @@ class MockProcess implements Process {
     }
     return true;
   }
+}
+
+class _MockIOSink implements IOSink {
+  final List<String> writtenLines = [];
+  bool _closed = false;
 
   @override
-  late final IOSink stdin = IOSink(StreamController<List<int>>().sink);
+  Encoding encoding = utf8;
+
+  @override
+  void add(List<int> data) {
+    if (_closed) throw StateError('IOSink is closed');
+  }
+
+  @override
+  void write(Object? object) {
+    if (_closed) throw StateError('IOSink is closed');
+  }
+
+  @override
+  void writeln([Object? object = '']) {
+    if (_closed) throw StateError('IOSink is closed');
+    writtenLines.add(object.toString());
+  }
+
+  @override
+  Future<void> flush() async {
+    if (_closed) throw StateError('IOSink is closed');
+  }
+
+  @override
+  Future<void> close() async {
+    _closed = true;
+  }
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future addStream(Stream<List<int>> stream) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future get done => Future.value();
+
+  @override
+  void writeAll(Iterable objects, [String separator = '']) {
+    throw UnimplementedError();
+  }
+
+  @override
+  void writeCharCode(int charCode) {
+    throw UnimplementedError();
+  }
 }


### PR DESCRIPTION
Adds `hot_restart` tool support to the `dart_mcp_server` Flutter launcher, enabling hot restart functionality for running Flutter applications while maintaining the current session.

This implementation is based on the changes from https://github.com/gemini-cli-extensions/flutter/pull/1 and addresses issue #254.

---

Closes #254