### PR TITLE
Fix #407

### DIFF
--- a/pkgs/dart_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_mcp_server/test/test_harness.dart
@@ -320,29 +320,39 @@ final class AppDebugSession {
   }
 
   static Future<void> kill(TestProcess process, bool isFlutter) async {
-    do {
-      if (isFlutter) {
-        process.stdin.writeln('q');
-        await process.shouldExit(0);
-      } else {
-        await process.kill();
-        await process.shouldExit();
+    if (isFlutter) {
+      process.stdin.writeln('q');
+      await process.shouldExit(0);
+    } else {
+      await process.kill();
+      await process.shouldExit();
+    }
+
+    // On Windows, the process might still be cleaning up even after the exit
+    // code is received.
+    // Poll with a delay to ensure it's fully gone before proceeding to cleanup.
+    if (Platform.isWindows) {
+      for (var i = 0; i < 20; i++) {
+        if (!await _pidAlive(process.pid)) break;
+        await Future<void>.delayed(const Duration(milliseconds: 50));
       }
-    } while (await _pidAlive(process.pid));
+    }
   }
 
   static Future<bool> _pidAlive(int pid) async {
     try {
       if (Platform.isWindows) {
-        final p = await Process.start('tasklist', const []);
-        final lines = await p.stdout
-            .transform(const Utf8Decoder(allowMalformed: true))
-            .toList();
-        return lines.where((e) => e.contains(' $pid ')).isNotEmpty;
-      } else {
-        // TODO: handle other platforms if needed
-        return false;
+        final result = await Process.run('tasklist', [
+          '/FI',
+          '"PID eq $pid"',
+          '/NH',
+        ]);
+        return result.stdout.toString().contains('$pid');
+      } else if (Platform.isLinux || Platform.isMacOS) {
+        final result = await Process.run('ps', ['-p', '$pid']);
+        return result.stdout.toString().contains('$pid');
       }
+      return false;
     } catch (_) {
       return false;
     }

--- a/pkgs/dart_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_mcp_server/test/test_harness.dart
@@ -320,12 +320,31 @@ final class AppDebugSession {
   }
 
   static Future<void> kill(TestProcess process, bool isFlutter) async {
-    if (isFlutter) {
-      process.stdin.writeln('q');
-      await process.shouldExit(0);
-    } else {
-      await process.kill();
-      await process.shouldExit();
+    do {
+      if (isFlutter) {
+        process.stdin.writeln('q');
+        await process.shouldExit(0);
+      } else {
+        await process.kill();
+        await process.shouldExit();
+      }
+    } while (await _pidAlive(process.pid));
+  }
+
+  static Future<bool> _pidAlive(int pid) async {
+    try {
+      if (Platform.isWindows) {
+        final p = await Process.start('tasklist', const []);
+        final lines = await p.stdout
+            .transform(const Utf8Decoder(allowMalformed: true))
+            .toList();
+        return lines.where((e) => e.contains(' $pid ')).isNotEmpty;
+      } else {
+        // TODO: handle other platforms if needed
+        return false;
+      }
+    } catch (_) {
+      return false;
     }
   }
 }

--- a/pkgs/dart_mcp_server/test/tools/dtd_multiple_connection_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dtd_multiple_connection_test.dart
@@ -164,14 +164,12 @@ void main() {
       }
     });
 
