### PR TITLE
publish package:skills 1.0.0-beta.1

### DIFF
--- a/pkgs/skills/CHANGELOG.md
+++ b/pkgs/skills/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.4.0-dev
+## 1.0.0-beta.1
 
 - feat: Added a dialog to select which packages to install skills from during
   `skills get` and `skills remove`.

--- a/pkgs/skills/README.md
+++ b/pkgs/skills/README.md
@@ -4,8 +4,6 @@ A CLI that brings AI agent skills from your Dart and Flutter package dependencie
 
 Dart packages can ship a `skills/` directory containing [Agent Skills](https://agentskills.io/specification), structured instructions that teach AI coding assistants how to use the package effectively. The `skills` CLI finds those skills in your dependency tree and installs them into your agent so your AI assistant better understands your stack.
 
-> If you want to discuss or contribute to the `skills` package, please join the `#skills` channel on the [Serverpod Discord](https://serverpod.dev/discord) server.
-
 ## The problem
 
 When you add a Dart package to your project, your AI coding assistant has no idea how to use it properly. It guesses APIs, invents patterns, and hallucinates methods that don't exist. You end up copy-pasting documentation into chat, writing custom rules, or correcting the AI over and over.

--- a/pkgs/skills/README.md
+++ b/pkgs/skills/README.md
@@ -2,8 +2,6 @@
 
 A CLI that brings AI agent skills from your Dart and Flutter package dependencies directly into your agent.
 
-> Note: The Dart team is working on a [similar solution](https://docs.google.com/document/d/1k_X-Sp4GQyZP6k9lvZ1Itj0GvzQZuWl3iKzi5AIa69Q/edit?tab=t.0) based on Dart's MCP server. When that is released, we will provide scripts to convert your skills to Dart's new format. This package will then either adopt the Dart MCP standard for delivering skills or be deprecated (assuming the MCP solution is equally capable).
-
 Dart packages can ship a `skills/` directory containing [Agent Skills](https://agentskills.io/specification), structured instructions that teach AI coding assistants how to use the package effectively. The `skills` CLI finds those skills in your dependency tree and installs them into your agent so your AI assistant better understands your stack.
 
 > If you want to discuss or contribute to the `skills` package, please join the `#skills` channel on the [Serverpod Discord](https://serverpod.dev/discord) server.
@@ -17,63 +15,64 @@ When you add a Dart package to your project, your AI coding assistant has no ide
 Package authors ship skills alongside their code. You run one command, and your AI assistant knows how to work with every package in your project.
 
 ```bash
-skills get
+dart run skills@ get
 ```
 
-That's it. Your AI assistant now has context-aware instructions for every dependency that provides skills.
-
-## Installation
-
-Activate the CLI globally:
-
-```bash
-dart pub global activate skills
-```
-
-Make sure `~/.pub-cache/bin` is on your PATH ([instructions](https://dart.dev/tools/pub/cmd/pub-global#running-a-script-from-your-path)).
+Select the skills you would like to install, or pass `--all` to just install everything. Your AI assistant now has context-aware instructions for every dependency that provides skills.
 
 ## Quick start
 
 Navigate to the root of your Dart or Flutter project and run:
 
 ```bash
-# Install skills from all dependencies
-skills get
+# Install selected skills from all dependencies
+dart run skills@ get
+
+# Install skills from all dependencies without prompting
+dart run skills@ get --all
 
 # Install skills from a specific package
-skills get serverpod
+dart run skills@ get <package>
 
 # List installed skills
-skills list
+dart run skills@ list
 
 # Remove skills for packages no longer in your dependency tree
-skills prune
+dart run skills@ prune
 
-# Remove all managed skills
-skills remove
+# Remove the selected managed skills
+dart run skills@ remove
 
 # Remove skills from one package
-skills remove serverpod
+dart run skills@ remove serverpod
+
+dart run skills@ add <git-url>
 ```
 
 The CLI will automatically run `pub get` if needed, scan your dependency packages for `skills/` directories, and install them in the right location for your agent. If you are using a monorepo, `skills` will locate your different packages and get the skills for all of them.
 
-If **git** is installed, `skills get` also fetches skills from GitHub registries (see [GitHub registries](#github-registries) below). Skills that come from a Dart package in your dependency tree always take precedence over registry skills for that same package, allowing package maintainers to override the skills in the registry.
+### Installing skills from git
+
+The `skills` package can also install skills from git repos, similar to how `npx skills` works. Given an `npx skills` command from https://skills.sh, you can substitute `npx skills` for `dart run skills@` to install them without the need for Node/NPX.
+
+Once a repo has been added, future calls to `dart run skills@ get` will also check those repos for updates to skills.
+
+- **Requirement:** Git must be installed and on your PATH. If git is not found, a warning is printed and only Dart package skills are used.
 
 ### Pruning removed dependencies
 
 When you remove a package from your `pubspec.yaml`, its skills stay in your agent directories until you clean them up. Run:
 
 ```bash
-skills prune
+dart run skills@ prune
 ```
 
-This removes only skills whose package is no longer in your dependency tree and updates the manifest. Use `--agent <agent>` to prune a single agent. If you have no managed skills, `skills prune` reports that and exits.
+This removes only skills whose package is no longer in your dependency tree and updates the manifest. Use `--agent <agent>` to prune a single agent. If you have no managed skills, `prune` reports that and exits.
 
 ### Version control and .gitignore
 
-- If you version-control your agent config (e.g. `.cursor/`), add `.dart_skills/repos/` to your `.gitignore` so cloned registry repos are not committed.
-- If you ignore your agent directory (e.g. `.cursor/`), you can ignore the whole `.dart_skills/` directory.
+- If you **do not** version-control your agent config (`.agents`, etc), then you should include `.config/dart_skills` in your `.gitignore` as well
+- If you **do** version control your agent config, then you should ensure sure that `.config/dart_skills` is **not** ignored. You may need to add `!.config/dart_skills` if you are ignoring the `.config` dir elsewhere in your git ignore.
 
 ## Supported agents
 
@@ -93,13 +92,6 @@ The CLI auto-detects your agent from project directory markers. If multiple agen
 Antigravity, Codex, and generic all install to the same `.agents/skills/` directory (only `generic` is stored in the config). GitHub Copilot is not auto-detected (`.github/` is often used for other purposes); use `--agent copilot` to install skills for Copilot explicitly.
 
 Each of these agents receives the full Agent Skills directory (SKILL.md plus `scripts/`, `references/`, `assets/`) in each tool’s documented location.
-
-## GitHub registries
-
-When you run `skills get`, the CLI can also install skills from **GitHub registries** — repositories that host a `skills/` directory with skills for packages that may not ship skills in their pub package. This is useful for community-maintained skills or packages that haven’t added a `skills/` directory yet.
-
-- **Requirement:** Git must be installed and on your PATH. If git is not found, a warning is printed and only Dart package skills are used.
-- **Registries:** The CLI currently uses two registries: [flutter/skills](https://github.com/flutter/skills) and [serverpod/skills-registry](https://github.com/serverpod/skills-registry). Each is cloned or updated under `.dart_skills/repos/`, you probably want to add this directory to your `.gitignore`.
 
 ## For package maintainers
 
@@ -174,14 +166,15 @@ All agents receive the full skill directory (SKILL.md plus `scripts/`, `referenc
 - **Keep SKILL.md under 500 lines.** Move detailed reference material into `references/` files; all supported agents receive the full skill directory.
 - **Version your skills with your package.** When you change APIs, update the skills to match.
 
-### What happens when users run `skills get`
+### What happens when users run `dart run skills@ get`
 
 1. The CLI resolves your package's location on disk from `package_config.json`.
 2. It finds your `skills/` directory and each skill subdirectory with a `SKILL.md`.
 3. It validates that each skill name starts with your package name.
-4. Skills are installed into the user's agent-specific location.
-5. A `.dart_skills/skills_config.json` tracking file records which skills were installed from which package and agent.
+4. It compares the current skills to any previously installed skills, presenting the user with relevant dialogs to update, install, or delete skills.
+5. The selected skills are installed into the user's agent-specific location.
+6. A `.config/dart_skills/skills_config.json` tracking file records information about all the available skills and their last known states.
 
-Users can update skills by running `skills get` again. Existing skills from your package are replaced with the latest versions.
+Users can update skills by running `dart run skills@ get` again.
 
-The `.dart_skills/skills_config.json` file tracks managed skills so `skills remove` knows what to clean up without touching skills you created manually.
+Users can remove skills by running `dart run skills@ remove`, which will read the `.config/dart_skills/skills_config.json` file so that it doesn't touch manually curated skills.

--- a/pkgs/skills/lib/src/agent/agent.dart
+++ b/pkgs/skills/lib/src/agent/agent.dart
@@ -8,9 +8,9 @@ import 'package:path/path.dart' as p;
 /// separate CLI options that all map here; only "generic" is stored in
 /// skills_config.
 enum Agent {
-  cursor('cursor', '.cursor/skills'),
   generic('generic', '.agents/skills'),
   claude('claude', '.claude/skills'),
+  cursor('cursor', '.cursor/skills'),
   copilot('copilot', '.github/skills'),
   cline('cline', '.cline/skills'),
   opencode('opencode', '.opencode/skills');

--- a/pkgs/skills/lib/src/commands/options.dart
+++ b/pkgs/skills/lib/src/commands/options.dart
@@ -61,7 +61,10 @@ Future<List<Agent>> resolveAgents({
   if (detected.isNotEmpty) return detected;
 
   if (dialogSupport case var dialogSupport?) {
-    final options = Agent.values.map((e) => e.cliName).toList();
+    final options = [
+      for (var agent in Agent.values)
+        '${agent.cliName}${agent.cliAliases.isEmpty ? '' : ' (${agent.cliAliases.join(', ')})'}',
+    ];
     final result = await dialogSupport.showMultiSelectDialog(
       options,
       title: 'Unable to auto-detect agent. Please select one or more:',

--- a/pkgs/skills/pubspec.yaml
+++ b/pkgs/skills/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   CLI that installs AI agent skills from your Dart and Flutter package
   dependencies into your Agent, so Antigravity, Claude, Codex, Cursor, and other
   assistants know how to use your stack.
-version: 0.4.0-dev
+version: 1.0.0-beta.1
 repository: https://github.com/serverpod/skills
 issue_tracker: https://github.com/serverpod/skills/issues
 

--- a/pkgs/skills/test/commands/get_command_select_agents_test.dart
+++ b/pkgs/skills/test/commands/get_command_select_agents_test.dart
@@ -1,0 +1,90 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
+import 'package:skills/src/commands/get_command.dart';
+import 'package:skills/src/commands/skills_command_runner.dart';
+import 'package:skills/src/core/git_runner.dart';
+import 'package:skills/src/agent/agent.dart';
+import '../fake_dialog_support.dart';
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+import '../utils.dart';
+
+void main() {
+  group(
+    'Given a project with dependencies dep1 (2 skills) and dep2 (1 skill)',
+    () {
+      late String projectPath;
+      late FakeDialogSupport fakeDialogSupport;
+
+      setUpAll(() {
+        Logger.root.onRecord.listen((r) => printOnFailure(r.toString()));
+      });
+
+      setUp(() async {
+        final dep1Dir = d.dir('dep1', [
+          pubspec('dep1'),
+          d.dir('skills', [
+            d.dir('dep1-skill1', [
+              d.file('SKILL.md', '---\nname: dep1-skill1\n---\n'),
+            ]),
+          ]),
+        ]);
+        await dep1Dir.create();
+
+        final projectRootDir = d.dir('project', [
+          pubspec('project', dependencies: [.new('dep1')]),
+        ]);
+        await projectRootDir.create();
+
+        projectPath = projectRootDir.io.path;
+        fakeDialogSupport = FakeDialogSupport();
+      });
+
+      test('when running `skills get --all` without agent, user is prompted '
+          'for agent and then all packages/skills are installed', () async {
+        // Select 'generic' (index 0)
+        fakeDialogSupport.multiSelectResults = [
+          {0},
+        ];
+
+        final getCommand = GetCommand(
+          dialogSupport: fakeDialogSupport,
+          gitRunner: GitRunner(isAvailableOverride: () async => false),
+        );
+        final runner = SkillsCommandRunner('skills', 'Test')
+          ..addCommand(getCommand);
+
+        await runner.run(['get', '--directory', projectPath, '--all']);
+
+        expect(fakeDialogSupport.allMultiSelectOptions, hasLength(1));
+        expect(
+          fakeDialogSupport.allMultiSelectOptions[0],
+          unorderedEquals([
+            'generic (antigravity, codex)',
+            'claude',
+            'cursor',
+            'copilot',
+            'cline',
+            'opencode',
+          ]),
+        );
+        expect(
+          fakeDialogSupport.allTitles[0],
+          equals('Unable to auto-detect agent. Please select one or more:'),
+        );
+
+        final skillsDir = Agent.generic.skillsPath(projectPath);
+        final dep1Skill1Dir = Directory(p.join(skillsDir, 'dep1-skill1'));
+
+        expect(await dep1Skill1Dir.exists(), isTrue);
+      });
+    },
+  );
+}

--- a/pkgs/skills/test/commands/get_command_select_skills_test.dart
+++ b/pkgs/skills/test/commands/get_command_select_skills_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:io';
 
 import 'package:logging/logging.dart';
@@ -52,7 +56,6 @@ void main() {
 
         final projectRootDir = d.dir('project', [
           pubspec('project', dependencies: [.new('dep1'), .new('dep2')]),
-          d.dir('.cursor', [d.dir('skills')]),
         ]);
         await projectRootDir.create();
 
@@ -204,7 +207,6 @@ void main() {
 
         final projectRootDir = d.dir('project', [
           pubspec('project', dependencies: [.new('dep1'), .new('dep2')]),
-          d.dir('.cursor', [d.dir('skills')]),
         ]);
         await projectRootDir.create();
 


### PR DESCRIPTION
This release will allow us to get a few dogfooders using the package like `dart run skills@1.0.0-beta.1` or `dart run skills@^1.0.0.beta`

- Also cleans up the README a bit
- And includes the agent aliases in the agent selection dialog