### PR TITLE
add obsolete issues skill

### DIFF
--- a/.agents/skills/closing_obsolete_issues/SKILL.md
+++ b/.agents/skills/closing_obsolete_issues/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: closing-obsolete-issues
+description: Find and close obsolete, stale, or not reproducible issues in the dart-lang/ai repository.
+---
+
+# Closing Obsolete Issues
+
+Use this skill to find old, outdated issues in the `dart-lang/ai` repository that can be closed because they have been fixed, are stale, obsolete, or not reproducible.
+
+## Instructions
+
+1. **Identify Target Issues**:
+   - Use the GitHub CLI (`gh`) to search for the oldest open issues.
+   - Use any label that the user gives you, or none if the user does not specify any issue labels.
+   - Sort by creation date (`created-asc`) or last update (`updated-asc`) to find the most likely candidates for being outdated.
+   - Fetch at least 10-20 candidates.
+   - Example command (with label): `gh issue list --repo dart-lang/ai --search "label:bug is:open sort:created-asc" --limit 20 | cat`
+   - Example command (without label): `gh issue list --repo dart-lang/ai --search "is:open sort:created-asc" --limit 20 | cat`
+
+2. **Investigate Status**:
+   - For each candidate, analyze its description and comments.
+   - Use `gh issue view <number> --repo dart-lang/ai` to get details.
+   - Compare the issue's request or reported bug with the current state of the codebase.
+   - Refer to `references/rationale_templates.md` for a library of common reasons issues become outdated.
+   - **Safety Rule**: Do not assume a bug is fixed or obsolete just because the code has been updated. Verify if the specific bug behavior is still possible. Valid bugs or feature requests should not be closed as stale just because they are old or have no activity. Inactivity alone does not invalidate a feature request or bug report.
+
+3. **Draft and Review Closing Comments (CRITICAL MANDATE)**:
+   - For issues identified as candidates for closing, draft a detailed comment for each explaining *why* it can be closed.
+   - **Style Constraint**: DO NOT use em dashes (—) in the comments. Use hyphens (-) or colons (:) instead.
+   - **Template**: Consult `references/rationale_templates.md` for wording inspiration.
+   - Each comment MUST end with: "If there is more work to do here, please let us know by filing a new issue with up to date information. Thanks!"
+   - **User Approval Required**: You MUST present the identified issues (including URLs to the issues for easy navigation) and their drafted comments to the user and obtain explicit approval BEFORE running any command that closes an issue.
+
+4. **Iterate on Skill Knowledge (Learning Loop)**:
+   - If you discover a new, distinct category of closing rationale that is not covered in `references/rationale_templates.md`, **update the reference file** to include it.
+
+5. **Execute and Summarize**:
+   - Once approved, use `gh issue close` with the `-c` flag to post the comment and close the issue.
+   - Provide the user with a clean bulleted list of links to each closing comment.
+
+## Tips
+
+- Use available file and content search tools (such as `grep`, `ripgrep`) to check the current codebase for references to the issue or relevant code.
+- Look for related PRs that might have fixed the issue but didn't close it automatically.

--- a/.agents/skills/closing_obsolete_issues/SKILL.md
+++ b/.agents/skills/closing_obsolete_issues/SKILL.md
@@ -28,7 +28,7 @@ Use this skill to find old, outdated issues in the `dart-lang/ai` repository tha
    - For issues identified as candidates for closing, draft a detailed comment for each explaining *why* it can be closed.
    - **Style Constraint**: DO NOT use em dashes (—) in the comments. Use hyphens (-) or colons (:) instead.
    - **Template**: Consult `references/rationale_templates.md` for wording inspiration.
-   - Each comment MUST end with: "If there is more work to do here, please let us know by filing a new issue with up to date information. Thanks!"
+   - Each comment MUST end with: "If there is more work to do here, please let us know by commenting on this issue or filing a new one with up to date information. Thanks!"
    - **User Approval Required**: You MUST present the identified issues (including URLs to the issues for easy navigation) and their drafted comments to the user and obtain explicit approval BEFORE running any command that closes an issue.
 
 4. **Iterate on Skill Knowledge (Learning Loop)**:

