### PR TITLE
fix version from 2025-11-05 to 2025-11-25

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.5.0-wip
 
-- Initial support for protocol version [2025-11-05](https://spec.modelcontextprotocol.io/specification/2025-11-05/).
+- Initial support for protocol version [2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25/).
   - Added support for `Icon`s in `Implementation`, `Tool`, `Resource`, `ResourceTemplate`, and `Prompt`.
   - Added support for `ToolChoice` in sampling `CreateMessageRequest`.
   - Added support for URL-based elicitations in `ElicitRequest`.

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -30,7 +30,7 @@ enum ProtocolVersion {
   v2024_11_05('2024-11-05'),
   v2025_03_26('2025-03-26'),
   v2025_06_18('2025-06-18'),
-  v2025_11_05('2025-11-05');
+  v2025_11_25('2025-11-25');
 
   const ProtocolVersion(this.versionString);
 
@@ -43,7 +43,7 @@ enum ProtocolVersion {
   static const oldestSupported = ProtocolVersion.v2024_11_05;
 
   /// The most recent version supported by the current API.
-  static const latestSupported = ProtocolVersion.v2025_11_05;
+  static const latestSupported = ProtocolVersion.v2025_11_25;
 
   /// The version string used over the wire to identify this version.
   final String versionString;


### PR DESCRIPTION
Fixes https://github.com/dart-lang/ai/issues/365

I mostly use antigravity which apparently doesn't require a valid version number to be returned, so I didn't notice this for a few days. We did just land a new version in the SDK so we might have a few broken dev releases and should get this in as soon as possible.