### PR TITLE
add a tool to make arbitrary vm service method calls

### DIFF
--- a/mcp_examples/bin/workflow_client.dart
+++ b/mcp_examples/bin/workflow_client.dart
@@ -15,7 +15,10 @@ import 'package:google_generative_ai/google_generative_ai.dart' as gemini;
 
 /// The list of Gemini models that are accepted as a "--model" argument.
 /// Defaults to the first one in the list.
-const List<String> allowedGeminiModels = ['gemini-2.5-pro', 'gemini-2.5-flash'];
+const List<String> allowedGeminiModels = [
+  'gemini-3.1-flash-lite',
+  'gemini-3.1-pro-preview',
+];
 
 void main(List<String> args) {
   final geminiApiKey = Platform.environment['GEMINI_API_KEY'];

--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Always enable roots fallback, and merge them with client roots that are set
   (if any).
+- Add a tool for making abribrary vm service method calls to connected apps.
 
 # 0.1.3 (Dart SDK 3.12.0)
 

--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Always enable roots fallback, and merge them with client roots that are set
   (if any).
-- Add a tool for making abribrary vm service method calls to connected apps.
+- Add a tool for making arbitrary vm service method calls to connected apps.
 
 # 0.1.3 (Dart SDK 3.12.0)
 

--- a/pkgs/dart_mcp_server/README.md
+++ b/pkgs/dart_mcp_server/README.md
@@ -179,6 +179,7 @@ available to the agent. For example, in a GEMINI.md file in your project:
 | Tool Name | Title | Description | Categories | Enabled |
 | --- | --- | --- | --- | --- |
 | `analyze_files` | Analyze projects | Analyzes specific paths, or the entire project, for errors. | analysis | Yes |
+| `call_vm_service_method` | Invoke VM Service Method | Invoke VM service methods on a connected app. See the Public RPCs section of https://raw.githubusercontent.com/dart-lang/sdk/refs/heads/main/runtime/vm/service/service.md | dart_tooling_daemon | Yes |
 | `create_project` | Create project | Creates a new Dart or Flutter project. | cli | No |
 | `dart_fix` | Dart fix | Runs `dart fix --apply` for the given project roots. | cli | No |
 | `dart_format` | Dart format | Runs `dart format .` for the given project roots. | cli | No |

--- a/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
@@ -204,6 +204,7 @@ base mixin DartToolingDaemonSupport
     registerTool(hotReloadTool, hotReload);
     registerTool(widgetInspectorTool, _widgetInspector);
     registerTool(flutterDriverTool, _callFlutterDriver);
+    registerTool(callVmServiceMethodTool, _callVmServiceMethod);
 
     return super.initialize(request);
   }
@@ -217,6 +218,7 @@ base mixin DartToolingDaemonSupport
     hotReloadTool,
     widgetInspectorTool,
     flutterDriverTool,
+    callVmServiceMethodTool,
   ];
 
   @override
@@ -284,7 +286,46 @@ base mixin DartToolingDaemonSupport
     );
   }
 
+  Future<CallToolResult> _callVmServiceMethod(CallToolRequest request) async {
+    // These are already validated to match the schema definition.
+    final method = request.arguments?[ParameterNames.method] as String;
+    var isolateId = request.arguments?[ParameterNames.isolateId] as String?;
+    final args =
+        request.arguments?[ParameterNames.arguments] as Map<String, Object?>?;
+    final appUri = request.arguments?[ParameterNames.appUri] as String?;
+
+    return _callOnVmService(
+      appUri: appUri,
+      callback: (vmService) async {
+        isolateId ??= (await vmService.getVM()).isolates!.first.id;
+        try {
+          final result = await vmService.callMethod(
+            method,
+            isolateId: isolateId,
+            args: args,
+          );
+          return CallToolResult(
+            content: [TextContent(text: jsonEncode(result.json))],
+          );
+        } on RPCError catch (e) {
+          return CallToolResult(
+            isError: true,
+            content: [
+              TextContent(text: 'RPCError when invoking method $method: $e'),
+            ],
+          )..failureReason = CallToolFailureReason.rpcError;
+        } catch (e) {
+          return CallToolResult(
+            isError: true,
+            content: [TextContent(text: 'Error invoking method $method: $e')],
+          )..failureReason = CallToolFailureReason.unhandledError;
+        }
+      },
+    );
+  }
+
   /// Connects to the Dart Tooling Daemon.
