### PR TITLE
allow connecting directly to vm service URIs

### DIFF
--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.0-wip
+
+- Create vm_service meta tool, which allows direct connections to apps via vm
+  service URIs, and also handles the direct vm service method calls.
+
 ## 1.0.2
 
 - Send a SIGKILL to the analysis server if it doesn't respond to a SIGTERM in

--- a/pkgs/dart_mcp_server/README.md
+++ b/pkgs/dart_mcp_server/README.md
@@ -178,7 +178,6 @@ available to the agent. For example, in a GEMINI.md file in your project:
 | Tool Name | Title | Description | Categories | Enabled |
 | --- | --- | --- | --- | --- |
 | `analyze_files` | Analyze projects | Analyzes specific paths, or the entire project, for errors. | analysis | Yes |
-| `call_vm_service_method` | Invoke VM Service Method | Invoke VM service methods on a connected app. See the Public RPCs section of https://raw.githubusercontent.com/dart-lang/sdk/refs/heads/main/runtime/vm/service/service.md | dart_tooling_daemon | Yes |
 | `create_project` | Create project | Creates a new Dart or Flutter project. | cli | No |
 | `dart_fix` | Dart fix | Runs `dart fix --apply` for the given project roots. | cli | No |
 | `dart_format` | Dart format | Runs `dart format .` for the given project roots. | cli | No |
@@ -200,6 +199,7 @@ available to the agent. For example, in a GEMINI.md file in your project:
 | `roots` |  | Manage project roots. | None | Yes |
 | `run_tests` | Run tests | Run Dart or Flutter tests with an agent centric UX. ALWAYS use instead of `dart test` or `flutter test` shell commands. | cli | No |
 | `stop_app` |  | Kills a running Flutter process started by the launch_app tool. | flutter, flutter_app_lifecycle | No |
+| `vm_service` | VM Service | Manage and interact with VM service connections. This tool allows you to connect to an app using its VM service URI, disconnect from it, or invoke VM service methods directly. Connecting allows features like hot reload to work on apps not launched via DTD. | dart_tooling_daemon | Yes |
 | `widget_inspector` | Widget Inspector | Interact with the Flutter widget inspector in the active Flutter application. Requires an active DTD connection. | flutter | Yes |
 
 <!-- generated -->

--- a/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
@@ -122,6 +122,58 @@ base mixin DartToolingDaemonSupport
     debugAwaitVmServiceDisposal ? await future : unawaited(future);
   }
 
+  /// Connects to [vmServiceUri] and adds it to the [activeVmServices].
+  Future<void> _addVmService(String vmServiceUri, {String? name}) async {
+    final vmServiceFuture = activeVmServices[vmServiceUri] =
+        vmServiceConnectUri(vmServiceUri);
+    final vmService = await vmServiceFuture;
+    // Start listening for and collecting errors immediately.
+    final errorService = await _AppListener.forVmService(vmService, this);
+    final resource = Resource(
+      uri: '$runtimeErrorsScheme://${vmService.id}',
+      name: 'Errors for app ${name ?? vmServiceUri}',
+      description:
+          'Recent runtime errors seen for app "${name ?? vmServiceUri}".',
+    );
+    addResource(resource, (request) async {
+      final watch = Stopwatch()..start();
+      final result = ReadResourceResult(
+        contents: [
+          for (var error in errorService.errorLog.errors)
+            TextResourceContents(uri: resource.uri, text: error),
+        ],
+      );
+      watch.stop();
+      try {
+        analytics?.send(
+          ua.Event.dartMCPEvent(
+            client: clientInfo.name,
+            clientVersion: clientInfo.version,
+            serverVersion: implementation.version,
+            type: AnalyticsEvent.readResource.name,
+            additionalData: ReadResourceMetrics(
+              kind: ResourceKind.runtimeErrors,
+              length: result.contents.length,
+              elapsedMilliseconds: watch.elapsedMilliseconds,
+            ),
+          ),
+        );
+      } catch (e) {
+        log(LoggingLevel.warning, 'Error sending analytics event: $e');
+      }
+      return result;
+    });
+    try {
+      errorService.errorsStream.listen((_) => updateResource(resource));
+    } catch (_) {}
+    unawaited(
+      vmService.onDone.then((_) {
+        removeResource(resource.uri);
+        activeVmServices.remove(vmServiceUri);
+      }),
+    );
+  }
+
   /// Updates the list of active VM services based on the connected apps in DTD.
   ///
   /// Returns the list of all VM service URIs that are currently connected to
