### PR TITLE
try using package:test version 1.30.0 to avoid test hangs on exit

### DIFF
--- a/pkgs/dart_mcp/pubspec.yaml
+++ b/pkgs/dart_mcp/pubspec.yaml
@@ -17,4 +17,5 @@ dependencies:
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.2.1
+  # TODO: Remove upper bound https://github.com/dart-lang/test/issues/2688
   test: '>=1.25.15 <1.31.0'

--- a/pkgs/dart_mcp/pubspec.yaml
+++ b/pkgs/dart_mcp/pubspec.yaml
@@ -17,4 +17,4 @@ dependencies:
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.2.1
-  test: ^1.25.15
+  test: '>=1.25.15 <1.31.0'


### PR DESCRIPTION
We have been seeing issues with the test runner not exiting, ever since package:test 1.31.0 was released. Specifically this is just on windows, and just for the dart_mcp package.

Trying with the old version to see if that fixes things for now.