### PR TITLE
Emphasize the actual skill name in dialogs

### DIFF
--- a/pkgs/skills/CHANGELOG.md
+++ b/pkgs/skills/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.0-wip
 
+- Emphasize (bold) actual skill names in interactive dialog options.
 - JSON encode descriptions in the `create` command.
 
 ## 1.0.0-beta.4

--- a/pkgs/skills/lib/src/commands/get_skills.dart
+++ b/pkgs/skills/lib/src/commands/get_skills.dart
@@ -679,7 +679,11 @@ Future<_PromptResult> _promptForSkillsToInstall({
             ? ''
             : ' for ${adapters.map((a) => a.agent.cliName).join(', ')}';
 
-        final fullLabel = '${skill.skillName}$agentstr ($labelSuffix)';
+        final formattedSkillName = formatSkillName(
+          skill.skillName,
+          packageName: skill.packageName,
+        );
+        final fullLabel = '$formattedSkillName$agentstr ($labelSuffix)';
 
         dialogOptions.add((
           skill: skill,

--- a/pkgs/skills/lib/src/commands/remove_command.dart
+++ b/pkgs/skills/lib/src/commands/remove_command.dart
@@ -123,17 +123,24 @@ class RemoveCommand extends SkillsCommand {
           for (final MapEntry(key: sourceUri, value: entry)
               in manifest.sourceUrisForAgent(agent.cliName).entries)
             if (sourcesToRemove.isEmpty || sourcesToRemove.contains(sourceUri))
-              ...entry.skills.map((skill) => skill.name),
-      }.toList()..sort();
-      final options = potentialSkills
-          .map((name) => formatSkillName(name))
-          .toList();
+              ...entry.skills.map(
+                (skill) => (name: skill.name, sourceUri: sourceUri),
+              ),
+      }.toList()..sort((a, b) => a.name.compareTo(b.name));
+      final options = potentialSkills.map((skill) {
+        final packageName = skill.sourceUri.startsWith('package:')
+            ? skill.sourceUri.substring('package:'.length)
+            : null;
+        return formatSkillName(skill.name, packageName: packageName);
+      }).toList();
       final selectedIndices = await _dialogSupport.showMultiSelectDialog(
         options,
         title: 'Select skills to remove',
       );
       if (selectedIndices != null) {
-        skillsToRemove.addAll(selectedIndices.map((i) => potentialSkills[i]));
+        skillsToRemove.addAll(
+          selectedIndices.map((i) => potentialSkills[i].name),
+        );
       } else {
         logger.info('Skill removal aborted.');
         return;

--- a/pkgs/skills/lib/src/commands/remove_command.dart
+++ b/pkgs/skills/lib/src/commands/remove_command.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:args/command_runner.dart';
 import 'package:skills/src/core/git_repos.dart';
 

--- a/pkgs/skills/lib/src/commands/remove_command.dart
+++ b/pkgs/skills/lib/src/commands/remove_command.dart
@@ -121,8 +121,11 @@ class RemoveCommand extends SkillsCommand {
             if (sourcesToRemove.isEmpty || sourcesToRemove.contains(sourceUri))
               ...entry.skills.map((skill) => skill.name),
       }.toList()..sort();
+      final options = potentialSkills
+          .map((name) => formatSkillName(name))
+          .toList();
       final selectedIndices = await _dialogSupport.showMultiSelectDialog(
-        potentialSkills,
+        options,
         title: 'Select skills to remove',
       );
       if (selectedIndices != null) {

--- a/pkgs/skills/lib/src/core/dialog_support.dart
+++ b/pkgs/skills/lib/src/core/dialog_support.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:io/ansi.dart' as ansi;
+
 /// Interface for showing dialogs.
 abstract interface class DialogSupport {
   /// Shows a single select dialog with the given [options].
@@ -23,4 +25,37 @@ abstract interface class DialogSupport {
     String? title,
     Set<int> initialSelected = const {},
   });
+}
+
+/// Formats [skillName] for display in CLI dialogs by emphasizing (bolding)
+/// the actual skill name portion (the part after the package name or prefix).
+///
+/// For example:
+/// - `formatSkillName('foo-bar', packageName: 'foo')` -> `'foo-'` + bold `'bar'`
+/// - `formatSkillName('foo-bar-baz')` -> `'foo-'` + bold `'bar-baz'`
+/// - `formatSkillName('simple')` -> bold `'simple'`
+String formatSkillName(String skillName, {String? packageName}) {
+  final prefix = _getSkillPrefix(skillName, packageName: packageName);
+  if (prefix.isEmpty) {
+    return ansi.styleBold.wrap(skillName) ?? skillName;
+  }
+  final rest = skillName.substring(prefix.length);
+  final boldRest = ansi.styleBold.wrap(rest) ?? rest;
+  return '$prefix$boldRest';
+}
+
+String _getSkillPrefix(String skillName, {String? packageName}) {
+  if (packageName != null && packageName.isNotEmpty) {
+    final pkgPrefix = '$packageName-';
+    if (skillName.startsWith(pkgPrefix)) {
+      return pkgPrefix;
+    }
+  }
+  if (skillName.startsWith('flutter-')) {
+    return 'flutter-';
+  }
+  if (skillName.startsWith('dart-')) {
+    return 'dart-';
+  }
+  return '';
 }

--- a/pkgs/skills/lib/src/core/dialog_support.dart
+++ b/pkgs/skills/lib/src/core/dialog_support.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 
 import 'package:io/ansi.dart' as ansi;

--- a/pkgs/skills/test/core/dialog_support_test.dart
+++ b/pkgs/skills/test/core/dialog_support_test.dart
@@ -1,0 +1,69 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:io/ansi.dart';
+import 'package:skills/src/core/dialog_support.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('formatSkillName', () {
+    test(
+      'bolds skill name after package name prefix when package name is given',
+      () {
+        overrideAnsiOutput(true, () {
+          expect(
+            formatSkillName('foo-bar', packageName: 'foo'),
+            equals('foo-\x1B[1mbar\x1B[22m'),
+          );
+          expect(
+            formatSkillName('foo-bar-baz', packageName: 'foo'),
+            equals('foo-\x1B[1mbar-baz\x1B[22m'),
+          );
+        });
+      },
+    );
+
+    test(
+      'bolds skill name after flutter- or dart- prefix when package name is omitted',
+      () {
+        overrideAnsiOutput(true, () {
+          expect(
+            formatSkillName('flutter-widgets'),
+            equals('flutter-\x1B[1mwidgets\x1B[22m'),
+          );
+          expect(
+            formatSkillName('dart-async'),
+            equals('dart-\x1B[1masync\x1B[22m'),
+          );
+        });
+      },
+    );
+
+    test(
+      'bolds entire skill name when package name is omitted and prefix is not flutter-/dart-',
+      () {
+        overrideAnsiOutput(true, () {
+          expect(
+            formatSkillName('my_pkg-custom-skill'),
+            equals('\x1B[1mmy_pkg-custom-skill\x1B[22m'),
+          );
+          expect(
+            formatSkillName('simpleskill'),
+            equals('\x1B[1msimpleskill\x1B[22m'),
+          );
+        });
+      },
+    );
+
+    test('returns plain text when ANSI output is disabled', () {
+      overrideAnsiOutput(false, () {
+        expect(
+          formatSkillName('foo-bar', packageName: 'foo'),
+          equals('foo-bar'),
+        );
+        expect(formatSkillName('simpleskill'), equals('simpleskill'));
+      });
+    });
+  });
+}


### PR DESCRIPTION
Bolds actual skill names in CLI selection dialog options, separating them from package or framework prefixes.

Fixes #548