@@ -143,54 +195,7 @@ base mixin DartToolingDaemonSupport
 
       dtd.vmServiceUris.add(vmServiceUri);
 
-      final vmServiceFuture = activeVmServices[vmServiceUri] =
-          vmServiceConnectUri(vmServiceUri);
-      final vmService = await vmServiceFuture;
-      // Start listening for and collecting errors immediately.
-      final errorService = await _AppListener.forVmService(vmService, this);
-      final resource = Resource(
-        uri: '$runtimeErrorsScheme://${vmService.id}',
-        name: 'Errors for app ${vmServiceInfo.name}',
-        description:
-            'Recent runtime errors seen for app "${vmServiceInfo.name}".',
-      );
-      addResource(resource, (request) async {
-        final watch = Stopwatch()..start();
-        final result = ReadResourceResult(
-          contents: [
-            for (var error in errorService.errorLog.errors)
-              TextResourceContents(uri: resource.uri, text: error),
-          ],
-        );
-        watch.stop();
-        try {
-          analytics?.send(
-            ua.Event.dartMCPEvent(
-              client: clientInfo.name,
-              clientVersion: clientInfo.version,
-              serverVersion: implementation.version,
-              type: AnalyticsEvent.readResource.name,
-              additionalData: ReadResourceMetrics(
-                kind: ResourceKind.runtimeErrors,
-                length: result.contents.length,
-                elapsedMilliseconds: watch.elapsedMilliseconds,
-              ),
-            ),
-          );
-        } catch (e) {
-          log(LoggingLevel.warning, 'Error sending analytics event: $e');
-        }
-        return result;
-      });
-      try {
-        errorService.errorsStream.listen((_) => updateResource(resource));
-      } catch (_) {}
-      unawaited(
-        vmService.onDone.then((_) {
-          removeResource(resource.uri);
-          activeVmServices.remove(vmServiceUri);
-        }),
-      );
+      await _addVmService(vmServiceUri, name: vmServiceInfo.name);
     }
     return vmServiceInfos;
   }
@@ -204,7 +209,7 @@ base mixin DartToolingDaemonSupport
     registerTool(hotReloadTool, hotReload);
     registerTool(widgetInspectorTool, _widgetInspector);
     registerTool(flutterDriverTool, _callFlutterDriver);
-    registerTool(callVmServiceMethodTool, _callVmServiceMethod);
+    registerTool(vmServiceTool, _vmService);
 
     return super.initialize(request);
   }
@@ -218,7 +223,7 @@ base mixin DartToolingDaemonSupport
     hotReloadTool,
     widgetInspectorTool,
     flutterDriverTool,
-    callVmServiceMethodTool,
+    vmServiceTool,
   ];
 
   @override
