### PR TITLE
move SdkSupport to implements clause of DartToolingDaemonSupport

### DIFF
--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Create vm_service meta tool, which allows direct connections to apps via vm
   service URIs, and also handles the direct vm service method calls.
 - Add additional failure reasons to tool call analytics.
+- Move `SdkSupport` to `implements` instead of `on` in
+  `DartToolingDaemonSupport`.
 
 ## 1.0.2
 

--- a/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
@@ -41,8 +41,8 @@ extension McpServiceConstants on Never {
 ///
 /// The MCPServer must already have the [ToolsSupport] mixin applied.
 base mixin DartToolingDaemonSupport
-    on ToolsSupport, LoggingSupport, ResourcesSupport, SdkSupport
-    implements AnalyticsSupport, ProcessManagerSupport {
+    on ToolsSupport, LoggingSupport, ResourcesSupport
+    implements AnalyticsSupport, ProcessManagerSupport, SdkSupport {
   /// The DTD instances that this server is connected to.
   final List<DartToolingDaemon> _dtds = [];
 


### PR DESCRIPTION
This should have always been `implements`, we don't use `super.sdk`, we just require there to be an sdk getter.