### PR TITLE
Graduate dart_mcp_server to be a published package

### DIFF
--- a/.github/workflows/dart_mcp_server.yaml
+++ b/.github/workflows/dart_mcp_server.yaml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         flutterSdk:
-          # - beta 
+          - beta
           - master
         os:
           - ubuntu-latest

--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.0.0-wip
+## 1.0.0-wip
 
 - Package is now shipped on pub instead of through the SDK. The
   `dart mcp-server` command will continue to work as an alias for
@@ -9,7 +9,7 @@
 - Add a tool for making arbitrary vm service method calls to connected apps.
 - Move binary to `bin/dart_mcp_server.dart` to be compatible with dart run.
 
-# 0.1.3 (Dart SDK 3.12.0)
+## 0.1.3 (Dart SDK 3.12.0)
 
 - Add additional analytics for initialization events, and various list\* method
   calls. This will help understand how the server is being used by different
@@ -60,7 +60,7 @@
 - Enable `set_semantics` command for flutter_driver.
 - Add `listDtdUris` subcommand for the `dtd` tool.
 
-# 0.1.2 (Dart SDK 3.11.0)
+## 0.1.2 (Dart SDK 3.11.0)
 
 - Add `--tools=dart|all` argument to allow enabling only vanilla Dart tools for
   non-flutter projects.
@@ -77,7 +77,7 @@
 - Fix the `timeout` parameter for the flutter_driver tool to be a String,
   matching the underlying expected type (issue #330).
 
-# 0.1.1 (Dart SDK 3.10.0)
+## 0.1.1 (Dart SDK 3.10.0)
 
 - Change tools that accept multiple roots to not return immediately on the first
   failure.
@@ -105,7 +105,7 @@
   than just screenshots.
 - Mark the "root" parameter for `create_project` required.
 
-# 0.1.0 (Dart SDK 3.9.0)
+## 0.1.0 (Dart SDK 3.9.0)
 
 - Add documentation/homepage/repository links to pub results.
 - Handle relative paths under roots without trailing slashes.

--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -1,5 +1,8 @@
-# 0.1.4 (Dart SDK 3.13.0-WIP)
+# 1.0.0-wip
 
+- Package is now shipped on pub instead of through the SDK. The
+  `dart mcp-server` command will continue to work as an alias for
+  `dart run dart_mcp_server@`.
 - Support reading `DART_ROOT` environment variable to set the Dart SDK root.
 - Always enable roots fallback, and merge them with client roots that are set
   (if any).

--- a/pkgs/dart_mcp_server/lib/src/mixins/roots_fallback_support.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/roots_fallback_support.dart
@@ -54,7 +54,7 @@ base mixin RootsFallbackSupport on ToolsSupport, RootsTrackingSupport {
       StreamController<RootsListChangedNotification?>.broadcast();
 
   @override
-  FutureOr<InitializeResult> initialize(InitializeRequest request) async {
+  FutureOr<InitializeResult> initialize(InitializeRequest request) {
     try {
       return super.initialize(request);
     } finally {

--- a/pkgs/dart_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_mcp_server/lib/src/server.dart
@@ -109,8 +109,8 @@ package.
 
   /// The version of the MCP server.
   ///
-  /// Should match the version in the CHANGELOG.md.
-  static final version = '0.1.4';
+  /// Should match the version in `pubspec.yaml` and `CHANGELOG.md`.
+  static final version = '1.0.0-wip';
 
   /// Runs the MCP server given command line arguments and an optional
   /// [Analytics] instance.

--- a/pkgs/dart_mcp_server/pubspec.yaml
+++ b/pkgs/dart_mcp_server/pubspec.yaml
@@ -2,9 +2,9 @@ name: dart_mcp_server
 description: >-
   An MCP server for Dart projects, exposing various developer tools to AI
   models.
-publish_to: none
+version: 1.0.0-wip
 environment:
-  sdk: ^3.12.0-257.0.dev
+  sdk: ^3.12.0
 
 dependencies:
   args: ^2.7.0
@@ -18,8 +18,9 @@ dependencies:
   file: ^7.0.1
   http: ^1.3.0
   json_rpc_2: ^4.0.0
-  # TODO: Get this another way.
+  # TODO(https://github.com/dart-lang/ai/issues/477): Get this another way.
   language_server_protocol:
+    # ignore: invalid_dependency
     git:
       url: https://github.com/dart-lang/sdk.git
       path: third_party/pkg/language_server_protocol


### PR DESCRIPTION
Before we can actually publish, we will have to resolve https://github.com/dart-lang/ai/issues/484.

Closes https://github.com/dart-lang/ai/issues/482