### PR TITLE
Fix vm service disconnection hangs

### DIFF
--- a/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
@@ -184,7 +184,6 @@ base mixin DartToolingDaemonSupport
     unawaited(
       vmService.onDone.then((_) {
         removeResource(resource.uri);
-        activeVmServices.remove(vmServiceUri);
       }),
     );
   }

--- a/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
@@ -129,6 +129,15 @@ base mixin DartToolingDaemonSupport
     final VmService vmService;
     try {
       vmService = await vmServiceFuture;
+      unawaited(
+        vmService.onDone.then((_) {
+          // If our exact instance is still in the active vm services
+          // for this uri, remove it.
+          if (activeVmServices[vmServiceUri] == vmServiceFuture) {
+            activeVmServices.remove(vmServiceUri);
+          }
+        }),
+      );
     } catch (e) {
       unawaited(activeVmServices.remove(vmServiceUri));
       rethrow;
@@ -310,7 +319,6 @@ base mixin DartToolingDaemonSupport
     final args =
         request.arguments?[ParameterNames.arguments] as Map<String, Object?>?;
     final appUri = request.arguments?[ParameterNames.appUri] as String?;
-
     return _callOnVmService(
       appUri: appUri,
       callback: (vmService) async {
@@ -1058,7 +1066,16 @@ base mixin DartToolingDaemonSupport
       selectedAppUri = activeVmServices.keys.first;
     }
 
-    return await callback(await activeVmServices[selectedAppUri]!);
+    final vmService = await activeVmServices[selectedAppUri]!;
+    return await Future.any([
+      callback(vmService),
+      vmService.onDone.then<CallToolResult>((_) {
+        return CallToolResult(
+          isError: true,
+          content: [TextContent(text: 'Service connection disposed.')],
+        )..failureReason = CallToolFailureReason.alreadyDisconnected;
+      }),
+    ]);
   }
 
   /// Retrieves the active location from the editor.

--- a/pkgs/dart_mcp_server/test/tools/dtd_multiple_connection_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dtd_multiple_connection_test.dart
@@ -258,6 +258,7 @@ void main() async {
           name: ToolNames.getRuntimeErrors.name,
           arguments: {ParameterNames.appUri: session1.vmServiceUri},
         ),
+        retryUntil: (result) => result.content.length > 1,
       );
       expect(
         (errors1.content[1] as TextContent).text,

--- a/pkgs/dart_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dtd_test.dart
@@ -1571,7 +1571,12 @@ void main() {
       expect(callResult.isError, isTrue);
       expect(
         (callResult.content.first as TextContent).text,
-        contains('Service connection disposed'),
+        anyOf(
+          // If it got disconnected mid-call
+          contains('Service connection disposed'), 
+          // If it was disposed prior to the call
+          contains('No active debug session'),
+        ),
       );
     });
   });

--- a/pkgs/dart_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dtd_test.dart
@@ -1530,6 +1530,50 @@ void main() {
       debugSession.appProcess.stdin.writeln('q');
       await testHarness.stopDebugSession(debugSession);
     });
+
+    test('handles dropped VM service connections without hanging', () async {
+      final testHarness = await TestHarness.start(inProcess: true);
+      final debugSession = await testHarness.startDebugSession(
+        dartCliAppsPath,
+        'bin/infinite_wait.dart',
+        isFlutter: false,
+      );
+      await debugSession.appProcess.stdout.next;
+
+      final connectResult = await testHarness.callTool(
+        CallToolRequest(
+          name: ToolNames.vmService.name,
+          arguments: {
+            ParameterNames.command: 'connect',
+            ParameterNames.appUri: debugSession.vmServiceUri.toString(),
+          },
+        ),
+      );
+      expect(connectResult.isError, isNot(true));
+
+      // Simulate a dropped connection.
+      await testHarness.stopDebugSession(debugSession);
+
+      // Calling a method on a dropped VM service connection should fail and NOT
+      // hang.
+      final callResult = await testHarness.callTool(
+        CallToolRequest(
+          name: ToolNames.vmService.name,
+          arguments: {
+            ParameterNames.command: 'callMethod',
+            ParameterNames.method: 'ext.test.echo',
+            ParameterNames.arguments: {'message': 'ping'},
+            ParameterNames.isolateId: 'isolates/1',
+          },
+        ),
+        expectError: true,
+      );
+      expect(callResult.isError, isTrue);
+      expect(
+        (callResult.content.first as TextContent).text,
+        contains('Service connection disposed'),
+      );
+    });
   });
 }
 

--- a/pkgs/dart_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dtd_test.dart
@@ -1573,7 +1573,7 @@ void main() {
         (callResult.content.first as TextContent).text,
         anyOf(
           // If it got disconnected mid-call
-          contains('Service connection disposed'), 
+          contains('Service connection disposed'),
           // If it was disposed prior to the call
           contains('No active debug session'),
         ),


### PR DESCRIPTION
I noticed that when connecting to remote apps in particular, it isn't uncommon for the vm service connection to get dropped. We weren't handling that case well and would keep it in the active vm services map.

Now, if a vm service gets disposed we will remove it from that map. Also handles the case where the service dies in the middle of a tool call.