### PR TITLE
operate on decoded messages instead of JSON strings

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -1,6 +1,25 @@
 ## 0.6.0-wip
 
 - **BREAKING**:
+  - `MCPBase` (including the `MCPServer.fromStreamChannel` and
+    `ServerConnection.fromStreamChannel` constructors),
+    `MCPClient.connectServer`, `MCPServerFactory`, and `stdioChannel` now
+    operate on `StreamChannel<Map<String, Object?>>` instead of
+    `StreamChannel<String>`, so JSON is encoded and decoded only at the
+    transport edge rather than once more within the process.
+    - `stdioChannel` still speaks newline-delimited JSON on the wire, and now
+      itself answers frames which are not JSON objects with JSON-RPC error
+      responses. To migrate other message-framed `StreamChannel<String>`
+      transports, wrap them in the new `jsonRpcChannel` helper in
+      `package:dart_mcp/stdio.dart`, which adapts them the same way.
+    - JSON-RPC batch frames are no longer accepted. Batching was added in
+      protocol version 2025-03-26 and removed in 2025-06-18; a batch now gets
+      a single invalid request error response.
+    - Frames rejected at the transport edge, and the error responses they
+      produce, do not appear in `protocolLogSink`, which now logs each
+      message re-encoded as JSON.
+    - On in-memory channels, `RpcException.data` is no longer normalized by a
+      JSON round trip, so it can be an untyped map.
   - Separate server feature registration from the legacy protocol handshake.
     `MCPServer.initialize` now accepts an `MCPServerInitialization` containing
     the protocol version, client information, and client capabilities, and

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -17,7 +17,8 @@
       a single invalid request error response.
     - Frames rejected at the transport edge, and the error responses they
       produce, do not appear in `protocolLogSink`, which now logs each
-      message re-encoded as JSON.
+      message re-encoded as JSON, falling back to `toString` for messages
+      which cannot be encoded.
     - On in-memory channels, `RpcException.data` is no longer normalized by a
       JSON round trip, so it can be an untyped map.
   - Separate server feature registration from the legacy protocol handshake.

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -37,6 +37,8 @@
   **not** add any transport; wire formats and HTTP support land separately.
 - `RootsTrackingSupport` no longer surfaces an unhandled error when the
   connection closes while a `listRoots` request is in flight.
+- The URL elicitation retry rethrows the original error when its data is not
+  a map, instead of failing with a type error.
 
 ## 0.5.2
 

--- a/pkgs/dart_mcp/README.md
+++ b/pkgs/dart_mcp/README.md
@@ -8,8 +8,10 @@ A Dart package for making MCP servers and clients.
 ## Implementing Servers
 
 To implement a server, import `package:dart_mcp/server.dart` and extend the
-`MCPServer` class. You must provide the server a communication channel to send
-and receive messages with.
+`MCPServer` class. You must provide the server a
+`StreamChannel<Map<String, Object?>>` of decoded JSON-RPC messages to send
+and receive messages with, such as the one returned by `stdioChannel` from
+`package:dart_mcp/stdio.dart`.
 
 For each specific MCP capability or utility your server supports, there is a
 corresponding mixin that you can use (`ToolsSupport`, `ResourcesSupport`, etc).
@@ -62,9 +64,11 @@ can call.
 
 ### Connecting to Servers
 
-You can connect this client with STDIO servers using the
-`MCPClient.connectStdioServer` method, or you can call `MCPClient.connectServer`
-with any other communication channel.
+You can connect this client to STDIO servers by passing the channel returned
+by `stdioChannel` to `MCPClient.connectServer`, or any other
+`StreamChannel<Map<String, Object?>>` of decoded JSON-RPC messages. The
+`jsonRpcChannel` helper in `package:dart_mcp/stdio.dart` adapts a
+`StreamChannel<String>` whose events each contain one complete JSON document.
 
 The returned `ServerConnection` should be used for all interactions with the
 server, starting with a call to `ServerConnection.initialize`, followed up with
@@ -127,8 +131,9 @@ can be used, but some are directly supported out of the box.
 
 ## Batching Requests
 
-Both the client and server support processing batch requests, but do not support
-creating batch requests at this time.
+Batch requests are not supported. Batching was removed from MCP in protocol
+version 2025-06-18, and a batch frame is answered with a single invalid
+request error response, including for clients which negotiated 2025-03-26.
 
 ## Authorization
 

