### PR TITLE
Fix skills create description escaping

### DIFF
--- a/pkgs/skills/CHANGELOG.md
+++ b/pkgs/skills/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.0-wip
+
+- JSON encode descriptions in the `create` command.
+
 ## 1.0.0-beta.4
 
 - Update github repo link to the new location.

--- a/pkgs/skills/lib/src/commands/create_command.dart
+++ b/pkgs/skills/lib/src/commands/create_command.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
@@ -93,7 +94,7 @@ class CreateCommand extends SkillsCommand {
     final skillFile = File(p.join(skillsDir.path, 'SKILL.md'));
     await skillFile.writeAsString('''---
 name: $fullSkillName
-description: $description
+description: ${jsonEncode(description)}
 ---
 
 Add your skill instructions here.

--- a/pkgs/skills/lib/src/core/version.dart
+++ b/pkgs/skills/lib/src/core/version.dart
@@ -2,4 +2,4 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-const String version = '1.0.0-beta.4';
+const String version = '1.0.0-wip';

--- a/pkgs/skills/pubspec.yaml
+++ b/pkgs/skills/pubspec.yaml
@@ -1,9 +1,9 @@
 name: skills
 description: >
   Install AI skills from your Dart and Flutter package deps into your IDE,
-  so Antigravity, Claude, Codex, Cursor, and other agents 
+  so Antigravity, Claude, Codex, Cursor, and other agents
   know how to use your stack.
-version: 1.0.0-beta.4
+version: 1.0.0-wip
 repository: https://github.com/dart-lang/ai/tree/main/pkgs/skills
 issue_tracker: https://github.com/dart-lang/ai/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Askills
 

--- a/pkgs/skills/test/commands/create_command_test.dart
+++ b/pkgs/skills/test/commands/create_command_test.dart
@@ -36,7 +36,7 @@ void main() {
           d.dir('my_package-my-skill', [
             d.file('SKILL.md', '''---
 name: my_package-my-skill
-description: my description
+description: "my description"
 ---
 
 Add your skill instructions here.
@@ -110,6 +110,36 @@ Add your skill instructions here.
           ]),
           throwsA(isA<UsageException>()),
         );
+      },
+    );
+    test(
+      'creates a skill with a description containing special characters',
+      () async {
+        await d.dir('project', [pubspec('my_package')]).create();
+
+        await runner.run([
+          'create',
+          '--name',
+          'my-skill2',
+          '--description',
+          'description with: a colon, "quotes", \nnewlines\tand backticks `like this`',
+          '-C',
+          d.path('project'),
+        ]);
+
+        await d.dir('project', [
+          d.dir('skills', [
+            d.dir('my_package-my-skill2', [
+              d.file('SKILL.md', r'''---
+name: my_package-my-skill2
+description: "description with: a colon, \"quotes\", \nnewlines\tand backticks `like this`"
+---
+
+Add your skill instructions here.
+'''),
+            ]),
+          ]),
+        ]).validate();
       },
     );
   });


### PR DESCRIPTION
Just JSON encode the descriptions, Yaml is a superset of JSON so this should be sufficient.

Fixes #542