### PR TITLE
add request-scoped message dispatch for MCP servers

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -4,9 +4,19 @@
   - Separate server feature registration from the legacy protocol handshake.
     `MCPServer.initialize` now accepts an `MCPServerInitialization` containing
     the protocol version, client information, and client capabilities, and
-    returns `ServerCapabilities`.
+    returns `ServerCapabilities`. The client information is optional, since
+    clients are no longer required to send it on every request, see
+    https://github.com/modelcontextprotocol/modelcontextprotocol/pull/3002.
+    `MCPServer.clientInfo` is now nullable (`Implementation?`).
   - Override `MCPServer.initializeLegacy` only to customize the legacy
     initialize response or version negotiation.
+- Add `handleRequestScopedMessage` and `MCPServerFactory`, which serve each
+  decoded JSON-RPC message on a fresh server instance for request-scoped
+  transports. Successful results record the server implementation under the
+  reserved `io.modelcontextprotocol/serverInfo` result metadata key. Does
+  **not** add any transport; wire formats and HTTP support land separately.
+- `RootsTrackingSupport` no longer surfaces an unhandled error when the
+  connection closes while a `listRoots` request is in flight.
 
 ## 0.5.2
 

--- a/pkgs/dart_mcp/README.md
+++ b/pkgs/dart_mcp/README.md
@@ -22,10 +22,11 @@ Register server-specific tools, resources, prompts, and request handlers by
 overriding `MCPServer.initialize(MCPServerInitialization)`. Always call the
 super method and return its `ServerCapabilities`, including any capability
 changes made by your server. This hook can be used independently of the legacy
-MCP handshake; the context supplies the protocol version, client information,
-and client capabilities for either lifecycle. A request-scoped transport
-completes `MCPServer.initialized` by calling `handleInitialized()` after this
-hook and any transport-specific setup have finished.
+MCP handshake; the context supplies the protocol version, optional client
+information, and client capabilities for either lifecycle. A request-scoped
+transport completes `MCPServer.initialized` by calling `handleInitialized()`
+after this hook and any transport-specific setup have finished, or serves each
+decoded message on a fresh server instance with `handleRequestScopedMessage`.
 
 `MCPServer.initializeLegacy(InitializeRequest)` handles protocol negotiation
 and the legacy initialize response. Override it only when you need to customize

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -79,14 +79,12 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
       'A request or notification must not carry a result or error',
     );
   }
-  // Read the raw value so a non-string method fails with this argument error
-  // rather than a cast error from [JsonRpc2Object.method].
-  final method = message[Keys.method];
-  if (method is! String) {
+  final method = object.method;
+  if (method == null) {
     throw ArgumentError.value(
       message,
       'message',
-      'A dispatched message must have a string method',
+      'A dispatched message must have a method',
     );
   }
   if (object.kind == JsonRpc2Kind.request && object.id == null) {

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -79,7 +79,9 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
       'A request or notification must not carry a result or error',
     );
   }