@@ -492,11 +497,12 @@ base mixin DartToolingDaemonSupport
   }
 
   Future<CallToolResult> _listConnectedApps(CallToolRequest request) async {
-    if (_dtds.isEmpty) return _dtdNotConnected;
+    if (activeVmServices.isEmpty) return _noActiveDebugSession;
     final textResult = <TextContent>[];
     // Connected app info by DTD uri.
     final structuredResult = <String, List<Map<String, Object?>>>{};
 
+    final loggedAppUris = <String>{};
     for (final dtd in _dtds) {
       final vmServiceInfos = await updateActiveVmServices(dtd);
       final appsDescription = vmServiceInfos.isEmpty
@@ -509,6 +515,22 @@ base mixin DartToolingDaemonSupport
       structuredResult[dtd.uri.toString()] = vmServiceInfos
           .map((a) => a.toJson())
           .toList();
+      for (var info in vmServiceInfos) {
+        loggedAppUris.add(info.uri);
+      }
+    }
+
+    // Include other apps as well that are not associated with a DTD isntance.
+    final standaloneApps = activeVmServices.keys.where(
+      (uri) => !loggedAppUris.contains(uri),
+    );
+    if (standaloneApps.isNotEmpty) {
+      structuredResult['standalone'] = [
+        for (final uri in standaloneApps) VmServiceInfo(uri: uri).toJson(),
+      ];
+      textResult.add(
+        TextContent(text: '## Standlone Apps:\n${standaloneApps.join('\n')}\n'),
+      );
     }
 
     return CallToolResult(
@@ -970,21 +992,23 @@ base mixin DartToolingDaemonSupport
     required Future<CallToolResult> Function(VmService) callback,
     String? appUri,
   }) async {
-    if (_dtds.isEmpty) return _dtdNotConnected;
-    if (!_dtds.any((dtd) => dtd.supportsConnectedApps)) {
-      return _connectedAppsNotSupported;
-    }
-
-    // Update active vm services for all connected DTDs, if we no active ones
-    // or if the requested appUri is not in the active vm services.
+    // Update active vm services for all connected DTDs, if we have no active
+    // ones or if the requested appUri is not in the active vm services.
     if (activeVmServices.isEmpty ||
         (appUri != null && !activeVmServices.containsKey(appUri))) {
       for (final dtd in _dtds) {
-        await updateActiveVmServices(dtd);
+        if (dtd.supportsConnectedApps) {
+          await updateActiveVmServices(dtd);
+        }
       }
     }
 
-    if (activeVmServices.isEmpty) return _noActiveDebugSession;
+    if (activeVmServices.isEmpty) {
+      if (_dtds.isNotEmpty && !_dtds.any((dtd) => dtd.supportsConnectedApps)) {
+        return _connectedAppsNotSupported;
+      }
+      return _noActiveDebugSession;
+    }
 
     final String selectedAppUri;
     if (appUri != null) {
@@ -1406,19 +1430,33 @@ base mixin DartToolingDaemonSupport
         ..enabledByDefault = false;
 
   @visibleForTesting
-  static final callVmServiceMethodTool = Tool(
-    name: ToolNames.callVmServiceMethod.name,
+  static final vmServiceTool = Tool(
+    name: ToolNames.vmService.name,
     description:
-        'Invoke VM service methods on a connected app. See the Public RPCs '
-        'section of '
-        // TODO: Make vm service self describing
-        // https://github.com/dart-lang/sdk/issues/63415
-        'https://raw.githubusercontent.com/dart-lang/sdk/refs/heads/main/runtime/vm/service/service.md',
-    annotations: ToolAnnotations(title: 'Invoke VM Service Method'),
+        'Manage and interact with VM service connections. This tool '
+        'allows you to connect to an app using its VM service URI, disconnect '
+        'from it, or invoke VM service methods directly. Connecting allows '
+        'features like hot reload to work on apps not launched via DTD.',
+    annotations: ToolAnnotations(title: 'VM Service'),
     inputSchema: Schema.object(
       properties: {
+        ParameterNames.command: EnumSchema.untitledSingleSelect(
+          description: 'The command to execute.',
+          values: [
+            VmServiceCommand.connect,
+            VmServiceCommand.disconnect,
+            VmServiceCommand.callMethod,
+          ],
+        ),
+        ParameterNames.appUri: Schema.string(
+          description:
+              'The app URI (vm service URI) to target. Required if multiple '
+              'apps are connected, or when connecting or disconnecting.',
+        ),
         ParameterNames.method: Schema.string(
-          description: 'The name of the method to invoke.',
+          description:
+              'The name of the vm service method to invoke. Required for '
+              'callMethod.',
         ),
         ParameterNames.isolateId: Schema.string(
           description:
@@ -1430,15 +1468,82 @@ base mixin DartToolingDaemonSupport
           description: 'Arguments for the method (optional).',
           additionalProperties: true,
         ),
-        ParameterNames.appUri: Schema.string(
-          description:
-              'The app URI to target. Required if multiple apps are connected.',
-        ),
       },
-      required: [ParameterNames.method],
+      required: [ParameterNames.command],
       additionalProperties: false,
     ),
   )..categories = [FeatureCategory.dartToolingDaemon];
+
+  Future<CallToolResult> _vmService(CallToolRequest request) async {
+    final command = request.arguments![ParameterNames.command] as String;
+    final uriString = request.arguments?[ParameterNames.appUri] as String?;
+    switch (command) {
+      case VmServiceCommand.connect:
+        if (uriString == null) {
+          return CallToolResult(
+            isError: true,
+            content: [
+              TextContent(text: 'No URI provided for connect command.'),
+            ],
+          )..failureReason = CallToolFailureReason.argumentError;
+        }
+        if (activeVmServices.containsKey(uriString)) {
+          return CallToolResult(
+            content: [TextContent(text: 'Already connected to $uriString.')],
+          );
+        }
+        try {
+          await _addVmService(uriString);
+          return CallToolResult(
+            content: [
+              TextContent(text: 'Successfully connected to $uriString.'),
+            ],
+          );
+        } catch (e) {
+          return CallToolResult(
+            isError: true,
+            content: [TextContent(text: 'Failed to connect: $e')],
+          )..failureReason = CallToolFailureReason.unhandledError;
+        }
+
+      case VmServiceCommand.disconnect:
+        final vmServiceFuture = activeVmServices.remove(uriString);
+        if (vmServiceFuture == null) {
+          return CallToolResult(
+            isError: true,
+            content: [TextContent(text: 'Not connected to $uriString.')],
+          );
+        }
+        try {
+          final vmService = await vmServiceFuture;
+          await vmService.dispose();
+          return CallToolResult(
+            content: [TextContent(text: 'Disconnected from $uriString.')],
+          );
+        } catch (e) {
+          return CallToolResult(
+            isError: true,
+            content: [TextContent(text: 'Error disconnecting: $e')],
+          )..failureReason = CallToolFailureReason.unhandledError;
+        }
+
+      case VmServiceCommand.callMethod:
+        final method = request.arguments?[ParameterNames.method] as String?;
+        if (method == null) {
+          return CallToolResult(
+            isError: true,
+            content: [TextContent(text: 'No method provided for callMethod.')],
+          )..failureReason = CallToolFailureReason.argumentError;
+        }
+        return _callVmServiceMethod(request);
+
+      default:
+        return CallToolResult(
+          isError: true,
+          content: [TextContent(text: 'Unknown command: $command')],
+        );
+    }
+  }
 
   static final _connectedAppsNotSupported = CallToolResult(
     isError: true,
@@ -1498,10 +1603,8 @@ base mixin DartToolingDaemonSupport
       Content.text(
         text:
             'Connected to a VM Service but expected to connect to a Dart '
-            'Tooling Daemon service. When launching apps from an IDE you '
-            'should have a "Copy DTD URI to clipboard" command pallete option, '
-            'or when directly launching apps from a terminal you can pass the '
-            '"--print-dtd" command line option in order to get the DTD URI.',
+            'Tooling Daemon service. Use the '
+            '${vmServiceTool.name}.${VmServiceCommand.connect} tool instead.',
       ),
     ],
     isError: true,
@@ -1775,6 +1878,12 @@ extension DtdCommand on Never {
   static const disconnect = 'disconnect';
   static const listConnectedApps = 'listConnectedApps';
   static const listDtdUris = 'listDtdUris';
+}
+
+extension VmServiceCommand on Never {
+  static const connect = 'connect';
+  static const disconnect = 'disconnect';
+  static const callMethod = 'callMethod';
 }
 
 extension on VmServiceInfo {

--- a/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
@@ -124,13 +124,13 @@ base mixin DartToolingDaemonSupport
 
   /// Connects to [vmServiceUri] and adds it to the [activeVmServices].
   Future<void> _addVmService(String vmServiceUri, {String? name}) async {
-    final vmServiceFuture = activeVmServices[vmServiceUri] = 
+    final vmServiceFuture = activeVmServices[vmServiceUri] =
         vmServiceConnectUri(vmServiceUri);
     final VmService vmService;
     try {
       vmService = await vmServiceFuture;
     } catch (e) {
-      activeVmServices.remove(vmServiceUri);
+      unawaited(activeVmServices.remove(vmServiceUri));
       rethrow;
     }
     // Start listening for and collecting errors immediately.
@@ -199,9 +199,15 @@ base mixin DartToolingDaemonSupport
         continue;
       }
 
-      dtd.vmServiceUris.add(vmServiceUri);
-
-      await _addVmService(vmServiceUri, name: vmServiceInfo.name);
+      try {
+        await _addVmService(vmServiceUri, name: vmServiceInfo.name);
+        dtd.vmServiceUris.add(vmServiceUri);
+      } catch (e) {
+        log(
+          LoggingLevel.warning,
+          'Failed to connect to VM service at $vmServiceUri: $e',
+        );
+      }
     }
     return vmServiceInfos;
   }
@@ -526,7 +532,7 @@ base mixin DartToolingDaemonSupport
       }
     }
 