-    test(
-      'can get runtime errors from multiple apps using appUri',
-      () async {
-        await testHarness.connectToDtd();
+    test('can get runtime errors from multiple apps using appUri', () async {
+      await testHarness.connectToDtd();
 
-        await d.dir('dart_app_1', [
-          d.dir('bin', [
-            d.file('main.dart', '''
+      await d.dir('dart_app_1', [
+        d.dir('bin', [
+          d.file('main.dart', '''
 import 'dart:io';
 void main() async {
   stderr.writeln('error from app 1');
@@ -180,24 +178,24 @@ void main() async {
   }
 }
 '''),
-          ]),
-        ]).create();
-        final session1 = await testHarness.startDebugSession(
-          p.join(d.sandbox, 'dart_app_1'),
-          'bin/main.dart',
-          isFlutter: false,
-        );
-        addTearDown(() => testHarness.stopDebugSession(session1));
+        ]),
+      ]).create();
+      final session1 = await testHarness.startDebugSession(
+        p.join(d.sandbox, 'dart_app_1'),
+        'bin/main.dart',
+        isFlutter: false,
+      );
+      addTearDown(() => testHarness.stopDebugSession(session1));
 
-        final secondEditorExtension = await FakeEditorExtension.connect(
-          testHarness.sdk,
-        );
-        addTearDown(secondEditorExtension.shutdown);
-        await testHarness.connectToDtd(dtdUri: secondEditorExtension.dtdUri);
+      final secondEditorExtension = await FakeEditorExtension.connect(
+        testHarness.sdk,
+      );
+      addTearDown(secondEditorExtension.shutdown);
+      await testHarness.connectToDtd(dtdUri: secondEditorExtension.dtdUri);
 
-        await d.dir('dart_app_2', [
-          d.dir('bin', [
-            d.file('main.dart', '''
+      await d.dir('dart_app_2', [
+        d.dir('bin', [
+          d.file('main.dart', '''
 import 'dart:io';
 void main() async {
   stderr.writeln('error from app 2');
@@ -206,73 +204,72 @@ void main() async {
   }
 }
 '''),
-          ]),
-        ]).create();
-        final session2 = await testHarness.startDebugSession(
-          p.join(d.sandbox, 'dart_app_2'),
-          'bin/main.dart',
-          isFlutter: false,
+        ]),
+      ]).create();
+      final session2 = await testHarness.startDebugSession(
+        p.join(d.sandbox, 'dart_app_2'),
+        'bin/main.dart',
+        isFlutter: false,
+        editorExtension: secondEditorExtension,
+      );
+      addTearDown(
+        () => testHarness.stopDebugSession(
+          session2,
           editorExtension: secondEditorExtension,
-        );
-        addTearDown(
-          () => testHarness.stopDebugSession(
-            session2,
-            editorExtension: secondEditorExtension,
-          ),
-        );
+        ),
+      );
 
-        final listResult = await testHarness.callToolWithRetry(
-          CallToolRequest(
-            name: ToolNames.dtd.name,
-            arguments: {ParameterNames.command: DtdCommand.listConnectedApps},
-          ),
-          retryUntil: (result) =>
-              (result.structuredContent as Map<String, Object?>).values
-                  .cast<List<Object?>>()
-                  .fold(0, (count, apps) => count + apps.length) ==
-              2,
-        );
-        expect(listResult.isError, isNot(true));
-        final dtdEntries = listResult.structuredContent;
-        expect(dtdEntries, isNotNull);
-        final connectedAppUris = (dtdEntries as Map<String, Object?>).values
-            .cast<List<Object?>>()
-            .fold(
-              <String>[],
-              (apps, appInfos) => apps
-                ..addAll(
-                  appInfos.map(
-                    (app) => (app as Map<String, Object?>)['uri'] as String,
-                  ),
+      final listResult = await testHarness.callToolWithRetry(
+        CallToolRequest(
+          name: ToolNames.dtd.name,
+          arguments: {ParameterNames.command: DtdCommand.listConnectedApps},
+        ),
+        retryUntil: (result) =>
+            (result.structuredContent as Map<String, Object?>).values
+                .cast<List<Object?>>()
+                .fold(0, (count, apps) => count + apps.length) ==
+            2,
+      );
+      expect(listResult.isError, isNot(true));
+      final dtdEntries = listResult.structuredContent;
+      expect(dtdEntries, isNotNull);
+      final connectedAppUris = (dtdEntries as Map<String, Object?>).values
+          .cast<List<Object?>>()
+          .fold(
+            <String>[],
+            (apps, appInfos) => apps
+              ..addAll(
+                appInfos.map(
+                  (app) => (app as Map<String, Object?>)['uri'] as String,
                 ),
-            );
-        expect(connectedAppUris, hasLength(2));
+              ),
+          );
+      expect(connectedAppUris, hasLength(2));
 
-        // Verify errors for App 1
-        final errors1 = await testHarness.callToolWithRetry(
-          CallToolRequest(
-            name: ToolNames.getRuntimeErrors.name,
-            arguments: {ParameterNames.appUri: session1.vmServiceUri},
-          ),
-        );
-        expect(
-          (errors1.content[1] as TextContent).text,
-          contains('error from app 1'),
-        );
+      // Verify errors for App 1
+      final errors1 = await testHarness.callToolWithRetry(
+        CallToolRequest(
+          name: ToolNames.getRuntimeErrors.name,
+          arguments: {ParameterNames.appUri: session1.vmServiceUri},
+        ),
+      );
+      expect(
+        (errors1.content[1] as TextContent).text,
+        contains('error from app 1'),
+      );
 
-        // Verify errors for App 2
-        final errors2 = await testHarness.callToolWithRetry(
-          CallToolRequest(
-            name: ToolNames.getRuntimeErrors.name,
-            arguments: {ParameterNames.appUri: session2.vmServiceUri},
-          ),
-          retryUntil: (result) => result.content.length > 1,
-        );
-        expect(
-          (errors2.content[1] as TextContent).text,
-          contains('error from app 2'),
-        );
-      },
-    );
+      // Verify errors for App 2
+      final errors2 = await testHarness.callToolWithRetry(
+        CallToolRequest(
+          name: ToolNames.getRuntimeErrors.name,
+          arguments: {ParameterNames.appUri: session2.vmServiceUri},
+        ),
+        retryUntil: (result) => result.content.length > 1,
+      );
+      expect(
+        (errors2.content[1] as TextContent).text,
+        contains('error from app 2'),
+      );
+    });
   });
 }

--- a/pkgs/dart_mcp_server/test/tools/dtd_multiple_connection_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dtd_multiple_connection_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:dart_mcp/server.dart';
 import 'package:dart_mcp_server/src/mixins/dtd.dart';
 
@@ -275,9 +273,6 @@ void main() async {
           contains('error from app 2'),
         );
       },
-      skip: Platform.isWindows
-          ? 'https://github.com/dart-lang/ai/issues/407'
-          : false,
     );
   });
 }


### PR DESCRIPTION
Fix multi app DTD test on Windows by ensuring orphaned test apps and DTD connections shut down cleanly.

This prevents temp directory cleanup failures when the multi-connection DTD tests run on Windows.

- Fixes https://github.com/dart-lang/ai/issues/407
- Ensures `dtd_multiple_connection_test.dart` teardown completes properly on Windows
- Stabilizes multiple DTD connection test behavior across platforms

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
