### PR TITLE
Add hot restart tool

### DIFF
--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Fix a bug in hot_reload ([#290](https://github.com/dart-lang/ai/issues/290)).
 * Add the `list_devices`, `launch_app`, `get_app_logs`, and `list_running_apps`
   tools for running Flutter apps.
+* Add the `hot_restart` tool for restarting running Flutter apps.
 
 # 0.1.0 (Dart SDK 3.9.0)
 

--- a/pkgs/dart_mcp_server/README.md
+++ b/pkgs/dart_mcp_server/README.md
@@ -147,7 +147,8 @@ For more information, see the official VS Code documentation for
 | `get_runtime_errors` | Get runtime errors | Retrieves the most recent runtime errors that have occurred in the active Dart or Flutter application. Requires "connect_dart_tooling_daemon" to be successfully called first. |
 | `get_selected_widget` | Get selected widget | Retrieves the selected widget from the active Flutter application. Requires "connect_dart_tooling_daemon" to be successfully called first. |
 | `get_widget_tree` | Get widget tree | Retrieves the widget tree from the active Flutter application. Requires "connect_dart_tooling_daemon" to be successfully called first. |
-| `hot_reload` | Hot reload | Performs a hot reload of the active Flutter application. This is to apply the latest code changes to the running application. Requires "connect_dart_tooling_daemon" to be successfully called first. |
+| `hot_reload` | Hot reload | Performs a hot reload of the active Flutter application. This will apply the latest code changes to the running application, while maintaining application state.  Reload will not update const definitions of global values. Requires "connect_dart_tooling_daemon" to be successfully called first. |
+| `hot_restart` | Hot restart | Performs a hot restart of the active Flutter application. This applies the latest code changes to the running application, including changes to global const values, while resetting application state. Requires "connect_dart_tooling_daemon" to be successfully called first. Doesn't work for Non-Flutter Dart CLI programs. |
 | `hover` | Hover information | Get hover information at a given cursor position in a file. This can include documentation, type information, etc for the text at that position. |
 | `launch_app` |  | Launches a Flutter application and returns its DTD URI. |
 | `list_devices` |  | Lists available Flutter devices. |

--- a/pkgs/dart_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dtd_test.dart
@@ -75,6 +75,27 @@ void main() {
             TextContent(text: 'Hot reload succeeded.'),
           ]);
         });
+
+        test('can perform a hot restart', () async {
+          await testHarness.startDebugSession(
+            counterAppPath,
+            'lib/main.dart',
+            isFlutter: true,
+          );
+          final tools =
+              (await testHarness.mcpServerConnection.listTools()).tools;
+          final hotRestartTool = tools.singleWhere(
+            (t) => t.name == DartToolingDaemonSupport.hotRestartTool.name,
+          );
+          final hotRestartResult = await testHarness.callToolWithRetry(
+            CallToolRequest(name: hotRestartTool.name),
+          );
+
+          expect(hotRestartResult.isError, isNot(true));
+          expect(hotRestartResult.content, [
+            TextContent(text: 'Hot restart succeeded.'),
+          ]);
+        });
       });
 
       group('dart cli tests', () {


### PR DESCRIPTION
## Description

This adds a `hot_restart` tool that will restart Flutter applications when requested

## Related Issues
 -  Fixes https://github.com/dart-lang/ai/issues/254

## Tests
 - Added tests for the new tool.