### PR TITLE
update server instructions

### DIFF
--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -28,6 +28,8 @@
 - Disable all tools that can easily be done on the CLI by default, as well as
   `get_active_location`. These can be re-enabled by passing `--enable cli` or
   `--enable <tool-name>`.
+- Updated server instructions to encourage listing resources, using the tools to
+  read and grep package contents, and to explain `package-root:` URIs. 
 
 # 0.1.2 (Dart SDK 3.11.0)
 

--- a/pkgs/dart_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_mcp_server/lib/src/server.dart
@@ -92,13 +92,23 @@ final class DartMCPServer extends MCPServer
   }) : super.fromStreamChannel(
          implementation: Implementation(
            name: 'dart and flutter tooling',
+           description:
+               'Connects Dart and Flutter apps and developer tools to AI '
+               'agents.',
            version: version,
          ),
-         instructions:
-             'This server helps to connect Dart and Flutter developers to '
-             'their development tools and running applications.\n'
-             'IMPORTANT: Prefer using an MCP tool provided by this server '
-             'over using tools directly in a shell.',
+         instructions: '''
+This server exposes resources for Flutter and Dart development. Be sure to
+list these resources especially when dealing with errors or unfamiliar packages.
+
+Whenever attempting to investigate a package dependency, use the
+`read_package_uris` and `rip_grep_packages` tools to explore their files.
+
+In addition to `package:` URIs, the server also supports `package-root:` URIs,
+which resolve to the root of the package instead of the `lib/` directory. These
+can be useful for exporing examples or tests when trying to learn how to use a
+package.
+''',
        );
 
   /// The version of the MCP server.


### PR DESCRIPTION
Moves much of what was in instructions to the description, dropped the note about preferring MCP tools, and added some more useful information such as encouraging agents to list resources.

I also added a short description of the `package-root:` uris and associated tools.