### PR TITLE
Add test for DTD discovery

### DIFF
--- a/pkgs/dart_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dtd_test.dart
@@ -110,6 +110,12 @@ void main() {
       });
 
       test('Can list running DTD URIs', () async {
+        // Ensure we can see another one that is not directly connected to
+        // the test harness.
+        final secondEditorExtension = await FakeEditorExtension.connect(
+          testHarness.sdk,
+        );
+        addTearDown(secondEditorExtension.shutdown);
         final result = await testHarness.callTool(
           CallToolRequest(
             name: ToolNames.dtd.name,
@@ -124,6 +130,8 @@ void main() {
           matches(RegExp(r'Found \d+ Dart Tooling Daemon instance\(s\):')),
         );
         expect(text, contains('WS URI:'));
+        expect(text, contains(testHarness.fakeEditorExtension!.dtdUri));
+        expect(text, contains(secondEditorExtension.dtdUri));
         expect(text, contains('Workspace Root:'));
         expect(text, contains('PID:'));
       });


### PR DESCRIPTION
Closes https://github.com/dart-lang/ai/issues/405

This expands the existing test just a bit to ensure that a DTD instance spawned completely outside of the test harness is discoverable via the MCP server. 