-  final method = object.method;
+  // Read the raw value so a non-string method fails with this argument error
+  // rather than a cast error from [JsonRpc2Object.method].
+  final method = message[Keys.method];
   if (method is! String) {
     throw ArgumentError.value(
       message,

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -1,0 +1,221 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+part of 'server.dart';
+
+/// Creates the [MCPServer] which communicates over [channel].
+///
+/// The returned server must be constructed on [channel], typically by passing
+/// it to [MCPServer.fromStreamChannel].
+typedef MCPServerFactory = MCPServer Function(StreamChannel<String> channel);
+
+/// Handles one decoded JSON-RPC [message] on a fresh server instance.
+///
+/// In a request-scoped lifecycle there is no connection to initialize: every
+/// request carries its own client context, see
+/// https://modelcontextprotocol.io/specification/draft/basic. This function
+/// creates a server with [serverFactory], runs [MCPServer.initialize] with
+/// the [initialization] built by the transport, completes
+/// [MCPServer.initialized], and then delivers [message] to the server as if
+/// it had arrived over a connection. The server handles this one message and
+/// is shut down afterward; it is never reused, and no state carries over
+/// between messages. Decoding the wire format, extracting the per-request
+/// context, and anything HTTP-specific stay in the transport. Protocol
+/// metadata carried in [message]'s own `_meta` is not read here;
+/// [initialization] is the sole source of the per-request context.
+///
+/// [message] is a request if it has a non-null `id` member and a notification
+/// otherwise. Returns the decoded JSON-RPC response for a request, and `null`
+/// for a notification, which per JSON-RPC gets no response. A successful
+/// result records the server's [MCPServer.implementation] under the reserved
+/// `io.modelcontextprotocol/serverInfo` result metadata key; a result which
+/// already carries a server info entry, and every error response, is returned
+/// unchanged. If the server closes before responding to a request, an
+/// internal-error response is returned instead. The server may still be
+/// processing a notification when the returned future completes.
+///
+/// The returned future completes once the server responds or the exchange
+/// closes; it does not time out on its own. A handler that never returns
+/// leaves it pending and the server alive. To bound execution, retain the
+/// server your factory creates and call [MCPServer.shutdown] on it; the
+/// exchange then completes with an internal-error response.
+///
+/// The [ServerCapabilities] returned by [MCPServer.initialize] are
+/// intentionally not surfaced: in this lifecycle clients discover
+/// capabilities with `server/discover` rather than per message.
+///
+/// Notifications the server emits during the exchange, including any it emits
+/// while initializing, are passed to [onNotification] with their JSON-RPC
+/// envelope so a transport can decide how to deliver them. Errors thrown by
+/// [onNotification] are reported as uncaught errors and do not fail the
+/// exchange.
+///
+/// Requests from the server back to the client, such as `roots/list`, cannot
+/// be answered within a single-message exchange: they fail with an
+/// [RpcException] inside their handler, or with a [StateError] if the exchange
+/// has already been torn down.
+///
+/// Throws an [ArgumentError] if [message] is not a JSON-RPC request or
+/// notification (no string `method`, a `null` id, or a `result` or `error`
+/// member), or if its method is the legacy `initialize` request or
+/// `initialized` notification; classifying a message as legacy or
+/// request-scoped is the transport's job. Errors thrown by [serverFactory] or
+/// by [MCPServer.initialize] propagate to the caller; a server that was
+/// created is shut down first.
+// TODO: Support server-to-client requests once a transport can route them.
+// https://github.com/dart-lang/ai/issues/162
+Future<Map<String, Object?>?> handleRequestScopedMessage(
+  Map<String, Object?> message,
+  MCPServerInitialization initialization,
+  MCPServerFactory serverFactory, {
+  void Function(Map<String, Object?> notification)? onNotification,
+}) async {
+  final method = message[Keys.method];
+  if (method is! String) {
+    throw ArgumentError.value(
+      message,
+      'message',
+      'A dispatched message must have a string method',
+    );
+  }
+  if (message.containsKey(Keys.id) && message[Keys.id] == null) {
+    throw ArgumentError.value(
+      message,
+      'message',
+      'A request id must not be null',
+    );
+  }
+  if (message.containsKey(Keys.result) || message.containsKey(Keys.error)) {
+    throw ArgumentError.value(
+      message,
+      'message',
+      'A request or notification must not carry a result or error',
+    );
+  }
+  if (method == InitializeRequest.methodName ||
+      method == InitializedNotification.methodName) {
+    throw ArgumentError.value(
+      message,
+      'message',
+      'Legacy lifecycle messages are not used on a request-scoped transport',
+    );
+  }
+
+  // The message is re-encoded onto an in-memory channel so the exchange runs
+  // through the same Peer validation and dispatch path as a wire connection.
+  // TODO: A message-typed channel could drop the per-message encode/decode.
+  // https://github.com/dart-lang/ai/issues/162
+  final inbound = StreamController<String>();
+  final outbound = StreamController<String>();
+  final server = serverFactory(
+    StreamChannel.withCloseGuarantee(inbound.stream, outbound.sink),
+  );
+
+  final isRequest = message.containsKey(Keys.id);
+  final response = Completer<Map<String, Object?>?>();
+  final subscription = outbound.stream.listen(
+    (encoded) {
+      try {
+        final decoded = (jsonDecode(encoded) as Map).cast<String, Object?>();
+        if (decoded.containsKey(Keys.method)) {
+          if (decoded.containsKey(Keys.id)) {
+            // A request from the server to the client. Nothing can answer it
+            // in a single-message exchange, so fail it back to the server
+            // instead of leaving its handler waiting forever. Late requests
+            // from work which outlives the exchange find the connection
+            // already closed.
+            if (!inbound.isClosed) {
+              inbound.add(
+                jsonEncode(
+                  _errorResponse(
+                    decoded[Keys.id],
+                    'Server to client requests are not supported on a '
+                    'request-scoped transport',
+                  ),
+                ),
+              );
+            }
+          } else {
+            try {
+              onNotification?.call(decoded);
+            } catch (error, stackTrace) {
+              // A misbehaving callback must not fail the request being
+              // handled, but it should still be visible.
+              Zone.current.handleUncaughtError(error, stackTrace);
+            }
+          }
+        } else if (!response.isCompleted) {
+          response.complete(_withServerInfo(decoded, server.implementation));
+        }
+      } catch (error, stackTrace) {
+        // The server sent a frame we could not process. Never let it wedge or
+        // escape the exchange: a request gets an internal error, anything else
+        // surfaces as an uncaught error.
+        if (isRequest && !response.isCompleted) {
+          response.complete(
+            _errorResponse(
+              message[Keys.id],
+              'The server sent an invalid response',
+            ),
+          );
+        } else {
+          Zone.current.handleUncaughtError(error, stackTrace);
+        }
+      }
+    },
+    onDone: () {
+      if (isRequest && !response.isCompleted) {
+        response.complete(
+          _errorResponse(
+            message[Keys.id],
+            'The server closed before responding to the request',
+          ),
+        );
+      }
+    },
+  );
+
+  try {
+    await server.initialize(initialization);
+    server.handleInitialized();
+    inbound.add(jsonEncode(message));
+    if (isRequest) return await response.future;
+    return null;
+  } finally {
+    await inbound.close();
+    await server.done;
+    await subscription.cancel();
+  }
+}
+
+/// A JSON-RPC internal-error response to the request with the given [id].
+Map<String, Object?> _errorResponse(Object? id, String message) => {
+  Keys.jsonrpc: '2.0',
+  Keys.id: id,
+  Keys.error: {Keys.code: error_code.INTERNAL_ERROR, Keys.message: message},
+};
+
+/// Returns [response] with [implementation] recorded under the reserved
+/// `io.modelcontextprotocol/serverInfo` result metadata key.
+///
+/// Error responses have no result and are returned unchanged, as are results
+/// which already carry a server info entry.
+Map<String, Object?> _withServerInfo(
+  Map<String, Object?> response,
+  Implementation implementation,
+) {
+  final result = response[Keys.result];
+  if (result is! Map) return response;
+  final existingMeta = result[Keys.meta];
+  if (existingMeta is! Map?) return response;
+  final resultMap = result.cast<String, Object?>();
+  final meta = existingMeta?.cast<String, Object?>() ?? <String, Object?>{};
+  // Copy so the returned response does not alias the shared server info map.
+  meta.putIfAbsent(
+    Keys.serverInfoMeta,
+    () => Map<String, Object?>.of(implementation as Map<String, Object?>),
+  );
+  resultMap[Keys.meta] = meta;
+  return response;
+}

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -71,7 +71,15 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
   MCPServerFactory serverFactory, {
   void Function(Map<String, Object?> notification)? onNotification,
 }) async {
-  final method = message[Keys.method];
+  final object = JsonRpc2Object.fromMap(message);
+  if (object.kind == JsonRpc2Kind.response) {
+    throw ArgumentError.value(
+      message,
+      'message',
+      'A request or notification must not carry a result or error',
+    );
+  }
+  final method = object.method;
   if (method is! String) {
     throw ArgumentError.value(
       message,
@@ -79,18 +87,11 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
       'A dispatched message must have a string method',
     );
   }
-  if (message.containsKey(Keys.id) && message[Keys.id] == null) {
+  if (object.kind == JsonRpc2Kind.request && object.id == null) {
     throw ArgumentError.value(
       message,
       'message',
       'A request id must not be null',
-    );
-  }
-  if (message.containsKey(Keys.result) || message.containsKey(Keys.error)) {
-    throw ArgumentError.value(
-      message,
-      'message',
-      'A request or notification must not carry a result or error',
     );
   }
   if (method == InitializeRequest.methodName ||
@@ -112,14 +113,14 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
     StreamChannel.withCloseGuarantee(inbound.stream, outbound.sink),
   );
 
-  final isRequest = message.containsKey(Keys.id);
+  final isRequest = object.kind == JsonRpc2Kind.request;
   final response = Completer<Map<String, Object?>?>();
   final subscription = outbound.stream.listen(
     (encoded) {
       try {
         final decoded = (jsonDecode(encoded) as Map).cast<String, Object?>();
-        if (decoded.containsKey(Keys.method)) {
-          if (decoded.containsKey(Keys.id)) {
+        switch (JsonRpc2Object.fromMap(decoded).kind) {
+          case JsonRpc2Kind.request:
             // A request from the server to the client. Nothing can answer it
             // in a single-message exchange, so fail it back to the server
             // instead of leaving its handler waiting forever. Late requests
@@ -129,14 +130,14 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
               inbound.add(
                 jsonEncode(
                   _errorResponse(
-                    decoded[Keys.id],
+                    JsonRpc2Request.fromMap(decoded).id,
                     'Server to client requests are not supported on a '
                     'request-scoped transport',
                   ),
                 ),
               );
             }
-          } else {
+          case JsonRpc2Kind.notification:
             try {
               onNotification?.call(decoded);
             } catch (error, stackTrace) {
@@ -144,9 +145,12 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
               // handled, but it should still be visible.
               Zone.current.handleUncaughtError(error, stackTrace);
             }
-          }
-        } else if (!response.isCompleted) {
-          response.complete(_withServerInfo(decoded, server.implementation));
+          case JsonRpc2Kind.response:
+            if (!response.isCompleted) {
+              response.complete(
+                _withServerInfo(decoded, server.implementation),
+              );
+            }
         }
       } catch (error, stackTrace) {
         // The server sent a frame we could not process. Never let it wedge or
@@ -205,11 +209,11 @@ Map<String, Object?> _withServerInfo(
   Map<String, Object?> response,
   Implementation implementation,
 ) {
-  final result = response[Keys.result];
+  final result = JsonRpc2Response.fromMap(response).result;
   if (result is! Map) return response;
-  final existingMeta = result[Keys.meta];
-  if (existingMeta is! Map?) return response;
   final resultMap = result.cast<String, Object?>();
+  final existingMeta = resultMap[Keys.meta];
+  if (existingMeta is! Map?) return response;
   final meta = existingMeta?.cast<String, Object?>() ?? <String, Object?>{};
   // Copy so the returned response does not alias the shared server info map.
   meta.putIfAbsent(

--- a/pkgs/dart_mcp/lib/src/server/roots_tracking_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/roots_tracking_support.dart
@@ -95,6 +95,12 @@ base mixin RootsTrackingSupport on LoggingSupport {
       result = await listRoots(ListRootsRequest());
     } on RpcException catch (e) {
       log(LoggingLevel.error, 'Error calling listRoots: $e');
+      // json_rpc_2 completes requests which are still pending when the
+      // connection closes with a `StateError`, for instance when a
+      // request-scoped exchange is torn down mid-request.
+      // ignore: avoid_catching_errors
+    } on StateError catch (e) {
+      log(LoggingLevel.error, 'Error calling listRoots: $e');
     } finally {
       // Only complete the completer if it's still the one we created. Otherwise
       // we wait for the next result to come back and throw away this result.

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -14,6 +14,7 @@ import 'package:stream_transform/stream_transform.dart';
 import '../api/api.dart';
 import '../shared.dart';
 import '../utils/constants.dart';
+import '../utils/json_rpc_2_object.dart';
 
 part 'completions_support.dart';
 part 'elicitation_request_support.dart';

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -3,18 +3,23 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 
+import 'package:json_rpc_2/error_code.dart' as error_code;
 import 'package:json_rpc_2/json_rpc_2.dart';
 import 'package:meta/meta.dart';
+import 'package:stream_channel/stream_channel.dart';
 import 'package:stream_transform/stream_transform.dart';
 
 import '../api/api.dart';
 import '../shared.dart';
+import '../utils/constants.dart';
 
 part 'completions_support.dart';
 part 'elicitation_request_support.dart';
 part 'logging_support.dart';
 part 'prompts_support.dart';
+part 'request_scoped.dart';
 part 'resources_support.dart';
 part 'roots_tracking_support.dart';
 part 'tools_support.dart';
@@ -27,7 +32,7 @@ final class MCPServerInitialization {
   const MCPServerInitialization({
     required this.protocolVersion,
     required this.clientCapabilities,
-    required this.clientInfo,
+    this.clientInfo,
   });
 
   /// The protocol version used for this connection or request.
@@ -36,8 +41,11 @@ final class MCPServerInitialization {
   /// The capabilities declared by the client.
   final ClientCapabilities clientCapabilities;
 
-  /// The implementation information declared by the client.
-  final Implementation clientInfo;
+  /// The implementation information declared by the client, if any.
+  ///
+  /// The legacy handshake always provides this. Request-scoped transports may
+  /// omit it, since clients are not required to send it on every request.
+  final Implementation? clientInfo;
 }
 
 /// Base class to extend when implementing an MCP server.
@@ -76,8 +84,9 @@ abstract base class MCPServer extends MCPBase {
 
   /// The client implementation information provided during initialization.
   ///
-  /// Only assigned after [initialize] has been called.
-  late Implementation clientInfo;
+  /// `null` until [initialize] has been called, and remains `null` when the
+  /// client did not declare any implementation information.
+  Implementation? clientInfo;
 
   @override
   String get name => implementation.name;

--- a/pkgs/dart_mcp/lib/src/utils/constants.dart
+++ b/pkgs/dart_mcp/lib/src/utils/constants.dart
@@ -84,6 +84,7 @@ extension Keys on Never {
   static const oneOf = 'oneOf';
   static const openWorldHint = 'openWorldHint';
   static const outputSchema = 'outputSchema';
+  static const params = 'params';
   static const path = 'path';
   static const pattern = 'pattern';
   static const patternProperties = 'patternProperties';

--- a/pkgs/dart_mcp/lib/src/utils/constants.dart
+++ b/pkgs/dart_mcp/lib/src/utils/constants.dart
@@ -17,6 +17,7 @@ extension Keys on Never {
   static const cancel = 'cancel';
   static const capabilities = 'capabilities';
   static const clientInfo = 'clientInfo';
+  static const code = 'code';
   static const completion = 'completion';
   static const completions = 'completions';
   static const const_ = 'const';
@@ -44,6 +45,7 @@ extension Keys on Never {
   static const hasMore = 'hasMore';
   static const hints = 'hints';
   static const icons = 'icons';
+  static const id = 'id';
   static const idempotentHint = 'idempotentHint';
   static const includeContext = 'includeContext';
   static const inputSchema = 'inputSchema';
@@ -51,6 +53,7 @@ extension Keys on Never {
   static const intelligencePriority = 'intelligencePriority';
   static const isError = 'isError';
   static const items = 'items';
+  static const jsonrpc = 'jsonrpc';
   static const lastModified = 'lastModified';
   static const level = 'level';
   static const listChanged = 'listChanged';
@@ -65,6 +68,7 @@ extension Keys on Never {
   static const messages = 'messages';
   static const meta = '_meta';
   static const metadata = 'metadata';
+  static const method = 'method';
   static const mimeType = 'mimeType';
   static const minItems = 'minItems';
   static const minLength = 'minLength';
@@ -100,10 +104,12 @@ extension Keys on Never {
   static const resource = 'resource';
   static const resourceTemplates = 'resourceTemplates';
   static const resources = 'resources';
+  static const result = 'result';
   static const role = 'role';
   static const roots = 'roots';
   static const sampling = 'sampling';
   static const serverInfo = 'serverInfo';
+  static const serverInfoMeta = 'io.modelcontextprotocol/serverInfo';
   static const size = 'size';
   static const sizes = 'sizes';
   static const speedPriority = 'speedPriority';

--- a/pkgs/dart_mcp/lib/src/utils/json_rpc_2_object.dart
+++ b/pkgs/dart_mcp/lib/src/utils/json_rpc_2_object.dart
@@ -22,7 +22,15 @@ extension type JsonRpc2Object.fromMap(Map<String, Object?> _value) {
           : JsonRpc2Kind.notification;
 
   /// The method of this message, if it is a request or notification.
-  String? get method => _value[Keys.method] as String?;
+  ///
+  /// Throws an [ArgumentError] if the method is present but not a string.
+  String? get method {
+    final method = _value[Keys.method];
+    if (method is! String?) {
+      throw ArgumentError.value(method, Keys.method, 'Must be a String');
+    }
+    return method;
+  }
 
   /// The id of this message, if it is a request or response.
   ///

--- a/pkgs/dart_mcp/lib/src/utils/json_rpc_2_object.dart
+++ b/pkgs/dart_mcp/lib/src/utils/json_rpc_2_object.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'constants.dart';
+
+/// The kind of a decoded JSON-RPC 2.0 message.
+enum JsonRpc2Kind { request, notification, response }
+
+/// A decoded JSON-RPC 2.0 message.
+extension type JsonRpc2Object.fromMap(Map<String, Object?> _value) {
+  /// The kind of this message.
+  ///
+  /// A message with a `result` or `error` member is a response, any other
+  /// message with an `id` member is a request, and the rest are
+  /// notifications.
+  JsonRpc2Kind get kind =>
+      _value.containsKey(Keys.result) || _value.containsKey(Keys.error)
+          ? JsonRpc2Kind.response
+          : _value.containsKey(Keys.id)
+          ? JsonRpc2Kind.request
+          : JsonRpc2Kind.notification;
+
+  /// The method of this message, if it is a request or notification.
+  Object? get method => _value[Keys.method];
+
+  /// The id of this message, if it is a request or response.
+  Object? get id => _value[Keys.id];
+}
+
+/// A decoded JSON-RPC 2.0 request.
+extension type JsonRpc2Request.fromMap(Map<String, Object?> _value)
+    implements JsonRpc2Object {}
+
+/// A decoded JSON-RPC 2.0 response.
+extension type JsonRpc2Response.fromMap(Map<String, Object?> _value)
+    implements JsonRpc2Object {
+  /// The result of this response, if it is a success response.
+  Object? get result => _value[Keys.result];
+}

--- a/pkgs/dart_mcp/lib/src/utils/json_rpc_2_object.dart
+++ b/pkgs/dart_mcp/lib/src/utils/json_rpc_2_object.dart
@@ -22,9 +22,11 @@ extension type JsonRpc2Object.fromMap(Map<String, Object?> _value) {
           : JsonRpc2Kind.notification;
 
   /// The method of this message, if it is a request or notification.
-  Object? get method => _value[Keys.method];
+  String? get method => _value[Keys.method] as String?;
 
   /// The id of this message, if it is a request or response.
+  ///
+  /// A JSON-RPC id is a `String` or an `int`.
   Object? get id => _value[Keys.id];
 }
 

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -1,0 +1,516 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:dart_mcp/server.dart';
+import 'package:json_rpc_2/error_code.dart' as error_code;
+import 'package:test/test.dart';
+
+import '../test_utils.dart';
+
+void main() {
+  group('request dispatcher', () {
+    test('serves a request on a fresh initialized server', () async {
+      final harness = _DispatcherHarness();
+      final response = await harness.dispatch(
+        _callTool('probe'),
+        _initialization(),
+      );
+
+      expect(harness.servers, hasLength(1));
+      final result = _result(response);
+      final toolResult = CallToolResult.fromMap(result);
+      expect(
+        (toolResult.content.single as TextContent).text,
+        'ready: true',
+        reason: 'initialized must complete before the message is handled',
+      );
+    });
+
+    test('records server info on the response', () async {
+      final harness = _DispatcherHarness();
+      final response = await harness.dispatch(
+        _callTool('probe'),
+        _initialization(),
+      );
+
+      final meta = _result(response)['_meta'] as Map?;
+      final serverInfo = Implementation.fromMap(
+        (meta!['io.modelcontextprotocol/serverInfo'] as Map)
+            .cast<String, Object?>(),
+      );
+      expect(serverInfo.name, 'test server');
+      expect(serverInfo.version, '0.1.0');
+    });
+
+    test('preserves an existing server info entry', () async {
+      final harness = _DispatcherHarness();
+      final response = await harness.dispatch(
+        _callTool('custom_info'),
+        _initialization(),
+      );
+
+      final meta = (_result(response)['_meta'] as Map).cast<String, Object?>();
+      final serverInfo = Implementation.fromMap(
+        (meta['io.modelcontextprotocol/serverInfo'] as Map)
+            .cast<String, Object?>(),
+      );
+      expect(serverInfo.name, 'already there');
+    });
+
+    test('answers even when a result has malformed metadata', () async {
+      final harness = _DispatcherHarness();
+      final response = await harness.dispatch(
+        _callTool('bad_meta'),
+        _initialization(),
+      );
+
+      // Server info stamping is skipped rather than throwing and wedging.
+      expect(_result(response)['_meta'], 'not a map');
+    });
+
+    test('declares client capabilities per request', () async {
+      final harness = _DispatcherHarness();
+      await harness.dispatch(
+        _callTool('probe'),
+        _initialization(
+          capabilities: ClientCapabilities(roots: RootsCapabilities()),
+        ),
+      );
+      await harness.dispatch(_callTool('probe'), _initialization());
+
+      expect(harness.servers, hasLength(2));
+      final first = harness.servers[0];
+      final second = harness.servers[1];
+      expect(first, isNot(same(second)));
+      expect(first.initializedWith?.clientCapabilities.roots, isNotNull);
+      expect(second.initializedWith?.clientCapabilities.roots, isNull);
+    });
+
+    test('serves a request which declares no client info', () async {
+      final harness = _DispatcherHarness();
+      final response = await harness.dispatch(
+        _callTool('probe'),
+        _initialization(),
+      );
+
+      expect(harness.servers.single.clientInfo, isNull);
+      expect(_result(response), isNotEmpty);
+    });
+
+    test('passes emitted notifications to onNotification', () async {
+      final harness = _DispatcherHarness();
+      final notifications = <Map<String, Object?>>[];
+      await harness.dispatch(
+        _callTool('notify'),
+        _initialization(),
+        onNotification: notifications.add,
+      );
+
+      final methods = [for (final n in notifications) n['method']];
+      expect(methods, contains(ProgressNotification.methodName));
+      expect(methods, contains(LoggingMessageNotification.methodName));
+    });
+
+    test('delivers notifications emitted during initialization', () async {
+      final servers = <_RootsTrackingDispatcherServer>[];
+      final notifications = <Map<String, Object?>>[];
+      // Without the roots capability, roots tracking logs a warning as it
+      // initializes, before the dispatched message is handled.
+      await handleRequestScopedMessage(_listTools(), _initialization(), (
+        channel,
+      ) {
+        final server = _RootsTrackingDispatcherServer(channel);
+        servers.add(server);
+        return server;
+      }, onNotification: notifications.add);
+
+      expect(
+        notifications.map((n) => n['method']),
+        contains(LoggingMessageNotification.methodName),
+      );
+    });
+
+    test('fails server to client requests instead of hanging', () async {
+      final harness = _DispatcherHarness();
+      final response = await harness.dispatch(
+        _callTool('roots'),
+        _initialization(),
+      );
+
+      final error = (response!['error'] as Map).cast<String, Object?>();
+      expect(error['code'], error_code.INTERNAL_ERROR);
+      expect(error['message'], contains('request-scoped transport'));
+    });
+
+    test('shuts the server down after a dispatch', () async {
+      final harness = _DispatcherHarness();
+      await harness.dispatch(_callTool('probe'), _initialization());
+
+      final server = harness.servers.single;
+      await server.done;
+      expect(server.isActive, isFalse);
+    });
+
+    test('returns an internal error when the server closes early', () async {
+      final harness = _DispatcherHarness();
+      final response = await harness.dispatch(
+        _callTool('shutdown'),
+        _initialization(),
+      );
+
+      final error = (response!['error'] as Map).cast<String, Object?>();
+      expect(error['code'], error_code.INTERNAL_ERROR);
+      expect(error['message'], contains('closed before responding'));
+    });
+
+    test('surfaces initialization failures without unhandled errors', () async {
+      final servers = <_FailingInitServer>[];
+      await expectLater(
+        handleRequestScopedMessage(_callTool('probe'), _initialization(), (
+          channel,
+        ) {
+          final server = _FailingInitServer(channel);
+          servers.add(server);
+          return server;
+        }),
+        throwsStateError,
+      );
+      await servers.single.done;
+    });
+
+    test('responds with method not found for unknown methods', () async {
+      final harness = _DispatcherHarness();
+      final response = await harness.dispatch({
+        'jsonrpc': '2.0',
+        'id': 1,
+        'method': 'no/such_method',
+      }, _initialization());
+
+      final error = (response!['error'] as Map).cast<String, Object?>();
+      expect(error['code'], error_code.METHOD_NOT_FOUND);
+      expect(
+        response.containsKey('result'),
+        isFalse,
+        reason: 'error responses get no result and no server info',
+      );
+    });
+
+    test('throws for messages without a method', () async {
+      final harness = _DispatcherHarness();
+      await expectLater(
+        harness.dispatch({
+          'jsonrpc': '2.0',
+          'id': 1,
+          'result': <String, Object?>{},
+        }, _initialization()),
+        throwsArgumentError,
+      );
+      expect(harness.servers, isEmpty);
+    });
+
+    test('throws for response-shaped messages', () async {
+      final harness = _DispatcherHarness();
+      await expectLater(
+        harness.dispatch({
+          'jsonrpc': '2.0',
+          'id': 1,
+          'method': ListToolsRequest.methodName,
+          'result': <String, Object?>{},
+        }, _initialization()),
+        throwsArgumentError,
+      );
+      await expectLater(
+        harness.dispatch({
+          'jsonrpc': '2.0',
+          'id': 1,
+          'method': ListToolsRequest.methodName,
+          'error': <String, Object?>{'code': 0, 'message': 'x'},
+        }, _initialization()),
+        throwsArgumentError,
+      );
+      expect(harness.servers, isEmpty);
+    });
+
+    test('throws for legacy lifecycle messages', () async {
+      final harness = _DispatcherHarness();
+      await expectLater(
+        harness.dispatch({
+          'jsonrpc': '2.0',
+          'id': 1,
+          'method': InitializeRequest.methodName,
+        }, _initialization()),
+        throwsArgumentError,
+      );
+      await expectLater(
+        harness.dispatch({
+          'jsonrpc': '2.0',
+          'method': InitializedNotification.methodName,
+        }, _initialization()),
+        throwsArgumentError,
+      );
+      expect(harness.servers, isEmpty);
+    });
+
+    test('returns null for notifications', () async {
+      final harness = _DispatcherHarness();
+      final response = await harness.dispatch({
+        'jsonrpc': '2.0',
+        'method': _DispatcherTestServer.testNotification,
+      }, _initialization());
+
+      expect(response, isNull);
+      expect(harness.servers.single.testNotifications, 1);
+    });
+
+    test('throws for a message with a null id', () async {
+      final harness = _DispatcherHarness();
+      await expectLater(
+        harness.dispatch({
+          'jsonrpc': '2.0',
+          'id': null,
+          'method': ListToolsRequest.methodName,
+        }, _initialization()),
+        throwsArgumentError,
+      );
+      expect(harness.servers, isEmpty);
+    });
+
+    test(
+      'reports a throwing onNotification without failing the request',
+      () async {
+        final harness = _DispatcherHarness();
+        final callbackErrors = <Object>[];
+        Map<String, Object?>? response;
+        await runZonedGuarded(() async {
+          response = await harness.dispatch(
+            _callTool('notify'),
+            _initialization(),
+            onNotification: (_) => throw StateError('bad callback'),
+          );
+        }, (error, _) => callbackErrors.add(error));
+
+        expect(_result(response), isNotEmpty);
+        expect(callbackErrors, isNotEmpty);
+      },
+    );
+
+    test('isolates concurrent dispatches', () async {
+      final harness = _DispatcherHarness();
+      final responses = await Future.wait([
+        harness.dispatch(
+          _callTool('slow_echo', arguments: {'message': 'first'}),
+          _initialization(
+            capabilities: ClientCapabilities(roots: RootsCapabilities()),
+          ),
+        ),
+        harness.dispatch(
+          _callTool('slow_echo', arguments: {'message': 'second'}),
+          _initialization(),
+        ),
+      ]);
+
+      final texts = [
+        for (final response in responses)
+          (CallToolResult.fromMap(_result(response)).content.single
+                  as TextContent)
+              .text,
+      ];
+      expect(texts, ['first', 'second']);
+      expect(harness.servers, hasLength(2));
+      expect(
+        harness.servers[0].initializedWith?.clientCapabilities.roots,
+        isNotNull,
+      );
+      expect(
+        harness.servers[1].initializedWith?.clientCapabilities.roots,
+        isNull,
+      );
+    });
+
+    test('degrades gracefully with roots tracking mixed in', () async {
+      final servers = <_RootsTrackingDispatcherServer>[];
+      final response = await handleRequestScopedMessage(
+        _listTools(),
+        _initialization(
+          capabilities: ClientCapabilities(roots: RootsCapabilities()),
+        ),
+        (channel) {
+          final server = _RootsTrackingDispatcherServer(channel);
+          servers.add(server);
+          return server;
+        },
+      );
+
+      final tools = ListToolsResult.fromMap(_result(response));
+      expect(tools.tools, isEmpty);
+      await servers.single.done;
+    });
+
+    test(
+      'survives a notification which triggers a server to client request',
+      () async {
+        // The immediate teardown after a notification races the listRoots
+        // request that roots tracking issues on initialization.
+        final response = await handleRequestScopedMessage(
+          {'jsonrpc': '2.0', 'method': _DispatcherTestServer.testNotification},
+          _initialization(
+            capabilities: ClientCapabilities(roots: RootsCapabilities()),
+          ),
+          _RootsTrackingDispatcherServer.new,
+        );
+
+        expect(response, isNull);
+      },
+    );
+  });
+
+  group('legacy lifecycle', () {
+    test('handshake still provides client info', () async {
+      final environment = TestEnvironment(
+        TestMCPClient(),
+        _DispatcherTestServer.new,
+      );
+      await environment.initializeServer();
+
+      expect(
+        environment.server.clientInfo?.name,
+        environment.client.implementation.name,
+      );
+    });
+  });
+}
+
+/// Dispatches messages over [_DispatcherTestServer]s and records the servers
+/// it creates.
+final class _DispatcherHarness {
+  final servers = <_DispatcherTestServer>[];
+
+  Future<Map<String, Object?>?> dispatch(
+    Map<String, Object?> message,
+    MCPServerInitialization initialization, {
+    void Function(Map<String, Object?> notification)? onNotification,
+  }) => handleRequestScopedMessage(message, initialization, (channel) {
+    final server = _DispatcherTestServer(channel);
+    servers.add(server);
+    return server;
+  }, onNotification: onNotification);
+}
+
+/// A server with tools which observe the request-scoped lifecycle.
+final class _DispatcherTestServer extends TestMCPServer
+    with LoggingSupport, ToolsSupport {
+  static const testNotification = 'notifications/test';
+
+  _DispatcherTestServer(super.channel);
+
+  MCPServerInitialization? initializedWith;
+
+  /// How many [testNotification] notifications this server received.
+  int testNotifications = 0;
+
+  @override
+  FutureOr<ServerCapabilities> initialize(
+    MCPServerInitialization initialization,
+  ) {
+    initializedWith = initialization;
+    registerNotificationHandler(testNotification, (Notification? _) {
+      testNotifications++;
+    });
+    registerTool(
+      Tool(name: 'probe', inputSchema: ObjectSchema()),
+      (_) => CallToolResult(content: [TextContent(text: 'ready: $ready')]),
+    );
+    registerTool(
+      Tool(name: 'custom_info', inputSchema: ObjectSchema()),
+      (_) => CallToolResult.fromMap({
+        'content': [TextContent(text: 'custom')],
+        '_meta': {
+          'io.modelcontextprotocol/serverInfo': Implementation(
+            name: 'already there',
+            version: '1.0.0',
+          ),
+        },
+      }),
+    );
+    registerTool(
+      Tool(name: 'bad_meta', inputSchema: ObjectSchema()),
+      (_) => CallToolResult.fromMap({
+        'content': [TextContent(text: 'bad')],
+        '_meta': 'not a map',
+      }),
+    );
+    registerTool(Tool(name: 'notify', inputSchema: ObjectSchema()), (_) {
+      notifyProgress(
+        ProgressNotification(progressToken: ProgressToken(1), progress: 50),
+      );
+      log(LoggingLevel.error, 'from the handler');
+      return CallToolResult(content: [TextContent(text: 'notified')]);
+    });
+    registerTool(Tool(name: 'roots', inputSchema: ObjectSchema()), (_) async {
+      final roots = await listRoots(ListRootsRequest());
+      return CallToolResult(content: [TextContent(text: '$roots')]);
+    });
+    registerTool(Tool(name: 'shutdown', inputSchema: ObjectSchema()), (
+      _,
+    ) async {
+      await shutdown();
+      return CallToolResult(content: [TextContent(text: 'unreachable')]);
+    });
+    registerTool(Tool(name: 'slow_echo', inputSchema: ObjectSchema()), (
+      request,
+    ) async {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      return CallToolResult(
+        content: [TextContent(text: request.arguments!['message'] as String)],
+      );
+    });
+    return super.initialize(initialization);
+  }
+}
+
+/// A server which tracks roots, to exercise a server to client request made
+/// during initialization rather than from a handler.
+final class _RootsTrackingDispatcherServer extends TestMCPServer
+    with LoggingSupport, RootsTrackingSupport, ToolsSupport {
+  _RootsTrackingDispatcherServer(super.channel);
+}
+
+/// A server whose initialization always fails.
+final class _FailingInitServer extends TestMCPServer {
+  _FailingInitServer(super.channel);
+
+  @override
+  // A server which fails to initialize cannot call super first.
+  // ignore: must_call_super
+  FutureOr<ServerCapabilities> initialize(
+    MCPServerInitialization initialization,
+  ) => throw StateError('initialization failed');
+}
+
+Map<String, Object?> _callTool(
+  String name, {
+  Map<String, Object?> arguments = const {},
+}) => {
+  'jsonrpc': '2.0',
+  'id': 1,
+  'method': CallToolRequest.methodName,
+  'params': {'name': name, 'arguments': arguments},
+};
+
+Map<String, Object?> _listTools() => {
+  'jsonrpc': '2.0',
+  'id': 1,
+  'method': ListToolsRequest.methodName,
+};
+
+MCPServerInitialization _initialization({ClientCapabilities? capabilities}) =>
+    MCPServerInitialization(
+      protocolVersion: ProtocolVersion.latestSupported,
+      clientCapabilities: capabilities ?? ClientCapabilities(),
+    );
+
+Map<String, Object?> _result(Map<String, Object?>? response) =>
+    (response!['result'] as Map).cast<String, Object?>();

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:dart_mcp/server.dart';
+import 'package:dart_mcp/src/utils/constants.dart';
 import 'package:json_rpc_2/error_code.dart' as error_code;
 import 'package:test/test.dart';
 
@@ -36,10 +37,9 @@ void main() {
         _initialization(),
       );
 
-      final meta = _result(response)['_meta'] as Map?;
+      final meta = _result(response)[Keys.meta] as Map<String, Object?>;
       final serverInfo = Implementation.fromMap(
-        (meta!['io.modelcontextprotocol/serverInfo'] as Map)
-            .cast<String, Object?>(),
+        meta[Keys.serverInfoMeta] as Map<String, Object?>,
       );
       expect(serverInfo.name, 'test server');
       expect(serverInfo.version, '0.1.0');
@@ -52,10 +52,9 @@ void main() {
         _initialization(),
       );
 
-      final meta = (_result(response)['_meta'] as Map).cast<String, Object?>();
+      final meta = _result(response)[Keys.meta] as Map<String, Object?>;
       final serverInfo = Implementation.fromMap(
-        (meta['io.modelcontextprotocol/serverInfo'] as Map)
-            .cast<String, Object?>(),
+        meta[Keys.serverInfoMeta] as Map<String, Object?>,
       );
       expect(serverInfo.name, 'already there');
     });
@@ -68,7 +67,7 @@ void main() {
       );
 
       // Server info stamping is skipped rather than throwing and wedging.
-      expect(_result(response)['_meta'], 'not a map');
+      expect(_result(response)[Keys.meta], 'not a map');
     });
 
     test('declares client capabilities per request', () async {
@@ -85,8 +84,8 @@ void main() {
       final first = harness.servers[0];
       final second = harness.servers[1];
       expect(first, isNot(same(second)));
-      expect(first.initializedWith?.clientCapabilities.roots, isNotNull);
-      expect(second.initializedWith?.clientCapabilities.roots, isNull);
+      expect(first.clientCapabilities.roots, isNotNull);
+      expect(second.clientCapabilities.roots, isNull);
     });
 
     test('serves a request which declares no client info', () async {
@@ -109,7 +108,7 @@ void main() {
         onNotification: notifications.add,
       );
 
-      final methods = [for (final n in notifications) n['method']];
+      final methods = [for (final n in notifications) n[Keys.method]];
       expect(methods, contains(ProgressNotification.methodName));
       expect(methods, contains(LoggingMessageNotification.methodName));
     });
@@ -128,7 +127,7 @@ void main() {
       }, onNotification: notifications.add);
 
       expect(
-        notifications.map((n) => n['method']),
+        notifications.map((n) => n[Keys.method]),
         contains(LoggingMessageNotification.methodName),
       );
     });
@@ -140,9 +139,9 @@ void main() {
         _initialization(),
       );
 
-      final error = (response!['error'] as Map).cast<String, Object?>();
-      expect(error['code'], error_code.INTERNAL_ERROR);
-      expect(error['message'], contains('request-scoped transport'));
+      final error = response![Keys.error] as Map<String, Object?>;
+      expect(error[Keys.code], error_code.INTERNAL_ERROR);
+      expect(error[Keys.message], contains('request-scoped transport'));
     });
 
     test('shuts the server down after a dispatch', () async {
@@ -161,9 +160,9 @@ void main() {
         _initialization(),
       );
 
-      final error = (response!['error'] as Map).cast<String, Object?>();
-      expect(error['code'], error_code.INTERNAL_ERROR);
-      expect(error['message'], contains('closed before responding'));
+      final error = response![Keys.error] as Map<String, Object?>;
+      expect(error[Keys.code], error_code.INTERNAL_ERROR);
+      expect(error[Keys.message], contains('closed before responding'));
     });
 
     test('surfaces initialization failures without unhandled errors', () async {
@@ -184,27 +183,31 @@ void main() {
     test('responds with method not found for unknown methods', () async {
       final harness = _DispatcherHarness();
       final response = await harness.dispatch({
-        'jsonrpc': '2.0',
-        'id': 1,
-        'method': 'no/such_method',
+        Keys.jsonrpc: '2.0',
+        Keys.id: 1,
+        Keys.method: 'no/such_method',
       }, _initialization());
 
-      final error = (response!['error'] as Map).cast<String, Object?>();
-      expect(error['code'], error_code.METHOD_NOT_FOUND);
+      final error = response![Keys.error] as Map<String, Object?>;
+      expect(error[Keys.code], error_code.METHOD_NOT_FOUND);
       expect(
-        response.containsKey('result'),
+        response.containsKey(Keys.result),
         isFalse,
         reason: 'error responses get no result and no server info',
       );
     });
 
-    test('throws for messages without a method', () async {
+    test('throws for messages without a string method', () async {
       final harness = _DispatcherHarness();
       await expectLater(
+        harness.dispatch({Keys.jsonrpc: '2.0', Keys.id: 1}, _initialization()),
+        throwsArgumentError,
+      );
+      await expectLater(
         harness.dispatch({
-          'jsonrpc': '2.0',
-          'id': 1,
-          'result': <String, Object?>{},
+          Keys.jsonrpc: '2.0',
+          Keys.id: 1,
+          Keys.method: 42,
         }, _initialization()),
         throwsArgumentError,
       );
@@ -215,19 +218,19 @@ void main() {
       final harness = _DispatcherHarness();
       await expectLater(
         harness.dispatch({
-          'jsonrpc': '2.0',
-          'id': 1,
-          'method': ListToolsRequest.methodName,
-          'result': <String, Object?>{},
+          Keys.jsonrpc: '2.0',
+          Keys.id: 1,
+          Keys.method: ListToolsRequest.methodName,
+          Keys.result: <String, Object?>{},
         }, _initialization()),
         throwsArgumentError,
       );
       await expectLater(
         harness.dispatch({
-          'jsonrpc': '2.0',
-          'id': 1,
-          'method': ListToolsRequest.methodName,
-          'error': <String, Object?>{'code': 0, 'message': 'x'},
+          Keys.jsonrpc: '2.0',
+          Keys.id: 1,
+          Keys.method: ListToolsRequest.methodName,
+          Keys.error: <String, Object?>{Keys.code: 0, Keys.message: 'x'},
         }, _initialization()),
         throwsArgumentError,
       );
@@ -238,16 +241,16 @@ void main() {
       final harness = _DispatcherHarness();
       await expectLater(
         harness.dispatch({
-          'jsonrpc': '2.0',
-          'id': 1,
-          'method': InitializeRequest.methodName,
+          Keys.jsonrpc: '2.0',
+          Keys.id: 1,
+          Keys.method: InitializeRequest.methodName,
         }, _initialization()),
         throwsArgumentError,
       );
       await expectLater(
         harness.dispatch({
-          'jsonrpc': '2.0',
-          'method': InitializedNotification.methodName,
+          Keys.jsonrpc: '2.0',
+          Keys.method: InitializedNotification.methodName,
         }, _initialization()),
         throwsArgumentError,
       );
@@ -257,8 +260,8 @@ void main() {
     test('returns null for notifications', () async {
       final harness = _DispatcherHarness();
       final response = await harness.dispatch({
-        'jsonrpc': '2.0',
-        'method': _DispatcherTestServer.testNotification,
+        Keys.jsonrpc: '2.0',
+        Keys.method: _DispatcherTestServer.testNotification,
       }, _initialization());
 
       expect(response, isNull);
@@ -269,9 +272,9 @@ void main() {
       final harness = _DispatcherHarness();
       await expectLater(
         harness.dispatch({
-          'jsonrpc': '2.0',
-          'id': null,
-          'method': ListToolsRequest.methodName,
+          Keys.jsonrpc: '2.0',
+          Keys.id: null,
+          Keys.method: ListToolsRequest.methodName,
         }, _initialization()),
         throwsArgumentError,
       );
@@ -320,14 +323,8 @@ void main() {
       ];
       expect(texts, ['first', 'second']);
       expect(harness.servers, hasLength(2));
-      expect(
-        harness.servers[0].initializedWith?.clientCapabilities.roots,
-        isNotNull,
-      );
-      expect(
-        harness.servers[1].initializedWith?.clientCapabilities.roots,
-        isNull,
-      );
+      expect(harness.servers[0].clientCapabilities.roots, isNotNull);
+      expect(harness.servers[1].clientCapabilities.roots, isNull);
     });
 
     test('degrades gracefully with roots tracking mixed in', () async {
@@ -355,7 +352,10 @@ void main() {
         // The immediate teardown after a notification races the listRoots
         // request that roots tracking issues on initialization.
         final response = await handleRequestScopedMessage(
-          {'jsonrpc': '2.0', 'method': _DispatcherTestServer.testNotification},
+          {
+            Keys.jsonrpc: '2.0',
+            Keys.method: _DispatcherTestServer.testNotification,
+          },
           _initialization(
             capabilities: ClientCapabilities(roots: RootsCapabilities()),
           ),
@@ -406,8 +406,6 @@ final class _DispatcherTestServer extends TestMCPServer
 
   _DispatcherTestServer(super.channel);
 
-  MCPServerInitialization? initializedWith;
-
   /// How many [testNotification] notifications this server received.
   int testNotifications = 0;
 
@@ -415,7 +413,6 @@ final class _DispatcherTestServer extends TestMCPServer
   FutureOr<ServerCapabilities> initialize(
     MCPServerInitialization initialization,
   ) {
-    initializedWith = initialization;
     registerNotificationHandler(testNotification, (Notification? _) {
       testNotifications++;
     });
@@ -426,9 +423,9 @@ final class _DispatcherTestServer extends TestMCPServer
     registerTool(
       Tool(name: 'custom_info', inputSchema: ObjectSchema()),
       (_) => CallToolResult.fromMap({
-        'content': [TextContent(text: 'custom')],
-        '_meta': {
-          'io.modelcontextprotocol/serverInfo': Implementation(
+        Keys.content: [TextContent(text: 'custom')],
+        Keys.meta: {
+          Keys.serverInfoMeta: Implementation(
             name: 'already there',
             version: '1.0.0',
           ),
@@ -438,8 +435,8 @@ final class _DispatcherTestServer extends TestMCPServer
     registerTool(
       Tool(name: 'bad_meta', inputSchema: ObjectSchema()),
       (_) => CallToolResult.fromMap({
-        'content': [TextContent(text: 'bad')],
-        '_meta': 'not a map',
+        Keys.content: [TextContent(text: 'bad')],
+        Keys.meta: 'not a map',
       }),
     );
     registerTool(Tool(name: 'notify', inputSchema: ObjectSchema()), (_) {
@@ -494,16 +491,16 @@ Map<String, Object?> _callTool(
   String name, {
   Map<String, Object?> arguments = const {},
 }) => {
-  'jsonrpc': '2.0',
-  'id': 1,
-  'method': CallToolRequest.methodName,
-  'params': {'name': name, 'arguments': arguments},
+  Keys.jsonrpc: '2.0',
+  Keys.id: 1,
+  Keys.method: CallToolRequest.methodName,
+  Keys.params: {Keys.name: name, Keys.arguments: arguments},
 };
 
 Map<String, Object?> _listTools() => {
-  'jsonrpc': '2.0',
-  'id': 1,
-  'method': ListToolsRequest.methodName,
+  Keys.jsonrpc: '2.0',
+  Keys.id: 1,
+  Keys.method: ListToolsRequest.methodName,
 };
 
 MCPServerInitialization _initialization({ClientCapabilities? capabilities}) =>
@@ -513,4 +510,4 @@ MCPServerInitialization _initialization({ClientCapabilities? capabilities}) =>
     );
 
 Map<String, Object?> _result(Map<String, Object?>? response) =>
-    (response!['result'] as Map).cast<String, Object?>();
+    response![Keys.result] as Map<String, Object?>;

--- a/pkgs/dart_mcp/test/server/tools_support_test.dart
+++ b/pkgs/dart_mcp/test/server/tools_support_test.dart
@@ -40,11 +40,11 @@ void main() {
       ProtocolVersion.oldestSupported,
     );
     expect(
-      environment.server.initializedWith?.clientInfo.name,
+      environment.server.initializedWith?.clientInfo?.name,
       environment.client.implementation.name,
     );
     expect(
-      environment.server.initializedWith?.clientInfo.version,
+      environment.server.initializedWith?.clientInfo?.version,
       environment.client.implementation.version,
     );
     expect(environment.server.ready, isFalse);


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162.

Adds `handleRequestScopedMessage` and `MCPServerFactory`: each decoded
JSON-RPC message is served on a fresh `MCPServer` instance (following
https://github.com/dart-lang/ai/pull/524#discussion_r3582076312), which gets
`initialize(MCPServerInitialization)` with the per-request context and a
completed `initialized` before the message is delivered. The shape follows
the sketch in
https://github.com/dart-lang/ai/issues/162#issuecomment-3198530648: a server
factory plus a handle function, no new transport abstraction.

Each message round-trips through an in-memory string channel, so the exchange
runs through the exact same `Peer` validation and dispatch path as a wire
connection; a message-typed channel could drop the extra encode/decode later.
Notifications emitted while handling are surfaced through a callback so a
transport can decide how to deliver them, and server-to-client requests fail
with an error inside their handler instead of deadlocking the exchange; real
routing for those comes with the transport work.

Also makes `MCPServerInitialization.clientInfo` (and `MCPServer.clientInfo`)
nullable, since
https://github.com/modelcontextprotocol/modelcontextprotocol/pull/3002 made
the per-request client info optional, and records the server implementation
on responses under the reserved `io.modelcontextprotocol/serverInfo` result
metadata key which the same spec change added. `RootsTrackingSupport` now
tolerates the connection closing while `listRoots` is in flight, which the
per-request teardown made easy to hit.

Tests:

- `dart_mcp`: analyze clean; format clean (dev SDK); 828/828 tests across
  chrome/vm and dart2wasm/dart2js/kernel/exe. 22 new request-scoped tests
  cover fresh-instance isolation, per-request capabilities, absent client
  info, server info stamping (including malformed metadata), notification
  passthrough, server-to-client request failure, malformed, legacy, and
  response-shaped message rejection, early shutdown, and initialization
  failure, plus a legacy handshake regression test for the nullable client
  info.
- `dart_mcp_examples` (path-overrides the local `dart_mcp`): analyze clean.

This PR does not add Streamable HTTP or any transport; wire formats, envelope
validation, and `server/discover` land separately.

