### PR TITLE
Support `internal: true` metadata to skip installing certain skills

### DIFF
--- a/pkgs/skills/CHANGELOG.md
+++ b/pkgs/skills/CHANGELOG.md
@@ -30,6 +30,8 @@
   `npx skills` for `dart run skills@`.
   - The `get` command now supports `--git` arguments for git repos to update
     skills from.
+- feat: Support `internal: true` metadata in frontmatter to skill internal
+  skills, unless the `INSTALL_INTERNAL_SKILLS=1` environment variable is set. 
 
 ## 0.3.1
 

--- a/pkgs/skills/lib/src/core/constants.dart
+++ b/pkgs/skills/lib/src/core/constants.dart
@@ -1,0 +1,8 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+final bool shouldInstallInternalSkills =
+    Platform.environment['INSTALL_INTERNAL_SKILLS'] == '1';

--- a/pkgs/skills/lib/src/core/frontmatter.dart
+++ b/pkgs/skills/lib/src/core/frontmatter.dart
@@ -55,14 +55,14 @@ class SkillFrontmatter {
     if (!content.startsWith('---')) {
       throw FormatException('Skill must start with `---` frontmatter', content);
     }
-    final frontMatterEnd = content.substring(3).indexOf('---');
+    final frontMatterEnd = content.indexOf('---', 3);
     if (frontMatterEnd == -1) {
       throw FormatException(
         'Skill must have front matter ending delimiter ---',
         content,
       );
     }
-    final yamlContent = content.substring(3, frontMatterEnd + 3);
+    final yamlContent = content.substring(3, frontMatterEnd);
     return SkillFrontmatter.fromYaml(
       loadYamlDocument(yamlContent, sourceUrl: sourceUri),
     );

--- a/pkgs/skills/lib/src/core/frontmatter.dart
+++ b/pkgs/skills/lib/src/core/frontmatter.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:yaml/yaml.dart';
+
+/// Parsed frontmatter from a skill file.
+class SkillFrontmatter {
+  /// The parsed metadata.internal field, defaults to false.
+  final bool isInternal;
+
+  /// The parsed name.
+  final String name;
+
+  SkillFrontmatter(this.name, {required this.isInternal});
+
+  /// Extracts values from a parsed skill frontmatter [YamlDocument].
+  factory SkillFrontmatter.fromYaml(YamlDocument document) {
+    final mapContent = document.contents;
+    if (mapContent is! YamlMap) {
+      throw FormatException(
+        'Expected a yaml map in the skill frontmatter',
+        mapContent,
+      );
+    }
+    final String name;
+    if (mapContent['name'] case String parsedName) {
+      name = parsedName;
+    } else {
+      throw FormatException('Expected a String name property', mapContent);
+    }
+
+    final YamlMap? metadata;
+    if (mapContent['metadata'] case YamlMap? parsedMetadata) {
+      metadata = parsedMetadata;
+    } else {
+      throw FormatException(
+        'Expected a YamlMap or empty metadata property',
+        mapContent,
+      );
+    }
+
+    final bool isInternal;
+    if (metadata?['internal'] case final bool parsedInternal) {
+      isInternal = parsedInternal;
+    } else {
+      isInternal = false;
+    }
+
+    return SkillFrontmatter(name, isInternal: isInternal);
+  }
+
+  /// Parses the [SkillFrontmatter] from the full skill file content.
+  factory SkillFrontmatter.fromSkillContent(String content, {Uri? sourceUri}) {
+    if (!content.startsWith('---')) {
+      throw FormatException('Skill must start with `---` frontmatter', content);
+    }
+    final frontMatterEnd = content.substring(3).indexOf('---');
+    if (frontMatterEnd == -1) {
+      throw FormatException(
+        'Skill must have front matter ending delimiter ---',
+        content,
+      );
+    }
+    final yamlContent = content.substring(3, frontMatterEnd + 3);
+    return SkillFrontmatter.fromYaml(
+      loadYamlDocument(yamlContent, sourceUrl: sourceUri),
+    );
+  }
+}

--- a/pkgs/skills/lib/src/core/git_scanner.dart
+++ b/pkgs/skills/lib/src/core/git_scanner.dart
@@ -1,7 +1,14 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:io';
 
+import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
+import 'package:skills/src/core/constants.dart';
 
+import 'frontmatter.dart';
 import 'git_repos.dart';
 import 'skill_scanner.dart';
 
@@ -10,6 +17,8 @@ import 'skill_scanner.dart';
 /// Recursively searches for `SKILL.md` files within the repository.
 class GitScanner {
   const GitScanner();
+
+  static final _logger = Logger('GitScanner'); 
 
   /// Scans all [repos] under [rootPath] and returns [ScannedSkill]s.
   Future<List<ScannedSkill>> scan(
@@ -42,6 +51,20 @@ class GitScanner {
       followLinks: false,
     )) {
       if (entity is! File || p.basename(entity.path) != 'SKILL.md') continue;
+
+      SkillFrontmatter? frontmatter;
+      try {
+        frontmatter = SkillFrontmatter.fromSkillContent(
+          await entity.readAsString(),
+        );
+      } on FormatException catch (e) {
+        _logger.warning(
+          'Skipping skill at path ${entity.path} due to formatting '
+          'error: $e',
+        );
+        continue;
+      }
+      if (frontmatter.isInternal && !shouldInstallInternalSkills) continue;
 
       final skillDir = entity.parent;
       final skillName = p.basename(skillDir.path);

--- a/pkgs/skills/lib/src/core/git_scanner.dart
+++ b/pkgs/skills/lib/src/core/git_scanner.dart
@@ -18,7 +18,7 @@ import 'skill_scanner.dart';
 class GitScanner {
   const GitScanner();
 
-  static final _logger = Logger('GitScanner'); 
+  static final _logger = Logger('GitScanner');
 
   /// Scans all [repos] under [rootPath] and returns [ScannedSkill]s.
   Future<List<ScannedSkill>> scan(

--- a/pkgs/skills/lib/src/core/skill_scanner.dart
+++ b/pkgs/skills/lib/src/core/skill_scanner.dart
@@ -1,8 +1,14 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:io';
 
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 
+import 'constants.dart';
+import 'frontmatter.dart';
 import 'package_resolver.dart';
 
 /// A scanned skill.
@@ -70,6 +76,20 @@ class SkillScanner {
 
       final skillMdFile = File(p.join(entity.path, 'SKILL.md'));
       if (!await skillMdFile.exists()) continue;
+
+      SkillFrontmatter? frontmatter;
+      try {
+        frontmatter = SkillFrontmatter.fromSkillContent(
+          await skillMdFile.readAsString(),
+        );
+      } on FormatException catch (e) {
+        logger.warning(
+          'Skipping skill at path ${entity.path} due to formatting '
+          'error: $e',
+        );
+        continue;
+      }
+      if (frontmatter.isInternal && !shouldInstallInternalSkills) continue;
 
       if (!skillName.startsWith(prefix)) {
         logger.warning(

--- a/pkgs/skills/test/core/git_scanner_test.dart
+++ b/pkgs/skills/test/core/git_scanner_test.dart
@@ -85,7 +85,12 @@ void main() {
                       ]),
                     ]),
                     d.dir('flutter_riverpod', [
-                      d.dir('flutter_riverpod-hooks', [d.file('SKILL.md', '')]),
+                      d.dir('flutter_riverpod-hooks', [
+                        d.file(
+                          'SKILL.md',
+                          '---\nname: flutter_riverpod-hooks\n---\n',
+                        ),
+                      ]),
                     ]),
                   ]),
                 ]),
@@ -117,17 +122,19 @@ void main() {
       },
     );
 