--- a/.agents/skills/closing_obsolete_issues/references/rationale_templates.md
+++ b/.agents/skills/closing_obsolete_issues/references/rationale_templates.md
@@ -1,0 +1,19 @@
+# Common Closing Rationales for dart-lang/ai
+
+When investigating old issues in the `dart-lang/ai` repository, look for these common reasons they may be eligible for closing. Use these as templates for your closing comments.
+
+## 1. Superseded by New Features or Refactoring
+The codebase has evolved. Many old requests for features or bug fixes may be resolved by newer implementations or refactoring.
+- **Rationale**: Point to the new feature or implementation that fulfills the need.
+
+## 2. Stale Feature Requests
+Proposals or feature requests from a long time ago with no recent activity or community interest may be closed if they no longer align with current priorities.
+- **Rationale**: Note that the issue is a stale feature request with no recent activity and that the project has evolved significantly since then.
+
+## 3. Insufficient Information
+Issues that lack clear descriptions, reproduction steps, or logs make it impossible to investigate.
+- **Rationale**: "Without additional information, we cannot debug this issue. Please re-open if you can provide a description of your issue and repro steps. Thanks."
+
+## 4. Very Old Version or Context
+Issues reported on very old contexts or dependencies that are no longer relevant.
+- **Rationale**: "This issue looks like it occurred in an older context. Are you still experiencing this issue with the latest version? If so, please reopen with updated information. Thanks."


### PR DESCRIPTION
Derived from https://github.com/flutter/devtools/pull/9812

Example output:


Ran command: `git status`
Ran command: `git checkout main`
Ran command: `git pull`
Viewed SKILL.md:1-45
Ran command: `gh issue list --repo dart-lang/ai --search "is:open sort:created-asc" --limit 20 | cat`
Viewed rationale_templates.md:1-20
Ran command: `gh issue view 20 --repo dart-lang/ai`
Ran command: `gh issue view 20 --repo dart-lang/ai --json title,body`
Listed directory dart_mcp
Listed directory ai
Viewed CONTRIBUTING.md:1-52
Ran command: `gh issue view 23 --repo dart-lang/ai --json title,body`
Viewed api.dart:1-597
Ran command: `gh issue view 28 --repo dart-lang/ai --json title,body`
Searched for "implements PaginatedRequest"
Viewed tools.dart:1-800
Searched for "tools/list"
Searched for "ListToolsRequest"
Viewed tools_support.dart:1-138
Searched for "CancelledNotification"
Ran command: `gh issue view 37 --repo dart-lang/ai --json title,body`
Ran command: `gh issue view 57 --repo dart-lang/ai --json title,body`
Searched for "Flutter.Error"
Viewed dtd.dart:913-1712
Ran command: `gh issue view 151 --repo dart-lang/ai --json title,body`
Searched for "skip"
Searched for "runtimeErrors"
Viewed dtd_test.dart:386-1185
Ran command: `gh issue view 215 --repo dart-lang/ai --json title,body`
Searched for "lint"
Ran command: `gh issue view 258 --repo dart-lang/ai --json title,body`
Searched for "summaries"
Ran command: `git branch -a | grep summaries`
Ran command: `gh issue view 165 --repo dart-lang/ai --json title,body`
Ran command: `gh label list --repo dart-lang/ai`
Ran command: `gh issue list --repo dart-lang/ai --search "label:needs-info is:open" | cat`

I have searched for obsolete issues in the `dart-lang/ai` repository by looking at the oldest open issues and investigating a sample of them. So far, I have not found any issues that are clearly obsolete, stale, or resolved.

Here are the issues I investigated and why they appear to still be valid:

*   **[Issue 20](https://github.com/dart-lang/ai/issues/20): Add a CONTRIBUTING.md file for package:dart_mcp**
    *   *Status*: Valid. While there is a root [CONTRIBUTING.md](file:///usr/local/google/home/jakemac/ai/CONTRIBUTING.md), it is generic and does not cover the specific development process for `dart_mcp` or point to schema files as requested.
*   **[Issue 23](https://github.com/dart-lang/ai/issues/23): Consider an autogenerator for api.dart**
    *   *Status*: Valid. The file api.dart is still manually maintained.
*   **[Issue 28](https://github.com/dart-lang/ai/issues/28): Support pagination for tools/resources/prompts**
    *   *Status*: Valid. Although the API definitions support pagination, the default implementation in tools_support.dart ignores the pagination parameters and returns all items.
*   **[Issue 37](https://github.com/dart-lang/ai/issues/37): Add cancellation support**
    *   *Status*: Valid. The `CancelledNotification` is defined in the API but not used in the implementation.
*   **[Issue 57](https://github.com/dart-lang/ai/issues/57): [cleanup] Consider pruning the flutter runtime errors output to only what is useful for the LLM**
    *   *Status*: Valid. There is an explicit `TODO` in dtd.dart referencing this issue.
*   **[Issue 151](https://github.com/dart-lang/ai/issues/151): Windows test for errors resource failing**
    *   *Status*: Valid. The relevant test in `dtd_test.dart` is still skipped on Windows with a reference to this issue.
*   **[Issue 258](https://github.com/dart-lang/ai/issues/258): Support dart summaries and providing package dependency context in the Dart MCP server**
    *   *Status*: Valid. The `summaries` branch mentioned in the issue still exists and has not been merged.

I also checked for issues with the `needs-info` label but found none that are currently open.

Do you have a specific label or keyword you would like me to search for, or should I investigate a different batch of issues?