+  ///
   /// Connects to a single DTD at [uri].
   Future<CallToolResult> _connectToDtdSingle(Uri uri) async {
     if (_dtds.any((dtd) => dtd.uri == uri)) {
@@ -1364,6 +1405,38 @@ base mixin DartToolingDaemonSupport
         )
         ..categories = [FeatureCategory.dartToolingDaemon]
         ..enabledByDefault = false;
+
+  @visibleForTesting
+  static final callVmServiceMethodTool = Tool(
+    name: ToolNames.callVmServiceMethod.name,
+    description:
+        'Invoke VM service methods on a connected app. See the Public RPCs '
+        'section of '
+        'https://raw.githubusercontent.com/dart-lang/sdk/refs/heads/main/runtime/vm/service/service.md',
+    annotations: ToolAnnotations(title: 'Invoke VM Service Method'),
+    inputSchema: Schema.object(
+      properties: {
+        ParameterNames.method: Schema.string(
+          description: 'The name of the method to invoke.',
+        ),
+        ParameterNames.isolateId: Schema.string(
+          description:
+              'The isolate ID to target (optional), defaults to the main '
+              'isolate.',
+        ),
+        ParameterNames.arguments: Schema.object(
+          description: 'Arguments for the method (optional).',
+          additionalProperties: true,
+        ),
+        ParameterNames.appUri: Schema.string(
+          description:
+              'The app URI to target. Required if multiple apps are connected.',
+        ),
+      },
+      required: [ParameterNames.method],
+      additionalProperties: false,
+    ),
+  )..categories = [FeatureCategory.dartToolingDaemon];
 
   static final _connectedAppsNotSupported = CallToolResult(
     isError: true,

--- a/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
@@ -1421,7 +1421,8 @@ base mixin DartToolingDaemonSupport
         ParameterNames.isolateId: Schema.string(
           description:
               'The isolate ID to target, you can find isolate IDs using the '
-              '`getVM` method.',
+              '`getVM` method. Only methods that require an isolate ID should '
+              'be given one.',
         ),
         ParameterNames.arguments: Schema.object(
           description: 'Arguments for the method (optional).',

--- a/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
@@ -1411,6 +1411,8 @@ base mixin DartToolingDaemonSupport
     description:
         'Invoke VM service methods on a connected app. See the Public RPCs '
         'section of '
+        // TODO: Make vm service self describing
+        // https://github.com/dart-lang/sdk/issues/63415
         'https://raw.githubusercontent.com/dart-lang/sdk/refs/heads/main/runtime/vm/service/service.md',
     annotations: ToolAnnotations(title: 'Invoke VM Service Method'),
     inputSchema: Schema.object(

--- a/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
@@ -289,7 +289,7 @@ base mixin DartToolingDaemonSupport
   Future<CallToolResult> _callVmServiceMethod(CallToolRequest request) async {
     // These are already validated to match the schema definition.
     final method = request.arguments?[ParameterNames.method] as String;
-    var isolateId = request.arguments?[ParameterNames.isolateId] as String?;
+    final isolateId = request.arguments?[ParameterNames.isolateId] as String?;
     final args =
         request.arguments?[ParameterNames.arguments] as Map<String, Object?>?;
     final appUri = request.arguments?[ParameterNames.appUri] as String?;
@@ -297,7 +297,6 @@ base mixin DartToolingDaemonSupport
     return _callOnVmService(
       appUri: appUri,
       callback: (vmService) async {
-        isolateId ??= (await vmService.getVM()).isolates?.firstOrNull?.id;
         try {
           final result = await vmService.callMethod(
             method,
@@ -1421,8 +1420,8 @@ base mixin DartToolingDaemonSupport
         ),
         ParameterNames.isolateId: Schema.string(
           description:
-              'The isolate ID to target (optional), defaults to the main '
-              'isolate.',
+              'The isolate ID to target, you can find isolate IDs using the '
+              '`getVM` method.',
         ),
         ParameterNames.arguments: Schema.object(
           description: 'Arguments for the method (optional).',

--- a/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
@@ -297,7 +297,7 @@ base mixin DartToolingDaemonSupport
     return _callOnVmService(
       appUri: appUri,
       callback: (vmService) async {
-        isolateId ??= (await vmService.getVM()).isolates!.first.id;
+        isolateId ??= (await vmService.getVM()).isolates?.firstOrNull?.id;
         try {
           final result = await vmService.callMethod(
             method,

--- a/pkgs/dart_mcp_server/lib/src/utils/analytics.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/analytics.dart
@@ -173,6 +173,7 @@ enum CallToolFailureReason {
   nonZeroExitCode,
   mustSpecifyDtdUri,
   processException,
+  rpcError,
   timeout,
   unhandledError,
   webSocketException,

--- a/pkgs/dart_mcp_server/lib/src/utils/names.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/names.dart
@@ -14,7 +14,9 @@ extension ParameterNames on Never {
   static const dtdUri = 'dtdUri';
   static const empty = 'empty';
   static const enabled = 'enabled';
+  static const isolateId = 'isolateId';
   static const line = 'line';
+  static const method = 'method';
   static const name = 'name';
   static const packageNames = 'packageNames';
   static const paths = 'paths';
@@ -47,6 +49,7 @@ enum ToolNames {
   getRuntimeErrors('get_runtime_errors'),
   hotReload('hot_reload'),
   hotRestart('hot_restart'),
+  callVmServiceMethod('call_vm_service_method'),
   launchApp('launch_app'),
   listDevices('list_devices'),
   listRunningApps('list_running_apps'),

--- a/pkgs/dart_mcp_server/test/test_harness.dart
+++ b/pkgs/dart_mcp_server/test/test_harness.dart
@@ -277,7 +277,10 @@ final class AppDebugSession {
       [
         'run',
         '--no${isFlutter ? '' : '-serve'}-devtools',
-        if (!isFlutter) '--enable-vm-service=0',
+        if (!isFlutter) ...[
+          '--enable-vm-service=0',
+          '--no-pause-isolates-on-start',
+        ],
         if (isFlutter) ...['-d', 'flutter-tester'],
         appPath,
         ...args,

--- a/pkgs/dart_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dtd_test.dart
@@ -1277,6 +1277,70 @@ void main() {
           await testHarness.stopDebugSession(debugSession);
         });
       });
+
+      test('can invoke VM service methods', () async {
+        final debugSession = await testHarness.startDebugSession(
+          dartCliAppsPath,
+          'bin/infinite_wait.dart',
+          isFlutter: false,
+        );
+        await debugSession.appProcess.stdout.next;
+
+        final result = await testHarness.callToolWithRetry(
+          CallToolRequest(
+            name: ToolNames.callVmServiceMethod.name,
+            arguments: {
+              ParameterNames.method: 'ext.test.echo',
+              ParameterNames.arguments: {'message': 'hello'},
+            },
+          ),
+        );
+
+        expect(result.isError, isNot(true));
+        final content =
+            jsonDecode((result.content.single as TextContent).text)
+                as Map<String, Object?>;
+        expect(content['method'], 'ext.test.echo');
+        expect(content['parameters'], containsPair('message', 'hello'));
+
+        debugSession.appProcess.stdin.writeln('q');
+        await testHarness.stopDebugSession(debugSession);
+      });
+
+      test('reports errors from VM service method calls', () async {
+        final debugSession = await testHarness.startDebugSession(
+          dartCliAppsPath,
+          'bin/infinite_wait.dart',
+          isFlutter: false,
+        );
+        await debugSession.appProcess.stdout.next;
+
+        final result = await testHarness.callToolWithRetry(
+          CallToolRequest(
+            name: ToolNames.callVmServiceMethod.name,
+            arguments: {
+              ParameterNames.method: 'ext.test.failure',
+              ParameterNames.arguments: {'message': 'hello'},
+            },
+          ),
+          expectError: true,
+          retryUntil: (r) =>
+              r.isError == true && r.content.single is TextContent
+              ? (r.content.single as TextContent).text.contains(
+                  'Something went wrong',
+                )
+              : false,
+        );
+
+        expect(result.isError, true);
+        final content = (result.content.single as TextContent).text;
+        expect(content, contains('RPCError'));
+        expect(content, contains('ext.test.failure'));
+        expect(content, contains('Something went wrong'));
+
+        debugSession.appProcess.stdin.writeln('q');
+        await testHarness.stopDebugSession(debugSession);
+      });
     });
 
     test('Does not include flutter tools with --tools=dart', () async {

--- a/pkgs/dart_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dtd_test.dart
@@ -1286,12 +1286,14 @@ void main() {
         );
         await debugSession.appProcess.stdout.next;
 
+        final isolateId = await _getIsolateId(testHarness);
         final result = await testHarness.callToolWithRetry(
           CallToolRequest(
             name: ToolNames.callVmServiceMethod.name,
             arguments: {
               ParameterNames.method: 'ext.test.echo',
               ParameterNames.arguments: {'message': 'hello'},
+              ParameterNames.isolateId: isolateId,
             },
           ),
         );
@@ -1315,12 +1317,14 @@ void main() {
         );
         await debugSession.appProcess.stdout.next;
 
+        final isolateId = await _getIsolateId(testHarness);
         final result = await testHarness.callToolWithRetry(
           CallToolRequest(
             name: ToolNames.callVmServiceMethod.name,
             arguments: {
               ParameterNames.method: 'ext.test.failure',
               ParameterNames.arguments: {'message': 'hello'},
+              ParameterNames.isolateId: isolateId,
             },
           ),
           expectError: true,
@@ -1481,4 +1485,19 @@ Future<void> _deleteWithRetry(Directory dir) async {
       await Future<void>.delayed(const Duration(milliseconds: 200));
     }
   }
+}
+
+Future<String> _getIsolateId(TestHarness testHarness) async {
+  final getVmResponse = await testHarness.callTool(
+    CallToolRequest(
+      name: ToolNames.callVmServiceMethod.name,
+      arguments: {ParameterNames.method: 'getVM'},
+    ),
+  );
+  final vmObject =
+      jsonDecode((getVmResponse.content.single as TextContent).text)
+          as Map<String, Object?>;
+  return ((vmObject['isolates'] as List<Object?>).first
+          as Map<String, Object?>)['id']
+      as String;
 }

--- a/pkgs/dart_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dtd_test.dart
@@ -1334,7 +1334,7 @@ void main() {
             ) =>
               msg.contains('Something went wrong'),
             _ => false,
-          }
+          },
         );
 
         expect(result.isError, true);

--- a/pkgs/dart_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dtd_test.dart
@@ -1298,7 +1298,6 @@ void main() {
           ),
         );
 
-        expect(result.isError, isNot(true));
         final content =
             jsonDecode((result.content.single as TextContent).text)
                 as Map<String, Object?>;
@@ -1328,12 +1327,14 @@ void main() {
             },
           ),
           expectError: true,
-          retryUntil: (r) =>
-              r.isError == true && r.content.single is TextContent
-              ? (r.content.single as TextContent).text.contains(
-                  'Something went wrong',
-                )
-              : false,
+          retryUntil: (r) => switch (r) {
+            CallToolResult(
+              isError: true,
+              content: [TextContent(text: final msg)],
+            ) =>
+              msg.contains('Something went wrong'),
+            _ => false,
+          }
         );
 
         expect(result.isError, true);
@@ -1494,10 +1495,12 @@ Future<String> _getIsolateId(TestHarness testHarness) async {
       arguments: {ParameterNames.method: 'getVM'},
     ),
   );
-  final vmObject =
-      jsonDecode((getVmResponse.content.single as TextContent).text)
-          as Map<String, Object?>;
-  return ((vmObject['isolates'] as List<Object?>).first
-          as Map<String, Object?>)['id']
-      as String;
+  if (getVmResponse case CallToolResult(
+    content: [TextContent(text: final text)],
+  )) {
+    if (jsonDecode(text) case {'isolates': [{'id': final String id}, ...]}) {
+      return id;
+    }
+  }
+  throw StateError('Failed to extract isolate ID from VM response');
 }

--- a/pkgs/dart_mcp_server/test_fixtures/dart_cli_app/bin/infinite_wait.dart
+++ b/pkgs/dart_mcp_server/test_fixtures/dart_cli_app/bin/infinite_wait.dart
@@ -2,9 +2,25 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
+import 'dart:developer';
 import 'dart:io';
 
 void main() async {
+  registerExtension('ext.test.echo', (method, parameters) async {
+    return ServiceExtensionResponse.result(
+      jsonEncode({'method': method, 'parameters': parameters}),
+    );
+  });
+
+  registerExtension('ext.test.failure', (method, parameters) async {
+    return ServiceExtensionResponse.error(
+      ServiceExtensionResponse.extensionError,
+      jsonEncode({'message': 'Something went wrong'}),
+    );
+  });
+  print('ready');
+
   stdin.listen((data) {
     if (String.fromCharCodes(data).trim() == 'q') exit(0);
   }, onDone: () => exit(0));


### PR DESCRIPTION
Adds a new tool `call_vm_service_method`, which takes an app uri, method name, isolate ID, and arguments, and returns the raw vm service response.

While low level, you can easily write various skills on top of this API to do things such as calling custom VM service methods (specific to a package or app), setting breakpoints, evaluating expressions, etc.

Ultimately it is a very powerful building block for arbitrary agent interactions, and anybody can write skills to guide agents through complex use cases.

Closes https://github.com/dart-lang/ai/issues/472