### PR TITLE
add reason to launch_app failures, refactor tests

### DIFF
--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -1,9 +1,10 @@
 # 0.1.3 (Dart SDK 3.12.0) - WIP
 
-- Add additional analytics for initialization events, and various list* method
+- Add additional analytics for initialization events, and various list\* method
   calls. This will help understand how the server is being used by different
   clients, and what features clients support.
 - Add a tool for running ripgrep on package dependencies.
+- Add `timeout` option to `launch_app`.
 
 # 0.1.2 (Dart SDK 3.11.0)
 

--- a/pkgs/dart_mcp_server/lib/src/utils/analytics.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/analytics.dart
@@ -160,6 +160,8 @@ enum CallToolFailureReason {
   noRootGiven,
   noRootsSet,
   noSuchCommand,
+  processException,
+  timeout,
   webSocketException,
 }
 

--- a/pkgs/dart_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dtd_test.dart
@@ -118,7 +118,7 @@ void main() {
         }
 
         test('is registered with correct name format', () async {
-          final dtdClient = testHarness.fakeEditorExtension.dtd;
+          final dtdClient = testHarness.fakeEditorExtension!.dtd;
           final services = await dtdClient.getRegisteredServices();
           final samplingService = services.clientServices.first;
           final sanitizedClientName =
@@ -138,7 +138,7 @@ void main() {
         });
 
         test('can make a sampling request with text', () async {
-          final dtdClient = testHarness.fakeEditorExtension.dtd;
+          final dtdClient = testHarness.fakeEditorExtension!.dtd;
           final samplingServiceName = await getSamplingServiceName(dtdClient);
           final response = await dtdClient.call(
             samplingServiceName,
@@ -160,7 +160,7 @@ void main() {
         });
 
         test('can make a sampling request with an image', () async {
-          final dtdClient = testHarness.fakeEditorExtension.dtd;
+          final dtdClient = testHarness.fakeEditorExtension!.dtd;
           final samplingServiceName = await getSamplingServiceName(dtdClient);
           final response = await dtdClient.call(
             samplingServiceName,
@@ -186,7 +186,7 @@ void main() {
         });
 
         test('can make a sampling request with audio', () async {
-          final dtdClient = testHarness.fakeEditorExtension.dtd;
+          final dtdClient = testHarness.fakeEditorExtension!.dtd;
           final samplingServiceName = await getSamplingServiceName(dtdClient);
           final response = await dtdClient.call(
             samplingServiceName,
@@ -209,7 +209,7 @@ void main() {
         });
 
         test('can make a sampling request with an embedded resource', () async {
-          final dtdClient = testHarness.fakeEditorExtension.dtd;
+          final dtdClient = testHarness.fakeEditorExtension!.dtd;
           final samplingServiceName = await getSamplingServiceName(dtdClient);
           final response = await dtdClient.call(
             samplingServiceName,
@@ -234,7 +234,7 @@ void main() {
         });
 
         test('can make a sampling request with mixed content', () async {
-          final dtdClient = testHarness.fakeEditorExtension.dtd;
+          final dtdClient = testHarness.fakeEditorExtension!.dtd;
           final samplingServiceName = await getSamplingServiceName(dtdClient);
           final response = await dtdClient.call(
             samplingServiceName,
@@ -265,7 +265,7 @@ void main() {
         });
 
         test('can handle user and assistant messages', () async {
-          final dtdClient = testHarness.fakeEditorExtension.dtd;
+          final dtdClient = testHarness.fakeEditorExtension!.dtd;
           final samplingServiceName = await getSamplingServiceName(dtdClient);
           final response = await dtdClient.call(
             samplingServiceName,
@@ -297,7 +297,7 @@ void main() {
         });
 
         test('forwards all messages, even those with unknown types', () async {
-          final dtdClient = testHarness.fakeEditorExtension.dtd;
+          final dtdClient = testHarness.fakeEditorExtension!.dtd;
           final samplingServiceName = await getSamplingServiceName(dtdClient);
           final response = await dtdClient.call(
             samplingServiceName,
@@ -321,7 +321,7 @@ void main() {
         });
 
         test('throws for invalid requests', () async {
-          final dtdClient = testHarness.fakeEditorExtension.dtd;
+          final dtdClient = testHarness.fakeEditorExtension!.dtd;
           final samplingServiceName = await getSamplingServiceName(dtdClient);
           try {
             await dtdClient.call(
@@ -882,7 +882,7 @@ void main() {
 
           // Simulate activeLocationChanged event
           final fakeEvent = {'someData': 'isHere'};
-          await fakeEditor.dtd.postEvent(
+          await fakeEditor!.dtd.postEvent(
             'Editor',
             'activeLocationChanged',
             fakeEvent,


### PR DESCRIPTION
We are seeing a large number of failures for `launch_app`, but we don't log a reason for them. This is in an effort to help diagnose those issues.

- Creates two specialized cases that we track-  timeout exceptions and process exceptions, which are likely causes of these failures.
- Adds a timeout parameter to the method, agents can select a longer timeout if they want to try again.
- Heavily refactors tests to use the shared test harness, remove duplication, and remove usages of fake_async.