-    // Include other apps as well that are not associated with a DTD isntance.
+    // Include other apps as well that are not associated with a DTD instance.
     final standaloneApps = activeVmServices.keys.where(
       (uri) => !loggedAppUris.contains(uri),
     );
@@ -535,7 +541,9 @@ base mixin DartToolingDaemonSupport
         for (final uri in standaloneApps) VmServiceInfo(uri: uri).toJson(),
       ];
       textResult.add(
-        TextContent(text: '## Standlone Apps:\n${standaloneApps.join('\n')}\n'),
+        TextContent(
+          text: '## Standalone Apps:\n${standaloneApps.join('\n')}\n',
+        ),
       );
     }
 
@@ -1513,6 +1521,14 @@ base mixin DartToolingDaemonSupport
         }
 
       case VmServiceCommand.disconnect:
+        if (uriString == null) {
+          return CallToolResult(
+            isError: true,
+            content: [
+              TextContent(text: 'No URI provided for connect command.'),
+            ],
+          )..failureReason = CallToolFailureReason.argumentError;
+        }
         final vmServiceFuture = activeVmServices.remove(uriString);
         if (vmServiceFuture == null) {
           return CallToolResult(

--- a/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
@@ -124,9 +124,15 @@ base mixin DartToolingDaemonSupport
 
   /// Connects to [vmServiceUri] and adds it to the [activeVmServices].
   Future<void> _addVmService(String vmServiceUri, {String? name}) async {
-    final vmServiceFuture = activeVmServices[vmServiceUri] =
+    final vmServiceFuture = activeVmServices[vmServiceUri] = 
         vmServiceConnectUri(vmServiceUri);
-    final vmService = await vmServiceFuture;
+    final VmService vmService;
+    try {
+      vmService = await vmServiceFuture;
+    } catch (e) {
+      activeVmServices.remove(vmServiceUri);
+      rethrow;
+    }
     // Start listening for and collecting errors immediately.
     final errorService = await _AppListener.forVmService(vmService, this);
     final resource = Resource(

--- a/pkgs/dart_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_mcp_server/lib/src/server.dart
@@ -110,7 +110,7 @@ package.
   /// The version of the MCP server.
   ///
   /// Should match the version in `pubspec.yaml` and `CHANGELOG.md`.
-  static final version = '1.0.2';
+  static final version = '1.1.0-wip';
 
   /// Runs the MCP server given command line arguments and an optional
   /// [Analytics] instance.

--- a/pkgs/dart_mcp_server/lib/src/utils/names.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/names.dart
@@ -49,7 +49,6 @@ enum ToolNames {
   getRuntimeErrors('get_runtime_errors'),
   hotReload('hot_reload'),
   hotRestart('hot_restart'),
-  callVmServiceMethod('call_vm_service_method'),
   launchApp('launch_app'),
   listDevices('list_devices'),
   listRunningApps('list_running_apps'),
@@ -61,6 +60,7 @@ enum ToolNames {
   roots('roots'),
   runTests('run_tests'),
   stopApp('stop_app'),
+  vmService('vm_service'),
   widgetInspector('widget_inspector');
 
   final String name;

--- a/pkgs/dart_mcp_server/pubspec.yaml
+++ b/pkgs/dart_mcp_server/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/dart-lang/ai/tree/main/pkgs/dart_mcp_server
 issue_tracker: https://github.com/dart-lang/ai/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Adart_mcp_server
 
 # NOTE: Must also update version in pkgs/dart_mcp_server/lib/src/server.dart
-version: 1.0.2
+version: 1.1.0-wip
 
 environment:
   sdk: ^3.12.0

--- a/pkgs/dart_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dtd_test.dart
@@ -1289,8 +1289,9 @@ void main() {
         final isolateId = await _getIsolateId(testHarness);
         final result = await testHarness.callToolWithRetry(
           CallToolRequest(
-            name: ToolNames.callVmServiceMethod.name,
+            name: ToolNames.vmService.name,
             arguments: {
+              ParameterNames.command: 'callMethod',
               ParameterNames.method: 'ext.test.echo',
               ParameterNames.arguments: {'message': 'hello'},
               ParameterNames.isolateId: isolateId,
@@ -1319,8 +1320,9 @@ void main() {
         final isolateId = await _getIsolateId(testHarness);
         final result = await testHarness.callToolWithRetry(
           CallToolRequest(
-            name: ToolNames.callVmServiceMethod.name,
+            name: ToolNames.vmService.name,
             arguments: {
+              ParameterNames.command: 'callMethod',
               ParameterNames.method: 'ext.test.failure',
               ParameterNames.arguments: {'message': 'hello'},
               ParameterNames.isolateId: isolateId,
@@ -1447,6 +1449,88 @@ void main() {
     final retryResult = await testHarness.connectToDtd();
     expect(retryResult.isError, isNot(true));
   });
+
+  group('vmService tools', () {
+    test('can connect and disconnect directly to a VM service URI', () async {
+      final testHarness = await TestHarness.start(inProcess: true);
+      final debugSession = await testHarness.startDebugSession(
+        dartCliAppsPath,
+        'bin/infinite_wait.dart',
+        isFlutter: false,
+      );
+      await debugSession.appProcess.stdout.next;
+
+      // Connect
+      final connectResult = await testHarness.callTool(
+        CallToolRequest(
+          name: ToolNames.vmService.name,
+          arguments: {
+            ParameterNames.command: 'connect',
+            ParameterNames.appUri: debugSession.vmServiceUri.toString(),
+          },
+        ),
+      );
+
+      expect(connectResult.isError, isNot(true));
+      expect(
+        (connectResult.content.first as TextContent).text,
+        contains('Successfully connected'),
+      );
+
+      // Verify we can call a method (since it populates activeVmServices)
+      final isolateId = await _getIsolateId(testHarness);
+      final callResult = await testHarness.callToolWithRetry(
+        CallToolRequest(
+          name: ToolNames.vmService.name,
+          arguments: {
+            ParameterNames.command: 'callMethod',
+            ParameterNames.method: 'ext.test.echo',
+            ParameterNames.arguments: {'message': 'ping'},
+            ParameterNames.isolateId: isolateId,
+          },
+        ),
+      );
+      expect(callResult.isError, isNot(true));
+
+      // Disconnect
+      final disconnectResult = await testHarness.callTool(
+        CallToolRequest(
+          name: ToolNames.vmService.name,
+          arguments: {
+            ParameterNames.command: 'disconnect',
+            ParameterNames.appUri: debugSession.vmServiceUri.toString(),
+          },
+        ),
+      );
+      expect(disconnectResult.isError, isNot(true));
+      expect(
+        (disconnectResult.content.first as TextContent).text,
+        contains('Disconnected from'),
+      );
+
+      // Calling a method after disconnect should fail
+      final failResult = await testHarness.callToolWithRetry(
+        CallToolRequest(
+          name: ToolNames.vmService.name,
+          arguments: {
+            ParameterNames.command: 'callMethod',
+            ParameterNames.method: 'ext.test.echo',
+            ParameterNames.arguments: {'message': 'ping'},
+            ParameterNames.isolateId: isolateId,
+          },
+        ),
+        expectError: true,
+      );
+      expect(failResult.isError, isTrue);
+      expect(
+        (failResult.content.first as TextContent).text,
+        contains('No active debug session'),
+      );
+
+      debugSession.appProcess.stdin.writeln('q');
+      await testHarness.stopDebugSession(debugSession);
+    });
+  });
 }
 
 extension on Iterable<Resource> {
@@ -1491,8 +1575,11 @@ Future<void> _deleteWithRetry(Directory dir) async {
 Future<String> _getIsolateId(TestHarness testHarness) async {
   final getVmResponse = await testHarness.callTool(
     CallToolRequest(
-      name: ToolNames.callVmServiceMethod.name,
-      arguments: {ParameterNames.method: 'getVM'},
+      name: ToolNames.vmService.name,
+      arguments: {
+        ParameterNames.command: 'callMethod',
+        ParameterNames.method: 'getVM',
+      },
     ),
   );
   if (getVmResponse case CallToolResult(


### PR DESCRIPTION
Adds a new `vm_service` tool, with `connect` and `disconnect` commands. These accept raw vm service URIs instead of DTD uris, for cases where a DTD uri does not exist or is not known.

Also moves the previous `call_vm_service_method` tool under this tool, as a `callMethod` command.