### PR TITLE
enable the set_semantics flutter driver command

### DIFF
--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Compact the output of the `analyze_files` tool to reduce token usage.
 - Start analysis server instances lazily, and time them out after 10 minutes of
   inactivity.
+- Enable `set_semantics` command for flutter_driver.
 
 # 0.1.2 (Dart SDK 3.11.0)
 

--- a/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
@@ -1097,7 +1097,7 @@ base mixin DartToolingDaemonSupport
             'scroll',
             'scrollIntoView',
             // 'set_frame_sync',
-            // 'set_semantics',
+            'set_semantics',
             'set_text_entry_emulation',
             'tap',
             'waitFor',

--- a/pkgs/dart_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dtd_test.dart
@@ -1029,6 +1029,92 @@ void main() {
           await testHarness.stopDebugSession(debugSession);
         });
 
+        test('can enable and disable semantics', () async {
+          final debugSession = await testHarness.startDebugSession(
+            counterAppPath,
+            'lib/driver_main.dart',
+            isFlutter: true,
+          );
+
+          // Enable semantics
+          var result = await testHarness.callToolWithRetry(
+            CallToolRequest(
+              name: DartToolingDaemonSupport.flutterDriverTool.name,
+              arguments: {
+                ParameterNames.command: 'set_semantics',
+                ParameterNames.enabled: 'true',
+              },
+            ),
+          );
+          expect(result.isError, isNot(true));
+          expect(
+            result.content.first,
+            isA<TextContent>().having(
+              (c) => c.text,
+              'text',
+              contains('"changedState":true'),
+            ),
+          );
+
+          // Disable semantics
+          result = await testHarness.callToolWithRetry(
+            CallToolRequest(
+              name: DartToolingDaemonSupport.flutterDriverTool.name,
+              arguments: {
+                ParameterNames.command: 'set_semantics',
+                ParameterNames.enabled: 'false',
+              },
+            ),
+          );
+          expect(result.isError, isNot(true));
+          expect(
+            result.content.first,
+            isA<TextContent>().having(
+              (c) => c.text,
+              'text',
+              contains('"changedState":true'),
+            ),
+          );
+
+          await testHarness.stopDebugSession(debugSession);
+        });
+
+        test('set_semantics enables searching by semantics label', () async {
+          final debugSession = await testHarness.startDebugSession(
+            counterAppPath,
+            'lib/driver_main.dart',
+            isFlutter: true,
+          );
+
+          await testHarness.callToolWithRetry(
+            CallToolRequest(
+              name: DartToolingDaemonSupport.flutterDriverTool.name,
+              arguments: {
+                ParameterNames.command: 'set_semantics',
+                ParameterNames.enabled: 'true',
+              },
+            ),
+          );
+
+          // Should be able to find the counter text by semantics label.
+          // Note: We still can't see the "Increment" label for some reason,
+          // but this seems to be a flutter issue and not an MCP issue.
+          final result = await testHarness.callToolWithRetry(
+            CallToolRequest(
+              name: DartToolingDaemonSupport.flutterDriverTool.name,
+              arguments: {
+                ParameterNames.command: 'waitFor',
+                'finderType': 'BySemanticsLabel',
+                'label': '0',
+                'isRegExp': 'false',
+              },
+            ),
+          );
+          expect(result.isError, isNot(true));
+
+          await testHarness.stopDebugSession(debugSession);
+        });
+
         test('can use Descendant finder', () async {
           final debugSession = await testHarness.startDebugSession(
             counterAppPath,


### PR DESCRIPTION
This enables agents to enable or disable the semantics tree, which can help with finding and selecting certain elements on the page.