### PR TITLE
add some missing tool call failure reasons

### DIFF
--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Create vm_service meta tool, which allows direct connections to apps via vm
   service URIs, and also handles the direct vm service method calls.
+- Add additional failure reasons to tool call analytics.
 
 ## 1.0.2
 

--- a/pkgs/dart_mcp_server/lib/src/mixins/analyzer.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/analyzer.dart
@@ -491,7 +491,7 @@ base mixin DartAnalyzerSupport
         _ => CallToolResult(
           isError: true,
           content: [TextContent(text: 'Unknown LSP command: $command')],
-        ),
+        )..failureReason ??= CallToolFailureReason.noSuchCommand,
       };
       return result
         ..customMetrics = AnalysisMetrics(

--- a/pkgs/dart_mcp_server/lib/src/mixins/analyzer.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/analyzer.dart
@@ -491,7 +491,7 @@ base mixin DartAnalyzerSupport
         _ => CallToolResult(
           isError: true,
           content: [TextContent(text: 'Unknown LSP command: $command')],
-        )..failureReason ??= CallToolFailureReason.noSuchCommand,
+        )..failureReason = CallToolFailureReason.noSuchCommand,
       };
       return result
         ..customMetrics = AnalysisMetrics(

--- a/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
@@ -504,7 +504,7 @@ base mixin DartToolingDaemonSupport
         return CallToolResult(
           isError: true,
           content: [TextContent(text: 'Unknown command: $command')],
-        )..failureReason ??= CallToolFailureReason.noSuchCommand;
+        )..failureReason = CallToolFailureReason.noSuchCommand;
     }
   }
 

--- a/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
@@ -504,7 +504,7 @@ base mixin DartToolingDaemonSupport
         return CallToolResult(
           isError: true,
           content: [TextContent(text: 'Unknown command: $command')],
-        );
+        )..failureReason ??= CallToolFailureReason.noSuchCommand;
     }
   }
 
@@ -839,7 +839,7 @@ base mixin DartToolingDaemonSupport
                 '${WidgetInspectorCommand.setWidgetSelectionMode}.',
           ),
         ],
-      )..failureReason = CallToolFailureReason.argumentError,
+      )..failureReason = CallToolFailureReason.noSuchCommand,
     };
   }
 
@@ -1534,7 +1534,7 @@ base mixin DartToolingDaemonSupport
           return CallToolResult(
             isError: true,
             content: [TextContent(text: 'Not connected to $uriString.')],
-          );
+          )..failureReason = CallToolFailureReason.applicationNotFound;
         }
         try {
           final vmService = await vmServiceFuture;
@@ -1563,7 +1563,7 @@ base mixin DartToolingDaemonSupport
         return CallToolResult(
           isError: true,
           content: [TextContent(text: 'Unknown command: $command')],
-        );
+        )..failureReason = CallToolFailureReason.noSuchCommand;
     }
   }
 

--- a/pkgs/dart_mcp_server/lib/src/mixins/roots_fallback_support.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/roots_fallback_support.dart
@@ -102,7 +102,7 @@ base mixin RootsFallbackSupport on ToolsSupport, RootsTrackingSupport {
         return CallToolResult(
           isError: true,
           content: [TextContent(text: 'Unknown command: $command')],
-        )..failureReason ??= CallToolFailureReason.noSuchCommand;
+        )..failureReason = CallToolFailureReason.noSuchCommand;
     }
   }
 

--- a/pkgs/dart_mcp_server/lib/src/mixins/roots_fallback_support.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/roots_fallback_support.dart
@@ -11,6 +11,7 @@ import 'package:dart_mcp/server.dart';
 import 'package:meta/meta.dart';
 
 import '../features_configuration.dart';
+import '../utils/analytics.dart';
 import '../utils/constants.dart';
 import '../utils/names.dart';
 
@@ -101,7 +102,7 @@ base mixin RootsFallbackSupport on ToolsSupport, RootsTrackingSupport {
         return CallToolResult(
           isError: true,
           content: [TextContent(text: 'Unknown command: $command')],
-        );
+        )..failureReason ??= CallToolFailureReason.noSuchCommand;
     }
   }
 


### PR DESCRIPTION
Still seeing a fair number of `null` failure reasons in our analytics, this should cover at least some of those.