### PR TITLE
normalize roots so they always have a scheme

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.2
+
+- Update `listRoots` to normalize URIs to file: scheme variants when given raw
+  file paths. This fixes non-spec compliant clients.
+
 ## 0.5.1
 
 - Always send a properties object for tool input schemas, see

--- a/pkgs/dart_mcp/lib/src/server/roots_tracking_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/roots_tracking_support.dart
@@ -66,6 +66,9 @@ base mixin RootsTrackingSupport on LoggingSupport {
 
   /// Updates the list of [roots] by calling [listRoots].
   ///
+  /// Normalizes file paths to file: URIs to handle clients which do not
+  /// follow the spec exactly.
+  ///
   /// If the current [_rootsCompleter] was not yet completed, then we wait to
   /// complete it until we get an updated list of roots, so that we don't get
   /// stale results from [listRoots] requests that are still in flight during
@@ -94,7 +97,34 @@ base mixin RootsTrackingSupport on LoggingSupport {
       // Only complete the completer if it's still the one we created. Otherwise
       // we wait for the next result to come back and throw away this result.
       if (_rootsCompleter == newCompleter) {
-        final roots = result == null ? <Root>[] : result.roots;
+        final roots =
+            (result == null ? <Root>[] : result.roots)
+                .map<Root?>((root) {
+                  // Some clients just give file paths, but the spec states they
+                  // should be file: URIs. This converts paths to file: URIs to
+                  // paper over that issue.
+                  final parsedUri = Uri.tryParse(root.uri);
+                  if (parsedUri == null) {
+                    log(
+                      LoggingLevel.warning,
+                      'Invalid root given from client ${root.uri}',
+                    );
+                    return null;
+                  }
+                  // No scheme or the scheme actually looks like a windows drive
+                  // letter, convert it to a file: URI.
+                  if (!parsedUri.hasScheme || parsedUri.scheme.length == 1) {
+                    return Root(
+                      uri: Uri.file(root.uri).toString(),
+                      name: root.name,
+                    );
+                  }
+                  return root;
+                })
+                // `.nonNulls` gives us a type of Object here due to the
+                // extension types, so we use `whereType` instead
+                .whereType<Root>()
+                .toList();
         newCompleter.complete(roots);
         _roots = roots;
         _rootsCompleter = null;

--- a/pkgs/dart_mcp/pubspec.yaml
+++ b/pkgs/dart_mcp/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_mcp
-version: 0.5.1
+version: 0.5.2
 description: A package for making MCP servers and clients.
 repository: https://github.com/dart-lang/ai/tree/main/pkgs/dart_mcp
 issue_tracker: https://github.com/dart-lang/ai/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Adart_mcp

--- a/pkgs/dart_mcp/test/server/roots_tracking_support_test.dart
+++ b/pkgs/dart_mcp/test/server/roots_tracking_support_test.dart
@@ -10,16 +10,21 @@ import 'package:test/test.dart';
 import '../test_utils.dart';
 
 void main() {
-  test('server can track the workspace roots if enabled', () async {
+  late TestMCPClientWithRoots client;
+  late TestMCPServerWithRootsTracking server;
+
+  setUp(() async {
     final environment = TestEnvironment(
       TestMCPClientWithRoots(),
       TestMCPServerWithRootsTracking.new,
     );
     await environment.initializeServer();
 
-    final client = environment.client;
-    final server = environment.server;
+    client = environment.client;
+    server = environment.server;
+  });
 
+  test('server can track the workspace roots if enabled', () async {
     final a = Root(uri: 'test://a', name: 'a');
     final b = Root(uri: 'test://b', name: 'b');
 
@@ -56,6 +61,41 @@ void main() {
     client.waitToRespond = null;
     expect(await server.roots, unorderedEquals([b, c, d]));
   });
+
+  test('server normalizes absolute paths to file URIs', () async {
+    // Unix style absolute path
+    final unixRoot = Root(uri: '/Users/demo/todo', name: 'unix');
+    client.addRoot(unixRoot);
+    await pumpEventQueue();
+
+    final roots = await server.roots;
+    expect(roots.length, 1);
+    expect(roots.first.uri, 'file:///Users/demo/todo');
+    expect(roots.first.name, 'unix');
+  });
+
+  test('server normalizes windows drive letter paths to file URIs', () async {
+    // Windows style absolute path
+    final windowsRoot = Root(uri: r'C:\Users\demo\todo', name: 'windows');
+    client.addRoot(windowsRoot);
+    await pumpEventQueue();
+
+    var roots = await server.roots;
+    expect(roots.length, 1);
+    expect(roots.first.uri, 'file:///C:/Users/demo/todo');
+    expect(roots.first.name, 'windows');
+    client.removeRoot(windowsRoot);
+
+    // Existing file:// URIs should pass through untouched
+    final fileRoot = Root(uri: 'file:///C:/Users/demo/todo', name: 'file_uri');
+    client.addRoot(fileRoot);
+    await pumpEventQueue();
+
+    roots = await server.roots;
+    expect(roots.length, 1);
+    expect(roots.first.uri, 'file:///C:/Users/demo/todo');
+    expect(roots.first.name, 'file_uri');
+  }, testOn: 'windows');
 }
 
 final class TestMCPClientWithRoots extends TestMCPClient with RootsSupport {

--- a/pkgs/dart_mcp/test/server/roots_tracking_support_test.dart
+++ b/pkgs/dart_mcp/test/server/roots_tracking_support_test.dart
@@ -95,7 +95,7 @@ void main() {
     expect(roots.length, 1);
     expect(roots.first.uri, 'file:///C:/Users/demo/todo');
     expect(roots.first.name, 'file_uri');
-  }, testOn: 'windows');
+  }, testOn: 'windows && vm');
 }
 
 final class TestMCPClientWithRoots extends TestMCPClient with RootsSupport {

--- a/pkgs/dart_mcp_server/pubspec.yaml
+++ b/pkgs/dart_mcp_server/pubspec.yaml
@@ -47,3 +47,7 @@ dev_dependencies:
 
 executables:
   dart_mcp_server: dart_mcp_server
+
+dependency_overrides:
+  dart_mcp:
+    path: ../dart_mcp

--- a/pkgs/dart_mcp_server/test/tools/analyzer_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/analyzer_test.dart
@@ -120,6 +120,52 @@ void main() {
       );
     });
 
+    test('can analyze a project when roots use schemeless paths (Cursor '
+        'regression #506)', () async {
+      final example = d.dir('example', [
+        d.file('main.dart', 'void main() => 1 + "2";'),
+      ]);
+      await example.create();
+
+      // Instead of file:// URI, use the raw absolute path as the client root.
+      final schemelessRoot = Root(uri: example.io.path, name: 'example');
+      testHarness.mcpClient.addRoot(schemelessRoot);
+
+      await pumpEventQueue();
+
+      final request = CallToolRequest(
+        name: analyzeTool.name,
+        arguments: {
+          ParameterNames.roots: [
+            {
+              // Request uses file:// uri which doesn't match the root as
+              // provided in roots/list, but should normalize to the same URI.
+              ParameterNames.root: Uri.file(example.io.path).toString(),
+            },
+          ],
+        },
+      );
+      final result = await testHarness.callTool(request);
+      expect(result.isError, isNot(true));
+
+      final expectedUri = Uri.file(example.io.path).toString();
+      expect(result.content, [
+        isA<TextContent>().having(
+          (t) => t.text,
+          'text',
+          contains('# Diagnostics for root $expectedUri'),
+        ),
+        isA<TextContent>().having(
+          (t) => t.text,
+          'text',
+          contains(
+            "error • main.dart:1:20 • The argument type 'String' can't be "
+            "assigned to the parameter type 'num'.",
+          ),
+        ),
+      ]);
+    });
+
     test('can analyze a specific file', () async {
       final example = d.dir('example', [
         d.file('main.dart', 'void main() => 1 + "2";'),


### PR DESCRIPTION
Fixes https://github.com/dart-lang/ai/issues/506.

Some clients (such as Cursor) may give a file path for roots, which violates the spec (which specifies `file:` roots only). However we can still gracefully handle this.

Exactly why this was timing out is a separate issue though, I think we are likely just swallowing errors from a zone, and then never returning them as errors.