### PR TITLE
fix: graceful shutdown of orphaned test apps on windows

### DIFF
--- a/pkgs/dart_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_mcp_server/test/test_harness.dart
@@ -277,7 +277,7 @@ final class AppDebugSession {
       [
         'run',
         '--no${isFlutter ? '' : '-serve'}-devtools',
-        '--enable-vm-service=0',
+        if (!isFlutter) '--enable-vm-service=0',
         if (isFlutter) ...['-d', 'flutter-tester'],
         appPath,
         ...args,

--- a/pkgs/dart_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_mcp_server/test/test_harness.dart
@@ -28,7 +28,7 @@ import 'package:unified_analytics/unified_analytics.dart';
 
 Future<T> callWithRetry<T>(
   FutureOr<T> Function() fn, {
-  int maxTries = 10,
+  int maxTries = 5,
   bool Function(T)? retryUntil,
 }) async {
   var tryCount = 0;
@@ -231,7 +231,7 @@ class TestHarness {
   /// Some methods will fail if the DTD connection is not yet ready.
   Future<CallToolResult> callToolWithRetry(
     CallToolRequest request, {
-    int maxTries = 10,
+    int maxTries = 5,
     bool expectError = false,
     bool Function(CallToolResult)? retryUntil,
   }) => callWithRetry(
@@ -275,9 +275,9 @@ final class AppDebugSession {
     final process = await TestProcess.start(
       isFlutter ? sdk.flutterExecutablePath : sdk.dartExecutablePath,
       [
-        if (isFlutter) 'run',
-        if (isFlutter) '--no-devtools',
-        if (!isFlutter) '--enable-vm-service=0',
+        'run',
+        '--no${isFlutter ? '' : '-serve'}-devtools',
+        '--enable-vm-service=0',
         if (isFlutter) ...['-d', 'flutter-tester'],
         appPath,
         ...args,
@@ -336,12 +336,9 @@ final class AppDebugSession {
       }
       try {
         await process.shouldExit(0).timeout(const Duration(seconds: 10));
-      } catch (_) {
+      } on TimeoutException catch (_) {
         await process.kill();
-        // Ignore exit code since we had to forcefully kill
-        try {
-          await process.shouldExit().timeout(const Duration(seconds: 5));
-        } catch (_) {}
+        await process.shouldExit();
       }
     } else {
       // Send q which triggers graceful shutdown in our test scripts
@@ -355,11 +352,9 @@ final class AppDebugSession {
       }
       try {
         await process.shouldExit().timeout(const Duration(seconds: 10));
-      } catch (_) {
+      } on TimeoutException catch (_) {
         await process.kill();
-        try {
-          await process.shouldExit().timeout(const Duration(seconds: 5));
-        } catch (_) {}
+        await process.shouldExit();
       }
     }
   }
@@ -485,12 +480,14 @@ class FakeEditorExtension {
     await dtd.close();
     try {
       await dtdProcess.stdin.close();
-      await dtdProcess.shouldExit().timeout(const Duration(seconds: 5));
     } catch (_) {
+      // stdin already closed
+    }
+    try {
+      await dtdProcess.shouldExit().timeout(const Duration(seconds: 5));
+    } on TimeoutException catch (_) {
       await dtdProcess.kill();
-      try {
-        await dtdProcess.shouldExit().timeout(const Duration(seconds: 5));
-      } catch (_) {}
+      await dtdProcess.shouldExit();
     }
   }
 }
@@ -579,6 +576,8 @@ Future<ServerConnectionPair> _initializeMCPServer(
     connection = client.connectServer(clientChannel);
   } else {
     final process = await Process.start(sdk.dartExecutablePath, [
+      'pub', // Using `pub` gives us incremental compilation
+      'run',
       'bin/main.dart',
       ...cliArgs,
       for (var enabled in featuresConfig.enabledNames) '--enable=$enabled',
@@ -587,18 +586,14 @@ Future<ServerConnectionPair> _initializeMCPServer(
     addTearDown(() async {
       try {
         await process.stdin.close();
-        await process.exitCode.timeout(const Duration(seconds: 5));
       } catch (_) {
+        // stdin already closed
+      }
+      try {
+        await process.exitCode.timeout(const Duration(seconds: 5));
+      } on TimeoutException catch (_) {
         process.kill();
-        try {
-          await process.exitCode.timeout(
-            const Duration(seconds: 5),
-            onTimeout: () {
-              process.kill(ProcessSignal.sigkill);
-              return process.exitCode;
-            },
-          );
-        } catch (_) {}
+        await process.exitCode;
       }
     });
     connection = client.connectServer(

--- a/pkgs/dart_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_mcp_server/test/test_harness.dart
@@ -28,7 +28,7 @@ import 'package:unified_analytics/unified_analytics.dart';
 
 Future<T> callWithRetry<T>(
   FutureOr<T> Function() fn, {
-  int maxTries = 5,
+  int maxTries = 10,
   bool Function(T)? retryUntil,
 }) async {
   var tryCount = 0;
@@ -231,7 +231,7 @@ class TestHarness {
   /// Some methods will fail if the DTD connection is not yet ready.
   Future<CallToolResult> callToolWithRetry(
     CallToolRequest request, {
-    int maxTries = 5,
+    int maxTries = 10,
     bool expectError = false,
     bool Function(CallToolResult)? retryUntil,
   }) => callWithRetry(
@@ -275,8 +275,8 @@ final class AppDebugSession {
     final process = await TestProcess.start(
       isFlutter ? sdk.flutterExecutablePath : sdk.dartExecutablePath,
       [
-        'run',
-        '--no${isFlutter ? '' : '-serve'}-devtools',
+        if (isFlutter) 'run',
+        if (isFlutter) '--no-devtools',
         if (!isFlutter) '--enable-vm-service=0',
         if (isFlutter) ...['-d', 'flutter-tester'],
         appPath,
@@ -319,13 +319,48 @@ final class AppDebugSession {
     );
   }
 
+  /// Gracefully shuts down the [process].
+  ///
+  /// Note: this method may be called more than once for the same process
+  /// because [_start] registers its own [addTearDown] and some tests also
+  /// call [TestHarness.stopDebugSession] in their tearDown. The try/catch
+  /// around stdin operations handles the case where stdin is already closed
+  /// from a prior call.
   static Future<void> kill(TestProcess process, bool isFlutter) async {
     if (isFlutter) {
-      process.stdin.writeln('q');
-      await process.shouldExit(0);
+      try {
+        process.stdin.writeln('q');
+        // ignore: avoid_catching_errors
+      } on StateError catch (_) {
+        // stdin already closed from a prior kill() call.
+      }
+      try {
+        await process.shouldExit(0).timeout(const Duration(seconds: 10));
+      } catch (_) {
+        await process.kill();
+        // Ignore exit code since we had to forcefully kill
+        try {
+          await process.shouldExit().timeout(const Duration(seconds: 5));
+        } catch (_) {}
+      }
     } else {
-      await process.kill();
-      await process.shouldExit();
+      // Send q which triggers graceful shutdown in our test scripts
+      try {
+        process.stdin.writeln('q');
+        // Also close stdin for scripts listening to onDone
+        await process.stdin.close();
+        // ignore: avoid_catching_errors
+      } on StateError catch (_) {
+        // stdin already closed from a prior kill() call.
+      }
+      try {
+        await process.shouldExit().timeout(const Duration(seconds: 10));
+      } catch (_) {
+        await process.kill();
+        try {
+          await process.shouldExit().timeout(const Duration(seconds: 5));
+        } catch (_) {}
+      }
     }
   }
 }
@@ -447,9 +482,16 @@ class FakeEditorExtension {
 
   Future<void> shutdown() async {
     await _debugSessions.toList().map(removeDebugSession).wait;
-    await dtdProcess.kill();
-    await dtdProcess.shouldExit();
     await dtd.close();
+    try {
+      await dtdProcess.stdin.close();
+      await dtdProcess.shouldExit().timeout(const Duration(seconds: 5));
+    } catch (_) {
+      await dtdProcess.kill();
+      try {
+        await dtdProcess.shouldExit().timeout(const Duration(seconds: 5));
+      } catch (_) {}
+    }
   }
 }
 
@@ -537,16 +579,27 @@ Future<ServerConnectionPair> _initializeMCPServer(
     connection = client.connectServer(clientChannel);
   } else {
     final process = await Process.start(sdk.dartExecutablePath, [
-      'pub', // Using `pub` gives us incremental compilation
-      'run',
       'bin/main.dart',
       ...cliArgs,
       for (var enabled in featuresConfig.enabledNames) '--enable=$enabled',
       for (var disabled in featuresConfig.disabledNames) '--disable=$disabled',
     ]);
     addTearDown(() async {
-      process.kill();
-      await process.exitCode;
+      try {
+        await process.stdin.close();
+        await process.exitCode.timeout(const Duration(seconds: 5));
+      } catch (_) {
+        process.kill();
+        try {
+          await process.exitCode.timeout(
+            const Duration(seconds: 5),
+            onTimeout: () {
+              process.kill(ProcessSignal.sigkill);
+              return process.exitCode;
+            },
+          );
+        } catch (_) {}
+      }
     });
     connection = client.connectServer(
       stdioChannel(input: process.stdout, output: process.stdin),

--- a/pkgs/dart_mcp_server/test/tools/dtd_multiple_connection_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dtd_multiple_connection_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:dart_mcp/server.dart';
 import 'package:dart_mcp_server/src/mixins/dtd.dart';
 
@@ -166,118 +164,118 @@ void main() {
       }
     });
 
-    test(
-      'can get runtime errors from multiple apps using appUri',
-      () async {
-        await testHarness.connectToDtd();
+    test('can get runtime errors from multiple apps using appUri', () async {
+      await testHarness.connectToDtd();
 
-        await d.dir('dart_app_1', [
-          d.dir('bin', [
-            d.file('main.dart', '''
+      await d.dir('dart_app_1', [
+        d.dir('bin', [
+          d.file('main.dart', '''
 import 'dart:io';
 void main() async {
   stderr.writeln('error from app 1');
+  stdin.listen((data) {
+    if (String.fromCharCodes(data).trim() == 'q') exit(0);
+  }, onDone: () => exit(0));
   while (true) {
     await Future.delayed(Duration(seconds: 1));
   }
 }
 '''),
-          ]),
-        ]).create();
-        final session1 = await testHarness.startDebugSession(
-          p.join(d.sandbox, 'dart_app_1'),
-          'bin/main.dart',
-          isFlutter: false,
-        );
-        addTearDown(() => testHarness.stopDebugSession(session1));
+        ]),
+      ]).create();
+      final session1 = await testHarness.startDebugSession(
+        p.join(d.sandbox, 'dart_app_1'),
+        'bin/main.dart',
+        isFlutter: false,
+      );
+      addTearDown(() => testHarness.stopDebugSession(session1));
 
-        final secondEditorExtension = await FakeEditorExtension.connect(
-          testHarness.sdk,
-        );
-        addTearDown(secondEditorExtension.shutdown);
-        await testHarness.connectToDtd(dtdUri: secondEditorExtension.dtdUri);
+      final secondEditorExtension = await FakeEditorExtension.connect(
+        testHarness.sdk,
+      );
+      addTearDown(secondEditorExtension.shutdown);
+      await testHarness.connectToDtd(dtdUri: secondEditorExtension.dtdUri);
 
-        await d.dir('dart_app_2', [
-          d.dir('bin', [
-            d.file('main.dart', '''
+      await d.dir('dart_app_2', [
+        d.dir('bin', [
+          d.file('main.dart', '''
 import 'dart:io';
 void main() async {
   stderr.writeln('error from app 2');
+  stdin.listen((data) {
+    if (String.fromCharCodes(data).trim() == 'q') exit(0);
+  }, onDone: () => exit(0));
   while (true) {
     await Future.delayed(Duration(seconds: 1));
   }
 }
 '''),
-          ]),
-        ]).create();
-        final session2 = await testHarness.startDebugSession(
-          p.join(d.sandbox, 'dart_app_2'),
-          'bin/main.dart',
-          isFlutter: false,
+        ]),
+      ]).create();
+      final session2 = await testHarness.startDebugSession(
+        p.join(d.sandbox, 'dart_app_2'),
+        'bin/main.dart',
+        isFlutter: false,
+        editorExtension: secondEditorExtension,
+      );
+      addTearDown(
+        () => testHarness.stopDebugSession(
+          session2,
           editorExtension: secondEditorExtension,
-        );
-        addTearDown(
-          () => testHarness.stopDebugSession(
-            session2,
-            editorExtension: secondEditorExtension,
-          ),
-        );
+        ),
+      );
 
-        final listResult = await testHarness.callToolWithRetry(
-          CallToolRequest(
-            name: ToolNames.dtd.name,
-            arguments: {ParameterNames.command: DtdCommand.listConnectedApps},
-          ),
-          retryUntil: (result) =>
-              (result.structuredContent as Map<String, Object?>).values
-                  .cast<List<Object?>>()
-                  .fold(0, (count, apps) => count + apps.length) ==
-              2,
-        );
-        expect(listResult.isError, isNot(true));
-        final dtdEntries = listResult.structuredContent;
-        expect(dtdEntries, isNotNull);
-        final connectedAppUris = (dtdEntries as Map<String, Object?>).values
-            .cast<List<Object?>>()
-            .fold(
-              <String>[],
-              (apps, appInfos) => apps
-                ..addAll(
-                  appInfos.map(
-                    (app) => (app as Map<String, Object?>)['uri'] as String,
-                  ),
+      final listResult = await testHarness.callToolWithRetry(
+        CallToolRequest(
+          name: ToolNames.dtd.name,
+          arguments: {ParameterNames.command: DtdCommand.listConnectedApps},
+        ),
+        retryUntil: (result) =>
+            (result.structuredContent as Map<String, Object?>).values
+                .cast<List<Object?>>()
+                .fold(0, (count, apps) => count + apps.length) ==
+            2,
+      );
+      expect(listResult.isError, isNot(true));
+      final dtdEntries = listResult.structuredContent;
+      expect(dtdEntries, isNotNull);
+      final connectedAppUris = (dtdEntries as Map<String, Object?>).values
+          .cast<List<Object?>>()
+          .fold(
+            <String>[],
+            (apps, appInfos) => apps
+              ..addAll(
+                appInfos.map(
+                  (app) => (app as Map<String, Object?>)['uri'] as String,
                 ),
-            );
-        expect(connectedAppUris, hasLength(2));
+              ),
+          );
+      expect(connectedAppUris, hasLength(2));
 
-        // Verify errors for App 1
-        final errors1 = await testHarness.callToolWithRetry(
-          CallToolRequest(
-            name: ToolNames.getRuntimeErrors.name,
-            arguments: {ParameterNames.appUri: session1.vmServiceUri},
-          ),
-        );
-        expect(
-          (errors1.content[1] as TextContent).text,
-          contains('error from app 1'),
-        );
+      // Verify errors for App 1
+      final errors1 = await testHarness.callToolWithRetry(
+        CallToolRequest(
+          name: ToolNames.getRuntimeErrors.name,
+          arguments: {ParameterNames.appUri: session1.vmServiceUri},
+        ),
+      );
+      expect(
+        (errors1.content[1] as TextContent).text,
+        contains('error from app 1'),
+      );
 
-        // Verify errors for App 2
-        final errors2 = await testHarness.callToolWithRetry(
-          CallToolRequest(
-            name: ToolNames.getRuntimeErrors.name,
-            arguments: {ParameterNames.appUri: session2.vmServiceUri},
-          ),
-          retryUntil: (result) => result.content.length > 1,
-        );
-        expect(
-          (errors2.content[1] as TextContent).text,
-          contains('error from app 2'),
-        );
-      },
-      skip: Platform.isWindows
-          ? 'https://github.com/dart-lang/ai/issues/407'
-          : false,
-    );
+      // Verify errors for App 2
+      final errors2 = await testHarness.callToolWithRetry(
+        CallToolRequest(
+          name: ToolNames.getRuntimeErrors.name,
+          arguments: {ParameterNames.appUri: session2.vmServiceUri},
+        ),
+        retryUntil: (result) => result.content.length > 1,
+      );
+      expect(
+        (errors2.content[1] as TextContent).text,
+        contains('error from app 2'),
+      );
+    });
   });
 }

--- a/pkgs/dart_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dtd_test.dart
@@ -470,7 +470,16 @@ void main() {
           final stdin = debugSession.appProcess.stdin;
           await stdout.skip(1); // VM service line
           stdin.writeln('');
-          expect(await stdout.next, 'hello');
+
+          Future<void> expectNext(String expected) async {
+            var nextLine = await stdout.next;
+            while (nextLine.contains('DevTools debugger')) {
+              nextLine = await stdout.next;
+            }
+            expect(nextLine, expected);
+          }
+
+          await expectNext('hello');
           await Future<void>.delayed(const Duration(seconds: 1));
 
           final originalContents = await mainFile.readAsString();
@@ -494,7 +503,7 @@ void main() {
           );
 
           stdin.writeln('');
-          expect(await stdout.next, 'world');
+          await expectNext('world');
 
           stdin.writeln('q');
           await testHarness.stopDebugSession(debugSession);

--- a/pkgs/dart_mcp_server/test_fixtures/dart_cli_app/bin/infinite_wait.dart
+++ b/pkgs/dart_mcp_server/test_fixtures/dart_cli_app/bin/infinite_wait.dart
@@ -2,7 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 void main() async {
+  stdin.listen((data) {
+    if (String.fromCharCodes(data).trim() == 'q') exit(0);
+  }, onDone: () => exit(0));
   while (true) {
     await Future.delayed(const Duration(seconds: 1));
   }


### PR DESCRIPTION
Fixes #407

This PR resolves the multi-app DTD test teardown failure on Windows.

**What this PR changes:**
- Modified the test dummy applications in `dtd_multiple_connection_test.dart` and `infinite_wait.dart` to gracefully shut down by listening to `stdin` and calling `exit(0)` when the pipe is closed.

**Why:**
On Windows, when `AppDebugSession` terminates the parent `dart run` test process via `process.kill()`, the child `dart` process running the infinite `while(true)` loop tends to be left orphaned. This orphaned process maintained a lock on the `d.sandbox` directory, preventing the test framework from deleting the temp directory during teardown and throwing a "file in use" or "access denied" error. By having the test fixture scripts monitor `stdin` and exit on its closure, the child process dies gracefully as soon as the test stops the debug session or the test forcefully crashes.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