--- a/pkgs/dart_mcp/example/elicitations_client.dart
+++ b/pkgs/dart_mcp/example/elicitations_client.dart
@@ -170,7 +170,7 @@ Do you want to accept (a), decline (d), or cancel (c) the elicitation?
   /// The server we connect to will log the elicitation responses it receives.
   @override
   ServerConnection connectServer(
-    StreamChannel<String> channel, {
+    StreamChannel<Map<String, Object?>> channel, {
     Sink<String>? protocolLogSink,
   }) {
     final connection = super.connectServer(

--- a/pkgs/dart_mcp/example/roots_and_logging_client.dart
+++ b/pkgs/dart_mcp/example/roots_and_logging_client.dart
@@ -79,7 +79,7 @@ final class MCPClientWithRoots extends MCPClient with RootsSupport {
   /// and any time they change.
   @override
   ServerConnection connectServer(
-    StreamChannel<String> channel, {
+    StreamChannel<Map<String, Object?>> channel, {
     Sink<String>? protocolLogSink,
   }) {
     final connection = super.connectServer(

--- a/pkgs/dart_mcp/example/sampling_client.dart
+++ b/pkgs/dart_mcp/example/sampling_client.dart
@@ -87,7 +87,7 @@ final class MCPClientWithSamplingSupport extends MCPClient
   /// The server will log the responses it gets to sampling messages.
   @override
   ServerConnection connectServer(
-    StreamChannel<String> channel, {
+    StreamChannel<Map<String, Object?>> channel, {
     Sink<String>? protocolLogSink,
   }) {
     final connection = super.connectServer(

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -335,8 +335,10 @@ base class ServerConnection extends MCPBase {
       if (_elicitationUrlSupport?.autoHandleUrlElicitationRequired == true &&
           e.code == McpErrorCodes.urlElicitationRequired &&
           data is Map) {
-        // json_rpc_2 copies the error data into an untyped map when it
-        // serializes the exception, so restore the typed view.
+        // `RpcException.serialize` spreads the error data into an untyped map
+        // literal (adding a `request` key), so the map arriving here is not a
+        // `Map<String, Object?>` and a representation type check against
+        // `ElicitRequest` would fail. Restore the typed view instead.
         final elicitRequest = data.cast<String, Object?>() as ElicitRequest;
         final elicitationComplete =
             elicitRequest.onElicitationComplete(this).firstOrNull;

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -331,12 +331,13 @@ base class ServerConnection extends MCPBase {
       // If we are set up to try and auto handle url elicitation and we get
       // an error that the url elicitation is required, we will try and handle
       // it and then retry the request a single time.
+      final data = e.data;
       if (_elicitationUrlSupport?.autoHandleUrlElicitationRequired == true &&
-          e.code == McpErrorCodes.urlElicitationRequired) {
+          e.code == McpErrorCodes.urlElicitationRequired &&
+          data is Map) {
         // json_rpc_2 copies the error data into an untyped map when it
         // serializes the exception, so restore the typed view.
-        final elicitRequest =
-            (e.data as Map).cast<String, Object?>() as ElicitRequest;
+        final elicitRequest = data.cast<String, Object?>() as ElicitRequest;
         final elicitationComplete =
             elicitRequest.onElicitationComplete(this).firstOrNull;
         final elicitResult = await _elicitationUrlSupport!.handleElicitation(

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -74,8 +74,7 @@ base class MCPClient {
   /// Returns a connection for an MCP server using a [channel], which is already
   /// established.
   ///
-  /// Each [String] sent over [channel] represents an entire JSON request or
-  /// response.
+  /// Each map sent over [channel] is a single decoded JSON-RPC message.
   ///
   /// If [protocolLogSink] is provided, all messages sent on [channel] will be
   /// forwarded to that [Sink] as well, with `<<<` preceding incoming messages
@@ -85,7 +84,7 @@ base class MCPClient {
   /// To perform cleanup when this connection is closed, use the
   /// [ServerConnection.done] future.
   ServerConnection connectServer(
-    StreamChannel<String> channel, {
+    StreamChannel<Map<String, Object?>> channel, {
     Sink<String>? protocolLogSink,
   }) {
     // For type promotion in this function.
@@ -334,7 +333,10 @@ base class ServerConnection extends MCPBase {
       // it and then retry the request a single time.
       if (_elicitationUrlSupport?.autoHandleUrlElicitationRequired == true &&
           e.code == McpErrorCodes.urlElicitationRequired) {
-        final elicitRequest = e.data as ElicitRequest;
+        // json_rpc_2 copies the error data into an untyped map when it
+        // serializes the exception, so restore the typed view.
+        final elicitRequest =
+            (e.data as Map).cast<String, Object?>() as ElicitRequest;
         final elicitationComplete =
             elicitRequest.onElicitationComplete(this).firstOrNull;
         final elicitResult = await _elicitationUrlSupport!.handleElicitation(

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -211,8 +211,11 @@ Map<String, Object?> _withServerInfo(
   if (existingMeta != null && existingMeta.containsKey(Keys.serverInfoMeta)) {
     return response;
   }
-  // The response embeds the very maps the handler returned, which may be
-  // retained by the handler or even unmodifiable, so stamp copies of them.
+  // With decoded channels there is no decode step between the server and this
+  // dispatcher, so `result` can be the very map a handler returned. Handlers
+  // may retain that map, and it may not even be modifiable (the built-in ping
+  // handler's `EmptyResult()` is backed by a const map), so stamp copies
+  // instead of modifying it in place.
   return {
     ...response,
     Keys.result: {

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -8,7 +8,8 @@ part of 'server.dart';
 ///
 /// The returned server must be constructed on [channel], typically by passing
 /// it to [MCPServer.fromStreamChannel].
-typedef MCPServerFactory = MCPServer Function(StreamChannel<String> channel);
+typedef MCPServerFactory =
+    MCPServer Function(StreamChannel<Map<String, Object?>> channel);
 
 /// Handles one decoded JSON-RPC [message] on a fresh server instance.
 ///
@@ -103,12 +104,10 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
     );
   }
 
-  // The message is re-encoded onto an in-memory channel so the exchange runs
+  // The message is delivered over an in-memory channel so the exchange runs
   // through the same Peer validation and dispatch path as a wire connection.
-  // TODO: A message-typed channel could drop the per-message encode/decode.
-  // https://github.com/dart-lang/ai/issues/162
-  final inbound = StreamController<String>();
-  final outbound = StreamController<String>();
+  final inbound = StreamController<Map<String, Object?>>();
+  final outbound = StreamController<Map<String, Object?>>();
   final server = serverFactory(
     StreamChannel.withCloseGuarantee(inbound.stream, outbound.sink),
   );
@@ -116,10 +115,9 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
   final isRequest = object.kind == JsonRpc2Kind.request;
   final response = Completer<Map<String, Object?>?>();
   final subscription = outbound.stream.listen(
-    (encoded) {
+    (data) {
       try {
-        final decoded = (jsonDecode(encoded) as Map).cast<String, Object?>();
-        switch (JsonRpc2Object.fromMap(decoded).kind) {
+        switch (JsonRpc2Object.fromMap(data).kind) {
           case JsonRpc2Kind.request:
             // A request from the server to the client. Nothing can answer it
             // in a single-message exchange, so fail it back to the server
@@ -128,18 +126,16 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
             // already closed.
             if (!inbound.isClosed) {
               inbound.add(
-                jsonEncode(
-                  _errorResponse(
-                    JsonRpc2Request.fromMap(decoded).id,
-                    'Server to client requests are not supported on a '
-                    'request-scoped transport',
-                  ),
+                _errorResponse(
+                  JsonRpc2Request.fromMap(data).id,
+                  'Server to client requests are not supported on a '
+                  'request-scoped transport',
                 ),
               );
             }
           case JsonRpc2Kind.notification:
             try {
-              onNotification?.call(decoded);
+              onNotification?.call(data);
             } catch (error, stackTrace) {
               // A misbehaving callback must not fail the request being
               // handled, but it should still be visible.
@@ -147,15 +143,13 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
             }
           case JsonRpc2Kind.response:
             if (!response.isCompleted) {
-              response.complete(
-                _withServerInfo(decoded, server.implementation),
-              );
+              response.complete(_withServerInfo(data, server.implementation));
             }
         }
       } catch (error, stackTrace) {
         // The server sent a frame we could not process. Never let it wedge or
-        // escape the exchange: a request gets an internal error, anything else
-        // surfaces as an uncaught error.
+        // escape the exchange: a request gets an internal error, anything
+        // else surfaces as an uncaught error.
         if (isRequest && !response.isCompleted) {
           response.complete(
             _errorResponse(
@@ -183,7 +177,7 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
   try {
     await server.initialize(initialization);
     server.handleInitialized();
-    inbound.add(jsonEncode(message));
+    inbound.add(message);
     if (isRequest) return await response.future;
     return null;
   } finally {
@@ -200,26 +194,35 @@ Map<String, Object?> _errorResponse(Object? id, String message) => {
   Keys.error: {Keys.code: error_code.INTERNAL_ERROR, Keys.message: message},
 };
 
-/// Returns [response] with [implementation] recorded under the reserved
-/// `io.modelcontextprotocol/serverInfo` result metadata key.
+/// Returns a copy of [response] with [implementation] recorded under the
+/// reserved `io.modelcontextprotocol/serverInfo` result metadata key.
 ///
-/// Error responses have no result and are returned unchanged, as are results
-/// which already carry a server info entry.
+/// Returns [response] unchanged when there is nothing to stamp: error
+/// responses have no result, and results which already carry a server info
+/// entry or whose metadata is not a string-keyed map are left alone.
 Map<String, Object?> _withServerInfo(
   Map<String, Object?> response,
   Implementation implementation,
 ) {
   final result = JsonRpc2Response.fromMap(response).result;
-  if (result is! Map) return response;
-  final resultMap = result.cast<String, Object?>();
-  final existingMeta = resultMap[Keys.meta];
-  if (existingMeta is! Map?) return response;
-  final meta = existingMeta?.cast<String, Object?>() ?? <String, Object?>{};
-  // Copy so the returned response does not alias the shared server info map.
-  meta.putIfAbsent(
-    Keys.serverInfoMeta,
-    () => Map<String, Object?>.of(implementation as Map<String, Object?>),
-  );
-  resultMap[Keys.meta] = meta;
-  return response;
+  if (result is! Map<String, Object?>) return response;
+  final existingMeta = result[Keys.meta];
+  if (existingMeta is! Map<String, Object?>?) return response;
+  if (existingMeta != null && existingMeta.containsKey(Keys.serverInfoMeta)) {
+    return response;
+  }
+  // The response embeds the very maps the handler returned, which may be
+  // retained by the handler or even unmodifiable, so stamp copies of them.
+  return {
+    ...response,
+    Keys.result: {
+      ...result,
+      Keys.meta: {
+        ...?existingMeta,
+        Keys.serverInfoMeta: Map<String, Object?>.of(
+          implementation as Map<String, Object?>,
+        ),
+      },
+    },
+  };
 }

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:json_rpc_2/error_code.dart' as error_code;
 import 'package:json_rpc_2/json_rpc_2.dart';

--- a/pkgs/dart_mcp/lib/src/shared.dart
+++ b/pkgs/dart_mcp/lib/src/shared.dart
@@ -7,6 +7,7 @@
 library;
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:async/async.dart' show StreamSinkTransformer;
 import 'package:json_rpc_2/json_rpc_2.dart';
@@ -46,10 +47,16 @@ base class MCPBase {
   /// Initializes an MCP connection on [channel].
   ///
   /// If [protocolLogSink] is provided, all incoming and outgoing messages will
-  /// added logged to it. It is the responsibility of the caller to close the
+  /// be logged to it. It is the responsibility of the caller to close the
   /// sink.
-  MCPBase(StreamChannel<String> channel, {Sink<String>? protocolLogSink}) {
-    _peer = Peer(_maybeForwardMessages(channel, protocolLogSink));
+  MCPBase(
+    StreamChannel<Map<String, Object?>> channel, {
+    Sink<String>? protocolLogSink,
+  }) {
+    // The channel type admits only JSON objects, so json_rpc_2 never
+    // receives a batch and never writes the `List` frames its batch support
+    // would answer one with.
+    _peer = Peer.withoutJson(_maybeForwardMessages(channel, protocolLogSink));
     registerNotificationHandler(
       ProgressNotification.methodName,
       _handleProgress,
@@ -181,8 +188,8 @@ base class MCPBase {
   ///
   /// This is intended to be written to a file or emitted to a user to aid in
   /// debugging protocol messages between the client and server.
-  StreamChannel<String> _maybeForwardMessages(
-    StreamChannel<String> channel,
+  StreamChannel<Map<String, Object?>> _maybeForwardMessages(
+    StreamChannel<Map<String, Object?>> channel,
     Sink<String>? protocolLogSink,
   ) {
     if (protocolLogSink == null) return channel;
@@ -191,7 +198,7 @@ base class MCPBase {
         .transformStream(
           StreamTransformer.fromHandlers(
             handleData: (data, sink) {
-              protocolLogSink.add('<<< ($name) $data\n');
+              protocolLogSink.add('<<< ($name) ${jsonEncode(data)}\n');
               sink.add(data);
             },
           ),
@@ -199,7 +206,7 @@ base class MCPBase {
         .transformSink(
           StreamSinkTransformer.fromHandlers(
             handleData: (data, sink) {
-              protocolLogSink.add('>>> ($name) $data\n');
+              protocolLogSink.add('>>> ($name) ${jsonEncode(data)}\n');
               sink.add(data);
             },
           ),

--- a/pkgs/dart_mcp/lib/src/shared.dart
+++ b/pkgs/dart_mcp/lib/src/shared.dart
@@ -193,12 +193,21 @@ base class MCPBase {
     Sink<String>? protocolLogSink,
   ) {
     if (protocolLogSink == null) return channel;
+    String encodeForLog(Map<String, Object?> data) {
+      try {
+        return jsonEncode(data);
+      } catch (_) {
+        // The log is diagnostic only, so a message which cannot be encoded
+        // must not fail the connection.
+        return '$data';
+      }
+    }
 
     return channel
         .transformStream(
           StreamTransformer.fromHandlers(
             handleData: (data, sink) {
-              protocolLogSink.add('<<< ($name) ${jsonEncode(data)}\n');
+              protocolLogSink.add('<<< ($name) ${encodeForLog(data)}\n');
               sink.add(data);
             },
           ),
@@ -206,7 +215,7 @@ base class MCPBase {
         .transformSink(
           StreamSinkTransformer.fromHandlers(
             handleData: (data, sink) {
-              protocolLogSink.add('>>> ($name) ${jsonEncode(data)}\n');
+              protocolLogSink.add('>>> ($name) ${encodeForLog(data)}\n');
               sink.add(data);
             },
           ),

--- a/pkgs/dart_mcp/lib/stdio.dart
+++ b/pkgs/dart_mcp/lib/stdio.dart
@@ -45,7 +45,7 @@ StreamChannel<Map<String, Object?>> stdioChannel({
 StreamChannel<Map<String, Object?>> jsonRpcChannel(
   StreamChannel<String> channel,
 ) {
-  void answer(int code, String message, Object? request) {
+  void answerWithError(int code, String message, Object? request) {
     channel.sink.add(
       jsonEncode(RpcException(code, message).serialize(request)),
     );
@@ -54,17 +54,19 @@ StreamChannel<Map<String, Object?>> jsonRpcChannel(
   final stream =
       channel.stream
           .map<Object?>(jsonDecode)
-          .handleError((Object error) {
-            final formatException = error as FormatException;
-            answer(
+          .handleError((Object error, StackTrace stackTrace) {
+            if (error is! FormatException) {
+              Error.throwWithStackTrace(error, stackTrace);
+            }
+            answerWithError(
               error_code.PARSE_ERROR,
-              'Invalid JSON: ${formatException.message}',
-              formatException.source,
+              'Invalid JSON: ${error.message}',
+              error.source,
             );
           }, test: (error) => error is FormatException)
           .where((message) {
             if (message is Map<String, Object?>) return true;
-            answer(
+            answerWithError(
               error_code.INVALID_REQUEST,
               message is List
                   ? 'Batch messages are not supported. Batching was removed '

--- a/pkgs/dart_mcp/lib/stdio.dart
+++ b/pkgs/dart_mcp/lib/stdio.dart
@@ -6,22 +6,79 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:async/async.dart';
+import 'package:json_rpc_2/error_code.dart' as error_code;
+import 'package:json_rpc_2/json_rpc_2.dart';
 import 'package:stream_channel/stream_channel.dart';
 
-/// Creates a [StreamChannel] for Stdio communication where messages are
-/// separated by newlines.
+/// Creates a [StreamChannel] for Stdio communication where each message is a
+/// map, encoded as JSON on its own line.
 ///
 /// This expects incoming messages on [input], and writes messages to [output].
-StreamChannel<String> stdioChannel({
+/// Frames which are not JSON objects are answered with JSON-RPC error
+/// responses and never surface on the channel; see [jsonRpcChannel].
+StreamChannel<Map<String, Object?>> stdioChannel({
   required Stream<List<int>> input,
   required StreamSink<List<int>> output,
-}) => StreamChannel.withCloseGuarantee(input, output)
-    .transform(StreamChannelTransformer.fromCodec(utf8))
-    .transformStream(const LineSplitter())
-    .transformSink(
-      StreamSinkTransformer.fromHandlers(
-        handleData: (data, sink) {
-          sink.add('$data\n');
-        },
+}) => jsonRpcChannel(
+  StreamChannel.withCloseGuarantee(input, output)
+      .transform(StreamChannelTransformer.fromCodec(utf8))
+      .transformStream(const LineSplitter())
+      .transformSink(
+        StreamSinkTransformer.fromHandlers(
+          handleData: (data, sink) {
+            sink.add('$data\n');
+          },
+        ),
       ),
+);
+
+/// Adapts a channel of JSON strings into a channel of decoded JSON-RPC
+/// messages.
+///
+/// Each event on [channel] must contain one complete JSON document; this
+/// helper does not provide framing.
+///
+/// Frames which are not valid JSON, or which decode to something other than a
+/// JSON object, are answered on [channel] with a JSON-RPC error response and
+/// never surface on the returned channel. This includes JSON-RPC batch
+/// frames, which MCP removed in protocol version 2025-06-18.
+StreamChannel<Map<String, Object?>> jsonRpcChannel(
+  StreamChannel<String> channel,
+) {
+  void answer(int code, String message, Object? request) {
+    channel.sink.add(
+      jsonEncode(RpcException(code, message).serialize(request)),
     );
+  }
+
+  final stream =
+      channel.stream
+          .map<Object?>(jsonDecode)
+          .handleError((Object error) {
+            final formatException = error as FormatException;
+            answer(
+              error_code.PARSE_ERROR,
+              'Invalid JSON: ${formatException.message}',
+              formatException.source,
+            );
+          }, test: (error) => error is FormatException)
+          .where((message) {
+            if (message is Map<String, Object?>) return true;
+            answer(
+              error_code.INVALID_REQUEST,
+              message is List
+                  ? 'Batch messages are not supported. Batching was removed '
+                      'in MCP protocol version 2025-06-18.'
+                  : 'Message must be a JSON object.',
+              message,
+            );
+            return false;
+          })
+          .cast<Map<String, Object?>>();
+  final sink = StreamSinkTransformer<Map<String, Object?>, String>.fromHandlers(
+    handleData: (data, sink) {
+      sink.add(jsonEncode(data));
+    },
+  ).bind(channel.sink);
+  return StreamChannel.withCloseGuarantee(stream, sink);
+}

--- a/pkgs/dart_mcp/test/client/elicitation_test.dart
+++ b/pkgs/dart_mcp/test/client/elicitation_test.dart
@@ -6,7 +6,9 @@ import 'dart:async';
 
 import 'package:dart_mcp/client.dart';
 import 'package:dart_mcp/server.dart';
+import 'package:dart_mcp/src/utils/constants.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';
+import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
 
 import '../test_utils.dart';
@@ -146,6 +148,49 @@ void main() {
       );
 
       expect(toolCallCount, 1);
+    });
+
+    test('rethrows when the error data is not a map', () async {
+      final clientController = StreamController<Map<String, Object?>>();
+      final serverController = StreamController<Map<String, Object?>>();
+      final client = TestMCPClientWithElicitationUrlSupport(
+        elicitationHandler: (request, connection) async {
+          fail('should not elicit without an elicitation request');
+        },
+      );
+      addTearDown(client.shutdown);
+      final connection = client.connectServer(
+        StreamChannel.withGuarantees(
+          clientController.stream,
+          serverController.sink,
+        ),
+      );
+      // Answer like a non-Dart server which attaches something other than an
+      // elicitation request as the error data.
+      serverController.stream.listen((request) {
+        clientController.add({
+          Keys.jsonrpc: '2.0',
+          Keys.id: request[Keys.id],
+          Keys.error: {
+            Keys.code: McpErrorCodes.urlElicitationRequired,
+            Keys.message: 'Url required',
+            Keys.data: 'not a map',
+          },
+        });
+      });
+
+      await expectLater(
+        () => connection.callTool(CallToolRequest(name: 'test_tool')),
+        throwsA(
+          isA<RpcException>()
+              .having(
+                (e) => e.code,
+                'code',
+                McpErrorCodes.urlElicitationRequired,
+              )
+              .having((e) => e.data, 'data', 'not a map'),
+        ),
+      );
     });
   });
 }

--- a/pkgs/dart_mcp/test/client_and_server_test.dart
+++ b/pkgs/dart_mcp/test/client_and_server_test.dart
@@ -76,6 +76,24 @@ void main() {
     );
   });
 
+  test('protocol log survives unencodable messages', () async {
+    final serverLog = StreamController<String>();
+    final environment = TestEnvironment(
+      TestMCPClient(),
+      (c) => _BadMetaToolServer(c, protocolLogSink: serverLog.sink),
+    );
+    await environment.initializeServer();
+
+    expect(
+      serverLog.stream,
+      emitsThrough(allOf(startsWith('>>>'), contains('{1: kept}'))),
+    );
+    final result = await environment.serverConnection.callTool(
+      CallToolRequest(name: 'bad_meta_keys'),
+    );
+    expect((result.content.single as TextContent).text, 'kept');
+  });
+
   test('client and server can ping each other', () async {
     final environment = TestEnvironment(TestMCPClient(), TestMCPServer.new);
     await environment.initializeServer();
@@ -437,5 +455,25 @@ final class TestUnrecognizedVersionMcpServer extends TestMCPServer {
     final response = await super.initializeLegacy(request);
     (response as Map<String, Object?>)['protocolVersion'] = 'fooBar';
     return response;
+  }
+}
+
+/// A server whose only tool returns a result with non-string metadata keys,
+/// which cannot be JSON encoded.
+final class _BadMetaToolServer extends TestMCPServer with ToolsSupport {
+  _BadMetaToolServer(super.channel, {super.protocolLogSink});
+
+  @override
+  FutureOr<ServerCapabilities> initialize(
+    MCPServerInitialization initialization,
+  ) {
+    registerTool(
+      Tool(name: 'bad_meta_keys', inputSchema: ObjectSchema()),
+      (_) => CallToolResult.fromMap({
+        Keys.content: [TextContent(text: 'kept')],
+        Keys.meta: {1: 'kept'},
+      }),
+    );
+    return super.initialize(initialization);
   }
 }

--- a/pkgs/dart_mcp/test/client_and_server_test.dart
+++ b/pkgs/dart_mcp/test/client_and_server_test.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:async/async.dart';
 import 'package:dart_mcp/client.dart';
 import 'package:dart_mcp/server.dart';
+import 'package:dart_mcp/src/utils/constants.dart';
 import 'package:json_rpc_2/error_code.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';
 import 'package:stream_channel/stream_channel.dart';
@@ -89,7 +90,7 @@ void main() {
         StreamTransformer.fromHandlers(
           handleData: (data, sink) async {
             // Simulate a server that doesn't respond for 100ms.
-            if (data.contains('"ping"')) return;
+            if (data[Keys.method] == PingRequest.methodName) return;
             sink.add(data);
           },
         ),
@@ -112,7 +113,7 @@ void main() {
         StreamSinkTransformer.fromHandlers(
           handleData: (data, sink) async {
             // Simulate a client that doesn't respond.
-            if (data.contains('"ping"')) return;
+            if (data[Keys.method] == PingRequest.methodName) return;
             sink.add(data);
           },
         ),
@@ -225,11 +226,14 @@ void main() {
       ListRootsProgressTestMCPClient(),
       (channel) => TestMCPServer(
         channel.transformSink(
-          StreamSinkTransformer<String, String>.fromHandlers(
+          StreamSinkTransformer<
+            Map<String, Object?>,
+            Map<String, Object?>
+          >.fromHandlers(
             handleData: (data, sink) async {
               // Add a short delay when sending out a list roots request so
               // we can get progress notifications.
-              if (data.contains(ListRootsRequest.methodName)) {
+              if (data[Keys.method] == ListRootsRequest.methodName) {
                 await Future<void>.delayed(const Duration(milliseconds: 10));
               }
               sink.add(data);
@@ -326,45 +330,21 @@ void main() {
   });
 
   group('error handling', () {
-    test('client can handle invalid protocol messages', () async {
-      final protocolController = StreamController<String>();
-      final environment = TestEnvironment(
-        TestMCPClient(),
-        TestMCPServer.new,
-        protocolLogSink: protocolController.sink,
-      );
-      environment.serverChannel.sink.add('Just some random text');
-      expect(
-        protocolController.stream,
-        emitsThrough(allOf(startsWith('>>>'), contains('Invalid JSON'))),
-      );
-      expect(environment.initializeServer(), completes);
-    });
-
-    test('server can handle invalid protocol messages', () async {
-      final protocolController = StreamController<String>();
-      final environment = TestEnvironment(
-        TestMCPClient(),
-        TestMCPServer.new,
-        protocolLogSink: protocolController.sink,
-      );
-      environment.clientChannel.sink.add('Just some random text');
-      expect(
-        protocolController.stream,
-        emitsThrough(allOf(startsWith('<<<'), contains('Invalid JSON'))),
-      );
+    test('server survives a map which is not a valid message', () async {
+      final environment = TestEnvironment(TestMCPClient(), TestMCPServer.new);
+      environment.clientChannel.sink.add({'foo': 1});
       expect(environment.initializeServer(), completes);
     });
 
     test('server exits before initialization', () {
       final client = TestMCPClient();
-      final clientController = StreamController<String>();
-      final serverController = StreamController<String>();
-      final clientChannel = StreamChannel<String>.withGuarantees(
+      final clientController = StreamController<Map<String, Object?>>();
+      final serverController = StreamController<Map<String, Object?>>();
+      final clientChannel = StreamChannel<Map<String, Object?>>.withGuarantees(
         clientController.stream,
         serverController.sink,
       );
-      final serverChannel = StreamChannel<String>.withGuarantees(
+      final serverChannel = StreamChannel<Map<String, Object?>>.withGuarantees(
         serverController.stream,
         clientController.sink,
       );

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -70,6 +70,39 @@ void main() {
       expect(_result(response)[Keys.meta], 'not a map');
     });
 
+    test('answers even when metadata has non-string keys', () async {
+      final harness = _DispatcherHarness();
+      final response = await harness.dispatch(
+        _callTool('bad_meta_keys'),
+        _initialization(),
+      );
+
+      // Server info stamping is skipped rather than throwing and wedging.
+      expect(_result(response)[Keys.meta], {1: 'kept'});
+    });
+
+    test('stamps server info on an unmodifiable result', () async {
+      final harness = _DispatcherHarness();
+      // The built-in ping handler returns `EmptyResult()`, which is backed
+      // by a const map.
+      final response = await harness.dispatch(_ping(), _initialization());
+
+      final meta = _result(response)[Keys.meta] as Map<String, Object?>;
+      expect(meta[Keys.serverInfoMeta], isNotNull);
+    });
+
+    test('leaves the result map a handler returned unmodified', () async {
+      final harness = _DispatcherHarness();
+      final response = await harness.dispatch(
+        _callTool('retained'),
+        _initialization(),
+      );
+
+      expect(_result(response)[Keys.meta], isNotNull);
+      final retained = harness.servers.single.retainedResult!;
+      expect(retained, isNot(contains(Keys.meta)));
+    });
+
     test('declares client capabilities per request', () async {
       final harness = _DispatcherHarness();
       await harness.dispatch(
@@ -409,6 +442,10 @@ final class _DispatcherTestServer extends TestMCPServer
   /// How many [testNotification] notifications this server received.
   int testNotifications = 0;
 
+  /// The result map the `retained` tool returned, to assert that server info
+  /// stamping does not write into it.
+  Map<String, Object?>? retainedResult;
+
   @override
   FutureOr<ServerCapabilities> initialize(
     MCPServerInitialization initialization,
@@ -439,6 +476,19 @@ final class _DispatcherTestServer extends TestMCPServer
         Keys.meta: 'not a map',
       }),
     );
+    registerTool(
+      Tool(name: 'bad_meta_keys', inputSchema: ObjectSchema()),
+      (_) => CallToolResult.fromMap({
+        Keys.content: [TextContent(text: 'bad')],
+        Keys.meta: {1: 'kept'},
+      }),
+    );
+    registerTool(Tool(name: 'retained', inputSchema: ObjectSchema()), (_) {
+      retainedResult = {
+        Keys.content: [TextContent(text: 'kept')],
+      };
+      return CallToolResult.fromMap(retainedResult!);
+    });
     registerTool(Tool(name: 'notify', inputSchema: ObjectSchema()), (_) {
       notifyProgress(
         ProgressNotification(progressToken: ProgressToken(1), progress: 50),
@@ -501,6 +551,12 @@ Map<String, Object?> _listTools() => {
   Keys.jsonrpc: '2.0',
   Keys.id: 1,
   Keys.method: ListToolsRequest.methodName,
+};
+
+Map<String, Object?> _ping() => {
+  Keys.jsonrpc: '2.0',
+  Keys.id: 1,
+  Keys.method: PingRequest.methodName,
 };
 
 MCPServerInitialization _initialization({ClientCapabilities? capabilities}) =>

--- a/pkgs/dart_mcp/test/stdio_test.dart
+++ b/pkgs/dart_mcp/test/stdio_test.dart
@@ -1,0 +1,188 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:async/async.dart';
+import 'package:dart_mcp/server.dart';
+import 'package:dart_mcp/src/utils/constants.dart';
+import 'package:dart_mcp/stdio.dart';
+import 'package:json_rpc_2/error_code.dart' as error_code;
+import 'package:stream_channel/stream_channel.dart';
+import 'package:test/test.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  group('jsonRpcChannel', () {
+    test('decodes json objects and encodes them back', () async {
+      final harness = _EdgeHarness();
+      harness.wireIn.add(
+        jsonEncode({Keys.jsonrpc: '2.0', Keys.method: 'notifications/test'}),
+      );
+      await pumpEventQueue();
+      expect(harness.received.single[Keys.method], 'notifications/test');
+
+      harness.channel.sink.add({Keys.jsonrpc: '2.0', Keys.id: 1});
+      expect(jsonDecode(await harness.wire.next), {
+        Keys.jsonrpc: '2.0',
+        Keys.id: 1,
+      });
+    });
+
+    test('answers invalid json with a parse error', () async {
+      final harness = _EdgeHarness();
+      harness.wireIn.add('Just some random text');
+
+      final response = await harness.nextWireObject();
+      expect(response[Keys.id], isNull);
+      final error = _error(response);
+      expect(error[Keys.code], error_code.PARSE_ERROR);
+      expect(error[Keys.message], contains('Invalid JSON'));
+    });
+
+    test('answers a frame which is not a json object', () async {
+      final harness = _EdgeHarness();
+      harness.wireIn.add('42');
+
+      final response = await harness.nextWireObject();
+      expect(response[Keys.id], isNull);
+      final error = _error(response);
+      expect(error[Keys.code], error_code.INVALID_REQUEST);
+      expect(error[Keys.message], contains('must be a JSON object'));
+    });
+
+    test('answers a batch frame with an invalid request error', () async {
+      final harness = _EdgeHarness();
+      harness.wireIn.add(
+        jsonEncode([
+          {
+            Keys.jsonrpc: '2.0',
+            Keys.id: 1,
+            Keys.method: PingRequest.methodName,
+          },
+        ]),
+      );
+
+      final response = await harness.nextWireObject();
+      expect(response[Keys.id], isNull);
+      final error = _error(response);
+      expect(error[Keys.code], error_code.INVALID_REQUEST);
+      expect(error[Keys.message], contains('Batch messages are not supported'));
+    });
+
+    test('a server survives invalid frames', () async {
+      final harness = _EdgeHarness(drain: false);
+      final server = TestMCPServer(harness.channel);
+      addTearDown(server.shutdown);
+
+      harness.wireIn.add('Just some random text');
+      final parseError = _error(await harness.nextWireObject());
+      expect(parseError[Keys.code], error_code.PARSE_ERROR);
+
+      harness.wireIn.add(
+        jsonEncode({
+          Keys.jsonrpc: '2.0',
+          Keys.id: 1,
+          Keys.method: InitializeRequest.methodName,
+          Keys.params: {
+            Keys.protocolVersion: ProtocolVersion.latestSupported.versionString,
+            Keys.capabilities: <String, Object?>{},
+            Keys.clientInfo: {Keys.name: 'test client', Keys.version: '0.1'},
+          },
+        }),
+      );
+      final response = await harness.nextWireObject();
+      expect(response[Keys.id], 1);
+      expect(response.containsKey(Keys.result), isTrue);
+    });
+
+    test('a client survives invalid frames', () async {
+      final harness = _EdgeHarness(drain: false);
+      final client = TestMCPClient();
+      addTearDown(client.shutdown);
+      final connection = client.connectServer(harness.channel);
+
+      harness.wireIn.add('Just some random text');
+      final parseError = _error(await harness.nextWireObject());
+      expect(parseError[Keys.code], error_code.PARSE_ERROR);
+
+      final initializeDone = connection.initialize(
+        InitializeRequest(
+          protocolVersion: ProtocolVersion.latestSupported,
+          capabilities: client.capabilities,
+          clientInfo: client.implementation,
+        ),
+      );
+      final request = await harness.nextWireObject();
+      expect(request[Keys.method], InitializeRequest.methodName);
+      harness.wireIn.add(
+        jsonEncode({
+          Keys.jsonrpc: '2.0',
+          Keys.id: request[Keys.id],
+          Keys.result: {
+            Keys.protocolVersion: ProtocolVersion.latestSupported.versionString,
+            Keys.capabilities: <String, Object?>{},
+            Keys.serverInfo: {Keys.name: 'test server', Keys.version: '0.1'},
+          },
+        }),
+      );
+      final result = await initializeDone;
+      expect(result.serverInfo.name, 'test server');
+    });
+  });
+
+  group('stdioChannel', () {
+    test('speaks newline delimited json over bytes', () async {
+      final input = StreamController<List<int>>();
+      final output = StreamController<List<int>>();
+      final channel = stdioChannel(input: input.stream, output: output.sink);
+
+      input.add(utf8.encode('{"jsonrpc":"2.0","method":"a"}\n'));
+      expect((await channel.stream.first)[Keys.method], 'a');
+
+      channel.sink.add({Keys.jsonrpc: '2.0', Keys.id: 2});
+      final line = utf8.decode(await output.stream.first);
+      expect(line, endsWith('\n'));
+      expect(jsonDecode(line), {Keys.jsonrpc: '2.0', Keys.id: 2});
+    });
+  });
+}
+
+/// A [jsonRpcChannel] over an in-memory pair of string controllers.
+///
+/// The decoded messages are collected into [received] unless `drain` is
+/// false, in which case the caller owns the stream (for example by handing
+/// [channel] to a server). Wire output is read through [wire] or
+/// [nextWireObject].
+final class _EdgeHarness {
+  _EdgeHarness({bool drain = true}) {
+    addTearDown(close);
+    if (drain) channel.stream.listen(received.add);
+  }
+
+  final wireIn = StreamController<String>();
+  final wireOut = StreamController<String>();
+  final received = <Map<String, Object?>>[];
+
+  late final channel = jsonRpcChannel(
+    StreamChannel.withCloseGuarantee(wireIn.stream, wireOut.sink),
+  );
+
+  late final wire = StreamQueue(wireOut.stream);
+
+  /// Reads the next wire frame and decodes it as a JSON object.
+  Future<Map<String, Object?>> nextWireObject() async =>
+      (jsonDecode(await wire.next) as Map).cast<String, Object?>();
+
+  void close() {
+    unawaited(wireIn.close());
+    unawaited(wireOut.close());
+    unawaited(wire.cancel(immediate: true));
+  }
+}
+
+Map<String, Object?> _error(Object? response) =>
+    ((response as Map)[Keys.error] as Map).cast<String, Object?>();

--- a/pkgs/dart_mcp/test/test_utils.dart
+++ b/pkgs/dart_mcp/test/test_utils.dart
@@ -12,20 +12,22 @@ import 'package:test/test.dart';
 class TestEnvironment<Client extends MCPClient, Server extends MCPServer> {
   /// The client side of the communication channel - the stream is the incoming
   /// data and the sink is outgoing data.
-  final clientController = StreamController<String>();
+  final clientController = StreamController<Map<String, Object?>>();
 
   /// The server side of the communication channel - the stream is the incoming
   /// data and the sink is outgoing data.
-  final serverController = StreamController<String>();
+  final serverController = StreamController<Map<String, Object?>>();
 
-  late final clientChannel = StreamChannel<String>.withCloseGuarantee(
-    serverController.stream,
-    clientController.sink,
-  );
-  late final serverChannel = StreamChannel<String>.withCloseGuarantee(
-    clientController.stream,
-    serverController.sink,
-  );
+  late final clientChannel =
+      StreamChannel<Map<String, Object?>>.withCloseGuarantee(
+        serverController.stream,
+        clientController.sink,
+      );
+  late final serverChannel =
+      StreamChannel<Map<String, Object?>>.withCloseGuarantee(
+        clientController.stream,
+        serverController.sink,
+      );
 
   final Client client;
   late final Server server;
@@ -37,7 +39,7 @@ class TestEnvironment<Client extends MCPClient, Server extends MCPServer> {
   /// You may manually shut down the environment by calling [shutdown].
   TestEnvironment(
     this.client,
-    Server Function(StreamChannel<String>) createServer, {
+    Server Function(StreamChannel<Map<String, Object?>>) createServer, {
     Sink<String>? protocolLogSink,
   }) {
     server = createServer(serverChannel);


### PR DESCRIPTION
Follow-up to [this thread](https://github.com/dart-lang/ai/pull/528#discussion_r3604241409) in #528: `MCPBase`, `MCPClient.connectServer`, `MCPServerFactory`, and `stdioChannel` now operate on `StreamChannel<Map<String, Object?>>` instead of `StreamChannel<String>`, so JSON is encoded and decoded only at the transport edge rather than once more within the process.

- `MCPBase` hands the channel to `Peer.withoutJson`. The channel type admits only JSON objects, so json_rpc_2 never receives a batch and never emits the `List` frames its batch support would answer one with.
- `stdioChannel` still speaks newline-delimited JSON on the wire and now returns the decoded channel. The string-to-map adaptation is exposed separately as `jsonRpcChannel` for other `StreamChannel<String>` transports.
- Behavior deltas worth calling out:
  - Frames which are not valid JSON, or which decode to something other than a JSON object, are answered at the transport edge by `jsonRpcChannel` instead of by json_rpc_2 inside the peer. The two existing invalid-JSON tests moved to `stdio_test.dart` accordingly, and neither those frames nor their error responses appear in `protocolLogSink` anymore (which now logs each message re-encoded as JSON, falling back to `toString` when a message cannot be encoded). If wire-level visibility of rejected frames turns out to matter for debugging, an optional log sink on `jsonRpcChannel` would be a small follow-up.
  - JSON-RPC batch frames now get a single invalid request error response with a null id and a message pointing at the 2025-06-18 removal. Batching was added in protocol version 2025-03-26 and removed in 2025-06-18; this package never sent batches itself.
  - `handleRequestScopedMessage` now stamps server info onto a copy of the response. With decoded channels the response embeds the very maps the handler returned — which may be retained by the handler or even unmodifiable, like `EmptyResult()`'s — where previously it saw private `jsonDecode` copies.
- The URL elicitation retry path now restores a typed view of the error data itself. `RpcException.serialize` copies the data into an untyped map, and the JSON round trip previously re-laundered it to `Map<String, dynamic>` before user code saw it.

Does not add any transport or change protocol behavior beyond the frame type: HTTP, `server/discover`, and roots are untouched. Since 0.6.0-wip has never been published, current `dart_mcp` users only see this when they opt into 0.6.0; `dart_mcp_server` pins `^0.5.0` and migrates with its own 0.6.0 dependency bump.

## Tests

- New `stdio_test.dart` covers `jsonRpcChannel` (decode/encode round trip, parse error and non-object frames with null ids, batch rejection, and a server and a client each surviving invalid frames) plus `stdioChannel` at the byte level.
- New request-scoped tests pin that server info is stamped onto unmodifiable results (the built-in `ping` path) without modifying the map the handler returned, and skipped for metadata with non-string keys.
- A new test pins that a server survives a map which is not a valid message, now representable at the public channel seam.
- `dart test -p chrome,vm -c dart2wasm,dart2js,kernel,exe` passes (218 tests in each of the four configurations).
- `dart analyze --fatal-infos` and `dart format` (dev SDK) are clean here, and in `mcp_examples` resolved against this branch.

Part of #162.