-    test('when skill dir has no hyphen then skipped in flat layout', () async {
+    test('when skill is internal then it is skipped', () async {
+      final repo = const GitRepo(cloneUrl: 'https://github.com/a/b.git');
       await d.dir('project', [
         d.dir('.dart_tool', [
           d.dir('skills', [
             d.dir('repos', [
-              d.dir('a', [
-                d.dir('b', [
-                  d.dir('skills', [
-                    d.dir('no_hyphen', [
-                      d.file('SKILL.md', '---\nname: no_hyphen\n---\n'),
-                    ]),
+              d.dir(repo.pathSegment, [
+                d.dir('skills', [
+                  d.dir('pkg-internal', [
+                    d.file(
+                      'SKILL.md',
+                      '---\nname: pkg-internal\nmetadata:\n  internal: true\n---\n',
+                    ),
                   ]),
                 ]),
               ]),
@@ -140,21 +147,20 @@ void main() {
       final skills = await scanner.scan(
         d.path('project'),
         isGlobal: false,
-        repos: [const GitRepo(cloneUrl: 'https://github.com/a/b.git')],
+        repos: [repo],
       );
       expect(skills, isEmpty);
     });
 
     test('when skill dir has no SKILL.md then skipped', () async {
+      final repo = const GitRepo(cloneUrl: 'https://github.com/a/b.git');
       await d.dir('project', [
         d.dir('.dart_tool', [
           d.dir('skills', [
             d.dir('repos', [
-              d.dir('a', [
-                d.dir('b', [
-                  d.dir('skills', [
-                    d.dir('pkg-skill', [d.file('README.md', 'not a skill')]),
-                  ]),
+              d.dir(repo.pathSegment, [
+                d.dir('skills', [
+                  d.dir('pkg-skill', [d.file('README.md', 'not a skill')]),
                 ]),
               ]),
             ]),
@@ -166,7 +172,7 @@ void main() {
       final skills = await scanner.scan(
         d.path('project'),
         isGlobal: false,
-        repos: [const GitRepo(cloneUrl: 'https://github.com/a/b.git')],
+        repos: [repo],
       );
       expect(skills, isEmpty);
     });
@@ -182,12 +188,16 @@ void main() {
             d.dir('repos', [
               d.dir(gitRepos[0].pathSegment, [
                 d.dir('skills', [
-                  d.dir('pkg-a', [d.file('SKILL.md', '')]),
+                  d.dir('pkg-a', [
+                    d.file('SKILL.md', '---\nname: pkg-a\n---\n'),
+                  ]),
                 ]),
               ]),
               d.dir(gitRepos[1].pathSegment, [
                 d.dir('skills', [
-                  d.dir('pkg-b', [d.file('SKILL.md', '')]),
+                  d.dir('pkg-b', [
+                    d.file('SKILL.md', '---\nname: pkg-b\n---\n'),
+                  ]),
                 ]),
               ]),
             ]),

--- a/pkgs/skills/test/core/skill_scanner_test.dart
+++ b/pkgs/skills/test/core/skill_scanner_test.dart
@@ -167,6 +167,40 @@ Body.
     });
   });
 
+  group('Given a package with an internal skill', () {
+    test('when scanning then the internal skill is skipped', () async {
+      await d.dir('pkg_internal', [
+        d.dir('skills', [
+          d.dir('pkg_internal-skill', [
+            d.file('SKILL.md', '''
+---
+name: pkg_internal-skill
+description: Internal skill.
+metadata:
+  internal: true
+---
+
+Body.
+'''),
+          ]),
+        ]),
+      ]).create();
+
+      final package = ResolvedPackage(
+        name: 'pkg_internal',
+        rootPath: d.path('pkg_internal'),
+        originalPackageConfigPath: d.path(
+          p.join('.dart_tool', 'package_config.json'),
+        ),
+      );
+
+      final scanner = SkillScanner(logger);
+      final skills = await scanner.scanPackage(package);
+
+      expect(skills, isEmpty);
+    });
+  });
+
   group('Given multiple packages', () {
     test('when scanning all then aggregates skills from each', () async {
       await d.dir('pkg_a', [


### PR DESCRIPTION
Closes https://github.com/dart-lang/ai/issues/502

- Adds a simple parser for skill frontmatter as well.
- Uses that to extract the internal metadata field if present and skip skills unless the environment variable is set
- Cleans up some older tests that I noticed were set up wrong or invalid.