### PR TITLE
Fix nested finder JSON serialization for flutter_driver

### DIFF
--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -5,6 +5,8 @@
   clients, and what features clients support.
 - Add a tool for running ripgrep on package dependencies.
 - Add `timeout` option to `launch_app`.
+- Fix nested finder JSON serialization for Ancestor/Descendant finders in the
+  `flutter_driver` tool ([issue #345](https://github.com/dart-lang/ai/issues/345)).
 
 # 0.1.2 (Dart SDK 3.11.0)
 

--- a/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
@@ -231,6 +231,12 @@ base mixin DartToolingDaemonSupport
         if (isScreenshot) {
           request.arguments?.putIfAbsent('format', () => '4' /*png*/);
         }
+        // jsonEncode nested finder maps for Ancestor/Descendant finders.
+        for (final key in const ['of', 'matching']) {
+          if (request.arguments?[key] is Map) {
+            request.arguments![key] = jsonEncode(request.arguments![key]);
+          }
+        }
         final result = await vmService
             .callServiceExtension(
               _flutterDriverService,

--- a/pkgs/dart_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dtd_test.dart
@@ -1017,6 +1017,40 @@ void main() {
           // Clean up
           await testHarness.stopDebugSession(debugSession);
         });
+
+        test('can use Descendant finder', () async {
+          final debugSession = await testHarness.startDebugSession(
+            counterAppPath,
+            'lib/driver_main.dart',
+            isFlutter: true,
+          );
+          final result = await testHarness.callToolWithRetry(
+            CallToolRequest(
+              name: DartToolingDaemonSupport.flutterDriverTool.name,
+              arguments: {
+                'command': 'get_text',
+                'finderType': 'Descendant',
+                'of': {'finderType': 'ByType', 'type': 'Column'},
+                'matching': {
+                  'finderType': 'ByValueKey',
+                  'keyValueString': 'counter',
+                  'keyValueType': 'String',
+                },
+                'firstMatchOnly': 'true',
+                'matchRoot': 'false',
+              },
+            ),
+          );
+          expect(
+            result.content.first,
+            isA<TextContent>().having(
+              (c) => c.text,
+              'text',
+              contains('"text":"0"'),
+            ),
+          );
+          await testHarness.stopDebugSession(debugSession);
+        });
       });
     });
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/ai/issues/345.
  
The `flutter_driver` tool passes `of` and `matching` parameters as raw Maps to `callServiceExtension`, which calls `.toString()` on them, producing Dart map notation instead of valid JSON. This causes a `FormatException` in the flutter_driver extension's `jsonDecode()`.

Adds `jsonEncode` for `of`/`matching` before `callServiceExtension`, matching how `Descendant.serialize()`/`Ancestor.serialize()` work in `package:flutter_driver`.