### PR TITLE
include subcommand name in tool name when present for analytics

### DIFF
--- a/pkgs/dart_mcp_server/lib/src/mixins/analytics.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/analytics.dart
@@ -8,6 +8,7 @@ import 'package:dart_mcp/server.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
 import '../utils/analytics.dart';
+import '../utils/names.dart';
 
 /// A mixin which intercepts various MCP calls to track analytics.
 base mixin AnalyticsEvents
@@ -153,6 +154,11 @@ base mixin AnalyticsEvents
       return result = await super.callTool(request);
     } finally {
       watch.stop();
+      var toolName = request.name;
+      if (request.arguments?[ParameterNames.command]
+          case final String command) {
+        toolName += '.$command';
+      }
       trySendAnalyticsEvent(
         Event.dartMCPEvent(
           client: clientInfo.name,
@@ -160,7 +166,7 @@ base mixin AnalyticsEvents
           serverVersion: implementation.version,
           type: AnalyticsEvent.callTool.name,
           additionalData: CallToolMetrics(
-            tool: request.name,
+            tool: toolName,
             success: result != null && result.isError != true,
             elapsedMilliseconds: watch.elapsedMilliseconds,
             failureReason: result?.failureReason,

--- a/pkgs/dart_mcp_server/test/tools/analytics_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/analytics_test.dart
@@ -8,6 +8,7 @@ import 'package:dart_mcp/server.dart';
 import 'package:dart_mcp_server/src/features_configuration.dart';
 import 'package:dart_mcp_server/src/server.dart';
 import 'package:dart_mcp_server/src/utils/analytics.dart';
+import 'package:dart_mcp_server/src/utils/names.dart';
 import 'package:test/test.dart';
 import 'package:unified_analytics/testing.dart';
 import 'package:unified_analytics/unified_analytics.dart';
@@ -223,6 +224,51 @@ void main() {
                 'tool': tool.name,
                 'success': false,
                 'failureReason': 'argumentError',
+                'elapsedMilliseconds': isA<int>(),
+              }),
+            ),
+      );
+    });
+
+    test('includes the command in the tool name if present', () async {
+      analytics.sentEvents.clear();
+      final tool = Tool(
+        name: 'meta_tool',
+        inputSchema: Schema.object(
+          properties: {ParameterNames.command: Schema.string()},
+          required: [ParameterNames.command],
+        ),
+      )..categories = [FeatureCategory.cli];
+      server.registerTool(
+        tool,
+        (request) => CallToolResult(
+          content: [
+            Content.text(
+              text: request.arguments![ParameterNames.command] as String,
+            ),
+          ],
+        ),
+      );
+      await testHarness.mcpServerConnection.callTool(
+        CallToolRequest(
+          name: tool.name,
+          arguments: {ParameterNames.command: 'hello'},
+        ),
+      );
+      expect(
+        analytics.sentEvents.last,
+        isA<Event>()
+            .having((e) => e.eventName, 'eventName', DashEvent.dartMCPEvent)
+            .having(
+              (e) => e.eventData,
+              'eventData',
+              equals({
+                'client': server.clientInfo.name,
+                'clientVersion': server.clientInfo.version,
+                'serverVersion': server.implementation.version,
+                'type': AnalyticsEvent.callTool.name,
+                'tool': '${tool.name}.hello',
+                'success': true,
                 'elapsedMilliseconds': isA<int>(),
               }),
             ),


### PR DESCRIPTION
Given that we have moved more towards meta-tools with subcommands, we are going to lose some of the granularity on our tool call analytics.

This will restore that by including the subcommand as a part of the `tool` parameter, using `<tool>.<subcommand>` syntax.

This will make analytics a bit awkward during the transition, but it shouldn't be too bad.

We could decide to _just_ use the sub-command name if we wanted to try and keep the analytics consistent.