### PR TITLE
make some ResourceLink properties nullable (description/mimeType)

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.0-wip
+
+- **BREAKING**:
+  - Change many fields of `ResourceLink` to be nullable, and their associated
+    parameters to be optional. This brings us in line with the specification.
+
 ## 0.4.1
 
 - Expose various private methods on MCP server mixins as public methods, with

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -484,17 +484,17 @@ extension type ResourceLink.fromMap(Map<String, Object?> _value)
   factory ResourceLink({
     required String name,
     String? title,
-    required String description,
+    String? description,
     required String uri,
-    required String mimeType,
+    String? mimeType,
     Annotations? annotations,
     Meta? meta,
   }) => ResourceLink.fromMap({
     'name': name,
     if (title != null) 'title': title,
-    'description': description,
+    if (description != null) 'description': description,
     'uri': uri,
-    'mimeType': mimeType,
+    if (mimeType != null) 'mimeType': mimeType,
     'type': expectedType,
     if (annotations != null) 'annotations': annotations,
     if (meta != null) '_meta': meta,
@@ -507,13 +507,7 @@ extension type ResourceLink.fromMap(Map<String, Object?> _value)
   }
 
   /// The description of the resource.
-  String get description {
-    final description = _value['description'] as String?;
-    if (description == null) {
-      throw ArgumentError('Missing description field in $ResourceLink.');
-    }
-    return description;
-  }
+  String? get description => _value['description'] as String?;
 
   /// The URI of the resource.
   String get uri {
@@ -525,13 +519,13 @@ extension type ResourceLink.fromMap(Map<String, Object?> _value)
   }
 
   /// The MIME type of the resource.
-  String get mimeType {
-    final mimeType = _value['mimeType'] as String?;
-    if (mimeType == null) {
-      throw ArgumentError('Missing mimeType field in $ResourceLink.');
-    }
-    return mimeType;
-  }
+  String? get mimeType => _value['mimeType'] as String?;
+
+  /// The size of the resource in bytes.
+  int? get size => _value['size'] as int?;
+
+  /// List of icons for display in user interfaces
+  List<String>? get icons => (_value['icons'] as List?)?.cast<String>();
 }
 
 /// Base type for objects that include optional annotations for the client.

--- a/pkgs/dart_mcp/pubspec.yaml
+++ b/pkgs/dart_mcp/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_mcp
-version: 0.4.1
+version: 0.5.0-wip
 description: A package for making MCP servers and clients.
 repository: https://github.com/dart-lang/ai/tree/main/pkgs/dart_mcp
 issue_tracker: https://github.com/dart-lang/ai/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Adart_mcp

--- a/pkgs/dart_mcp_server/pubspec.yaml
+++ b/pkgs/dart_mcp_server/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   args: ^2.7.0
   async: ^2.13.0
   collection: ^1.19.1
-  dart_mcp: ^0.4.1
+  dart_mcp: ^0.5.0
   dds_service_extensions: ^2.0.1
   devtools_shared: ^12.0.0
   dtd: ^4.0.0


### PR DESCRIPTION
This brings us in line with the spec, these always should have been nullable.

It is breaking due to the getters becoming nullable. 