### PR TITLE
add ConstSchema type

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -22,7 +22,7 @@
   - Does **not** add support for Tasks yet.
   - Added support for `EnumSchema` subtypes, matching the spec. This includes
     multi select enums and enums with titles. Validation is also supported.
-  - Added support for validating `const` fields in schemas.
+- Added `ConstSchema` type for constant values, with validation.
 - **BREAKING**:
   - Change many fields of `ResourceLink` to be nullable, and their associated
     parameters to be optional. This brings us in line with the specification.

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -1938,6 +1938,34 @@ extension type ListSchema.fromMap(Map<String, Object?> _value)
   }
 }
 
+/// A JSON Schema definition for a constant value.
+extension type ConstSchema.fromMap(Map<String, Object?> _value)
+    implements Schema {
+  factory ConstSchema({
+    String? title,
+    String? description,
+    required Object? constValue,
+  }) => ConstSchema.fromMap({
+    Keys.const_: constValue,
+    if (title != null) Keys.title: title,
+    if (description != null) Keys.description: description,
+  });
+
+  /// The constant value for this schema.
+  Object? get constValue {
+    if (!_value.containsKey(Keys.const_)) {
+      throw ArgumentError('Missing ${Keys.const_} field in $ConstSchema');
+    }
+    return _value[Keys.const_];
+  }
+
+  /// The human readable title for this constant value.
+  String? get title => _value[Keys.title] as String?;
+
+  /// The description for this constant value.
+  String? get description => _value[Keys.description] as String?;
+}
+
 HashSet<ValidationError> _createHashSet() {
   return HashSet<ValidationError>(
     equals: (ValidationError a, ValidationError b) {

--- a/pkgs/dart_mcp/test/api/tools_test.dart
+++ b/pkgs/dart_mcp/test/api/tools_test.dart
@@ -321,6 +321,22 @@ void main() {
         ],
       });
     });
+
+    test('ConstSchema', () {
+      final schema = ConstSchema(
+        constValue: 12,
+        title: 'twelve',
+        description: 'its the number 12!',
+      );
+      expect(schema, {
+        'const': 12,
+        'title': 'twelve',
+        'description': 'its the number 12!',
+      });
+      expect(schema.constValue, 12);
+      expect(schema.title, 'twelve');
+      expect(schema.description, 'its the number 12!');
+    });
   });
 
   group('Schema Validation Tests (Paths Ignored)', () {
@@ -1708,7 +1724,7 @@ void main() {
     });
 
     test('const', () {
-      final schema = {'const': 'hello'} as Schema;
+      final schema = ConstSchema(constValue: 'hello');
       expectFailuresMatch(schema, 'hello', []);
       expectFailuresMatch(schema, 'world', [
         ValidationError(ValidationErrorType.wrongConstValue, path: const []),
@@ -1759,24 +1775,28 @@ void main() {
         final schema = ObjectSchema(
           properties: {
             'user': ObjectSchema(
-              properties: {'name': StringSchema(minLength: 5)},
+              properties: {
+                'name': StringSchema(minLength: 5),
+                'isUser': ConstSchema(constValue: true),
+              },
             ),
           },
         );
-        // 'user.name' is "hi" which fails minLength: 5
-        // _validate(StringSchema(minLength:5), "hi") -> [minLengthNotMet]
-        // This becomes propertyValueInvalid for 'name'
-        // Then this becomes propertyValueInvalid for 'user'
         expectFailuresExact(
           schema,
           {
-            'user': {'name': 'hi'},
+            'user': {'name': 'hi', 'isUser': false},
           },
           [
             ValidationError(
               ValidationErrorType.minLengthNotMet,
               path: ['user', 'name'],
               details: 'String "hi" is not at least 5 characters long',
+            ),
+            ValidationError(
+              ValidationErrorType.wrongConstValue,
+              path: ['user', 'isUser'],
+              details: 'Value false does not match constant true',
             ),
           ],
         );


### PR DESCRIPTION
This adds support for creating `{"const": someValue}` schema objects ([spec](https://json-schema.org/understanding-json-schema/reference/const)).

These are useful if you want to create a top level `oneOf` object, for instance for meta tools, where you want a `command` field with custom arguments for each command, and you don't want to rely on just descriptions of all the possible arguments and which commands they are valid for.