### PR TITLE
Make list command more consistent and informative

### DIFF
--- a/pkgs/skills/CHANGELOG.md
+++ b/pkgs/skills/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - Add a --version flag.
 - JSON encode descriptions in the `create` command.
+- Make `list` command more consistent with other commands and more informative:
+  - Add agent aliases to agent labels (e.g., `generic (antigravity, codex)`).
+  - Display actual install directory for each agent in the list header.
+  - Add a note that listed skills are managed skills and additional skills may be installed.
+  - Store relative repository paths in manifest and display in `list` output.
 
 ## 1.0.0-beta.4
 

--- a/pkgs/skills/lib/src/agent/agent.dart
+++ b/pkgs/skills/lib/src/agent/agent.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
@@ -27,6 +31,10 @@ enum Agent {
     Agent.generic => ['antigravity', 'codex'],
     _ => [],
   };
+
+  /// Formatted label including aliases (e.g. "generic (antigravity, codex)").
+  String get label =>
+      '$cliName${cliAliases.isEmpty ? '' : ' (${cliAliases.join(', ')})'}';
 
   /// Returns the absolute skills directory path for this agent within [projectPath].
   String skillsPath(String projectPath) =>

--- a/pkgs/skills/lib/src/commands/get_skills.dart
+++ b/pkgs/skills/lib/src/commands/get_skills.dart
@@ -842,6 +842,9 @@ class OrphanedSkill implements ScannedSkill {
   String? get skillPath => null;
 
   @override
+  String? get path => null;
+
+  @override
   String get sourceUri => gitUrl ?? 'package:${packageName!}';
 
   OrphanedSkill({required String sourceUri, required this.skillName})

--- a/pkgs/skills/lib/src/commands/list_command.dart
+++ b/pkgs/skills/lib/src/commands/list_command.dart
@@ -43,7 +43,7 @@ class ListCommand extends SkillsCommand {
       final String header;
       if (agentObj != null) {
         final adapter = createAgentAdapter(agentObj, rootPath, null);
-        final installDir = p.relative(adapter.skillsDirectory, from: rootPath);
+        final installDir = p.split(p.relative(adapter.skillsDirectory, from: rootPath)).join('/');
         header = '  ${agentObj.label} (installed at $installDir):';
       } else {
         header = '  $agentName:';

--- a/pkgs/skills/lib/src/commands/list_command.dart
+++ b/pkgs/skills/lib/src/commands/list_command.dart
@@ -43,7 +43,9 @@ class ListCommand extends SkillsCommand {
       final String header;
       if (agentObj != null) {
         final adapter = createAgentAdapter(agentObj, rootPath, null);
-        final installDir = p.split(p.relative(adapter.skillsDirectory, from: rootPath)).join('/');
+        final installDir = p
+            .split(p.relative(adapter.skillsDirectory, from: rootPath))
+            .join('/');
         header = '  ${agentObj.label} (installed at $installDir):';
       } else {
         header = '  $agentName:';
@@ -53,10 +55,9 @@ class ListCommand extends SkillsCommand {
       for (final entry in pkgs.entries) {
         buffer.writeln('    ${entry.key}:');
         for (final skill in entry.value.skills) {
-          final pathSuffix =
-              skill.path != null && skill.path != '.'
-                  ? ' (repo path: ${skill.path})'
-                  : '';
+          final pathSuffix = skill.path != null && skill.path != '.'
+              ? ' (repo path: ${skill.path})'
+              : '';
           buffer.writeln('      - ${skill.name}$pathSuffix');
         }
       }

--- a/pkgs/skills/lib/src/commands/list_command.dart
+++ b/pkgs/skills/lib/src/commands/list_command.dart
@@ -1,3 +1,11 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:path/path.dart' as p;
+
+import '../agent/agent.dart';
+import '../agent/agent_adapter_factory.dart';
 import '../models/skill_manifest.dart';
 import 'skills_command.dart';
 
@@ -27,18 +35,38 @@ class ListCommand extends SkillsCommand {
       ..writeln('Installed skills:')
       ..writeln();
 
-    for (final agent in manifest.allAgents) {
-      final pkgs = manifest.sourceUrisForAgent(agent);
+    for (final agentName in manifest.allAgents) {
+      final pkgs = manifest.sourceUrisForAgent(agentName);
       if (pkgs.isEmpty) continue;
 
-      buffer.writeln('  $agent:');
+      final agentObj = Agent.fromCliName(agentName);
+      final String header;
+      if (agentObj != null) {
+        final adapter = createAgentAdapter(agentObj, rootPath, null);
+        final installDir = p.relative(adapter.skillsDirectory, from: rootPath);
+        header = '  ${agentObj.label} (installed at $installDir):';
+      } else {
+        header = '  $agentName:';
+      }
+      buffer.writeln(header);
+
       for (final entry in pkgs.entries) {
         buffer.writeln('    ${entry.key}:');
         for (final skill in entry.value.skills) {
-          buffer.writeln('      - ${skill.name}');
+          final pathSuffix =
+              skill.path != null && skill.path != '.'
+                  ? ' (repo path: ${skill.path})'
+                  : '';
+          buffer.writeln('      - ${skill.name}$pathSuffix');
         }
       }
     }
+
+    buffer
+      ..writeln()
+      ..writeln(
+        'Note: These are only managed skills; there may be additional skills installed.',
+      );
 
     logger.info(buffer.toString());
   }

--- a/pkgs/skills/lib/src/commands/options.dart
+++ b/pkgs/skills/lib/src/commands/options.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:io' show Platform;
 
 import 'package:args/args.dart';
@@ -61,10 +65,7 @@ Future<List<Agent>> resolveAgents({
   if (detected.isNotEmpty) return detected;
 
   if (dialogSupport case var dialogSupport?) {
-    final options = [
-      for (var agent in Agent.values)
-        '${agent.cliName}${agent.cliAliases.isEmpty ? '' : ' (${agent.cliAliases.join(', ')})'}',
-    ];
+    final options = [for (var agent in Agent.values) agent.label];
     final result = await dialogSupport.showMultiSelectDialog(
       options,
       title: 'Unable to auto-detect agent. Please select one or more:',

--- a/pkgs/skills/lib/src/core/git_scanner.dart
+++ b/pkgs/skills/lib/src/core/git_scanner.dart
@@ -68,7 +68,9 @@ class GitScanner {
 
       final skillDir = entity.parent;
       final skillName = p.basename(skillDir.path);
-      final pathInRepo = p.split(p.relative(skillDir.path, from: repoDir.path)).join('/');
+      final pathInRepo = p
+          .split(p.relative(skillDir.path, from: repoDir.path))
+          .join('/');
 
       skills.add(
         ScannedSkill(

--- a/pkgs/skills/lib/src/core/git_scanner.dart
+++ b/pkgs/skills/lib/src/core/git_scanner.dart
@@ -68,7 +68,7 @@ class GitScanner {
 
       final skillDir = entity.parent;
       final skillName = p.basename(skillDir.path);
-      final pathInRepo = p.relative(skillDir.path, from: repoDir.path);
+      final pathInRepo = p.split(p.relative(skillDir.path, from: repoDir.path)).join('/');
 
       skills.add(
         ScannedSkill(

--- a/pkgs/skills/lib/src/core/git_scanner.dart
+++ b/pkgs/skills/lib/src/core/git_scanner.dart
@@ -68,6 +68,7 @@ class GitScanner {
 
       final skillDir = entity.parent;
       final skillName = p.basename(skillDir.path);
+      final pathInRepo = p.relative(skillDir.path, from: repoDir.path);
 
       skills.add(
         ScannedSkill(
@@ -75,6 +76,7 @@ class GitScanner {
           skillName: skillName,
           skillPath: skillDir.path,
           isGlobal: isGlobal,
+          path: pathInRepo,
         ),
       );
     }

--- a/pkgs/skills/lib/src/core/git_scanner.dart
+++ b/pkgs/skills/lib/src/core/git_scanner.dart
@@ -46,12 +46,13 @@ class GitScanner {
     bool isGlobal,
   ) async {
     final skills = <ScannedSkill>[];
-    await _scanDirectory(repoDir, gitUrl, isGlobal, skills);
+    await _scanDirectory(repoDir, repoDir, gitUrl, isGlobal, skills);
     return skills;
   }
 
   Future<void> _scanDirectory(
     Directory dir,
+    Directory repoDir,
     String gitUrl,
     bool isGlobal,
     List<ScannedSkill> skills,
@@ -60,7 +61,7 @@ class GitScanner {
       if (entity is Directory) {
         final name = p.basename(entity.path);
         if (name == 'third_party' || name.startsWith('.')) continue;
-        await _scanDirectory(entity, gitUrl, isGlobal, skills);
+        await _scanDirectory(entity, repoDir, gitUrl, isGlobal, skills);
       } else if (entity is File && p.basename(entity.path) == 'SKILL.md') {
         SkillFrontmatter? frontmatter;
         try {

--- a/pkgs/skills/lib/src/core/skill_installer.dart
+++ b/pkgs/skills/lib/src/core/skill_installer.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 
@@ -277,6 +281,7 @@ class SkillInstaller {
             installedAt: DateTime.now().toUtc(),
             contentHash: null,
             isInstalled: false,
+            path: skill.path,
           ),
         );
         continue;
@@ -290,6 +295,7 @@ class SkillInstaller {
           name: installedName,
           installedAt: DateTime.now().toUtc(),
           contentHash: installResult.contentHash,
+          path: skill.path,
         ),
       );
 

--- a/pkgs/skills/lib/src/core/skill_scanner.dart
+++ b/pkgs/skills/lib/src/core/skill_scanner.dart
@@ -28,12 +28,16 @@ class ScannedSkill {
 
   final bool isGlobal;
 
+  /// Relative path within the source repo or package (e.g. "skills/my-skill").
+  final String? path;
+
   const ScannedSkill({
     this.packageName,
     this.gitUrl,
     required this.skillName,
     required this.skillPath,
     this.isGlobal = false,
+    this.path,
   });
 
   String get sourceUri => gitUrl ?? 'package:$packageName';
@@ -99,11 +103,13 @@ class SkillScanner {
         continue;
       }
 
+      final pathInPackage = p.relative(entity.path, from: package.rootPath);
       skills.add(
         ScannedSkill(
           packageName: package.name,
           skillName: skillName,
           skillPath: entity.path,
+          path: pathInPackage,
         ),
       );
     }

--- a/pkgs/skills/lib/src/core/skill_scanner.dart
+++ b/pkgs/skills/lib/src/core/skill_scanner.dart
@@ -103,7 +103,7 @@ class SkillScanner {
         continue;
       }
 
-      final pathInPackage = p.relative(entity.path, from: package.rootPath);
+      final pathInPackage = p.split(p.relative(entity.path, from: package.rootPath)).join('/');
       skills.add(
         ScannedSkill(
           packageName: package.name,

--- a/pkgs/skills/lib/src/core/skill_scanner.dart
+++ b/pkgs/skills/lib/src/core/skill_scanner.dart
@@ -103,7 +103,9 @@ class SkillScanner {
         continue;
       }
 
-      final pathInPackage = p.split(p.relative(entity.path, from: package.rootPath)).join('/');
+      final pathInPackage = p
+          .split(p.relative(entity.path, from: package.rootPath))
+          .join('/');
       skills.add(
         ScannedSkill(
           packageName: package.name,

--- a/pkgs/skills/lib/src/models/skill_manifest.dart
+++ b/pkgs/skills/lib/src/models/skill_manifest.dart
@@ -276,12 +276,14 @@ class InstalledSkillEntry {
   final DateTime installedAt;
   final String? contentHash;
   final bool isInstalled;
+  final String? path;
 
   const InstalledSkillEntry({
     required this.name,
     required this.installedAt,
     this.contentHash,
     this.isInstalled = true,
+    this.path,
   });
 
   factory InstalledSkillEntry.fromJson(Map<String, dynamic> json) {
@@ -290,6 +292,7 @@ class InstalledSkillEntry {
       installedAt: DateTime.parse(json['installedAt'] as String),
       contentHash: json['contentHash'] as String?,
       isInstalled: json['isInstalled'] as bool? ?? true,
+      path: json['path'] as String?,
     );
   }
 
@@ -299,6 +302,7 @@ class InstalledSkillEntry {
       'installedAt': installedAt.toUtc().toIso8601String(),
       if (contentHash != null) 'contentHash': contentHash,
       if (!isInstalled) 'isInstalled': false,
+      if (path != null) 'path': path,
     };
   }
 }

--- a/pkgs/skills/test/commands/list_command_test.dart
+++ b/pkgs/skills/test/commands/list_command_test.dart
@@ -1,23 +1,68 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
 import 'dart:io';
 
+import 'package:args/command_runner.dart';
 import 'package:logging/logging.dart';
+import 'package:skills/src/commands/list_command.dart';
+import 'package:skills/src/commands/skills_command_runner.dart';
 import 'package:skills/src/models/skill_manifest.dart';
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
+import '../utils.dart';
+
 void main() {
+  late CommandRunner runner;
+  late List<String> loggedMessages;
+  late StreamSubscription<LogRecord> logSub;
+
   setUpAll(() {
-    Logger.root.onRecord.listen((r) => printOnFailure(r.toString()));
+    Logger.root.level = Level.ALL;
+  });
+
+  setUp(() {
+    loggedMessages = [];
+    logSub = Logger.root.onRecord.listen((r) {
+      printOnFailure(r.toString());
+      loggedMessages.add(r.message);
+    });
+    final listCommand = ListCommand();
+    runner = SkillsCommandRunner('skills', 'test')..addCommand(listCommand);
+  });
+
+  tearDown(() async {
+    await logSub.cancel();
   });
 
   group('Given a project with installed skills in multiple agents', () {
     late SkillManifest manifest;
+    late String projectPath;
 
     setUp(() async {
       manifest = SkillManifest(
         installations: {
+          'generic': {
+            'https://github.com/foo/bar.git': SkillsEntry(
+              skills: [
+                InstalledSkillEntry(
+                  name: 'deep-skill',
+                  installedAt: DateTime.utc(2026, 2, 25),
+                  path: 'packages/deep/path/to/deep-skill',
+                ),
+                InstalledSkillEntry(
+                  name: 'root-skill',
+                  installedAt: DateTime.utc(2026, 2, 25),
+                  path: '.',
+                ),
+              ],
+            ),
+          },
           'cursor': {
-            'pkg_a': SkillsEntry(
+            'package:pkg_a': SkillsEntry(
               skills: [
                 InstalledSkillEntry(
                   name: 'pkg_a-code-gen',
@@ -29,7 +74,7 @@ void main() {
                 ),
               ],
             ),
-            'pkg_b': SkillsEntry(
+            'package:pkg_b': SkillsEntry(
               skills: [
                 InstalledSkillEntry(
                   name: 'pkg_b-testing',
@@ -39,7 +84,7 @@ void main() {
             ),
           },
           'claude': {
-            'pkg_a': SkillsEntry(
+            'package:pkg_a': SkillsEntry(
               skills: [
                 InstalledSkillEntry(
                   name: 'pkg_a-code-gen',
@@ -51,18 +96,20 @@ void main() {
         },
       );
 
-      await d.dir('project').create();
-      await manifest.save(File(SkillManifest.pathIn(d.path('project'))));
+      await d.dir('project', [pubspec('test_app')]).create();
+      projectPath = d.path('project');
+      await manifest.save(File(SkillManifest.pathIn(projectPath)));
     });
 
     test('when listing then all agents and packages are present', () {
-      expect(manifest.allAgents, containsAll(['cursor', 'claude']));
+      expect(manifest.allAgents, containsAll(['generic', 'cursor', 'claude']));
+      expect(manifest.sourceUrisForAgent('generic'), hasLength(1));
       expect(manifest.sourceUrisForAgent('cursor'), hasLength(2));
       expect(manifest.sourceUrisForAgent('claude'), hasLength(1));
     });
 
     test('when listing then cursor skills are correct', () {
-      final cursorPkgA = manifest.sourceUrisForAgent('cursor')['pkg_a']!.skills;
+      final cursorPkgA = manifest.sourceUrisForAgent('cursor')['package:pkg_a']!.skills;
       expect(
         cursorPkgA.map((s) => s.name),
         containsAll(['pkg_a-code-gen', 'pkg_a-api-helper']),
@@ -70,17 +117,64 @@ void main() {
     });
 
     test('when listing then claude skills are correct', () {
-      final claudePkgA = manifest.sourceUrisForAgent('claude')['pkg_a']!.skills;
+      final claudePkgA = manifest.sourceUrisForAgent('claude')['package:pkg_a']!.skills;
       expect(claudePkgA.map((s) => s.name), equals(['pkg_a-code-gen']));
     });
 
     test('when iterating allSkills then returns total across agents', () {
-      expect(manifest.allSkills, hasLength(4));
+      expect(manifest.allSkills, hasLength(6));
     });
 
     test('when iterating allSkillsForIde then returns only that agent', () {
+      expect(manifest.allSkillsForAgent('generic'), hasLength(2));
       expect(manifest.allSkillsForAgent('cursor'), hasLength(3));
       expect(manifest.allSkillsForAgent('claude'), hasLength(1));
+    });
+
+    test('when running list command then formatted output is correct', () async {
+      await runner.run(['list', '--directory', projectPath]);
+
+      final output = loggedMessages.join('\n');
+
+      // Requirement 1: Agent labels contain aliases in parenthesis for agents with aliases
+      expect(output, contains('generic (antigravity, codex)'));
+
+      // Requirement 2: Actual install directory is messaged for each agent
+      expect(output, contains('(installed at .agents/skills)'));
+      expect(output, contains('(installed at .cursor/skills)'));
+      expect(output, contains('(installed at .claude/skills)'));
+
+      // Requirement 3: Note about managed skills
+      expect(
+        output,
+        contains(
+          'Note: These are only managed skills; there may be additional skills installed.',
+        ),
+      );
+
+      // Requirement 4: Full path listed for git sources with deep path
+      expect(
+        output,
+        contains(
+          '- deep-skill (repo path: packages/deep/path/to/deep-skill)',
+        ),
+      );
+      // Root skills (path '.') should not have '.' suffix
+      expect(output, contains('- root-skill'));
+      expect(output, isNot(contains('- root-skill (.)')));
+    });
+
+    test('InstalledSkillEntry JSON serialization preserves path', () {
+      final entry = InstalledSkillEntry(
+        name: 'test-skill',
+        installedAt: DateTime.parse('2026-07-23T18:00:00.000Z'),
+        path: 'deep/sub/path',
+      );
+      final json = entry.toJson();
+      expect(json['path'], equals('deep/sub/path'));
+
+      final deserialized = InstalledSkillEntry.fromJson(json);
+      expect(deserialized.path, equals('deep/sub/path'));
     });
   });
 
@@ -99,6 +193,15 @@ void main() {
       expect(manifest.isEmpty, isTrue);
       expect(manifest.allSkills, isEmpty);
       expect(manifest.allAgents, isEmpty);
+    });
+
+    test('when running list command then messages no managed skills installed', () async {
+      await d.dir('bare_project', [pubspec('bare_app')]).create();
+
+      await runner.run(['list', '--directory', d.path('bare_project')]);
+
+      final output = loggedMessages.join('\n');
+      expect(output, contains('No managed skills installed.'));
     });
   });
 }

--- a/pkgs/skills/test/commands/list_command_test.dart
+++ b/pkgs/skills/test/commands/list_command_test.dart
@@ -109,7 +109,9 @@ void main() {
     });
 
     test('when listing then cursor skills are correct', () {
-      final cursorPkgA = manifest.sourceUrisForAgent('cursor')['package:pkg_a']!.skills;
+      final cursorPkgA = manifest
+          .sourceUrisForAgent('cursor')['package:pkg_a']!
+          .skills;
       expect(
         cursorPkgA.map((s) => s.name),
         containsAll(['pkg_a-code-gen', 'pkg_a-api-helper']),
@@ -117,7 +119,9 @@ void main() {
     });
 
     test('when listing then claude skills are correct', () {
-      final claudePkgA = manifest.sourceUrisForAgent('claude')['package:pkg_a']!.skills;
+      final claudePkgA = manifest
+          .sourceUrisForAgent('claude')['package:pkg_a']!
+          .skills;
       expect(claudePkgA.map((s) => s.name), equals(['pkg_a-code-gen']));
     });
 
@@ -155,9 +159,7 @@ void main() {
       // Requirement 4: Full path listed for git sources with deep path
       expect(
         output,
-        contains(
-          '- deep-skill (repo path: packages/deep/path/to/deep-skill)',
-        ),
+        contains('- deep-skill (repo path: packages/deep/path/to/deep-skill)'),
       );
       // Root skills (path '.') should not have '.' suffix
       expect(output, contains('- root-skill'));
@@ -195,13 +197,16 @@ void main() {
       expect(manifest.allAgents, isEmpty);
     });
 
-    test('when running list command then messages no managed skills installed', () async {
-      await d.dir('bare_project', [pubspec('bare_app')]).create();
+    test(
+      'when running list command then messages no managed skills installed',
+      () async {
+        await d.dir('bare_project', [pubspec('bare_app')]).create();
 
-      await runner.run(['list', '--directory', d.path('bare_project')]);
+        await runner.run(['list', '--directory', d.path('bare_project')]);
 
-      final output = loggedMessages.join('\n');
-      expect(output, contains('No managed skills installed.'));
-    });
+        final output = loggedMessages.join('\n');
+        expect(output, contains('No managed skills installed.'));
+      },
+    );
   });
 }


### PR DESCRIPTION
Fixes #550.

- Agent labels now include aliases in parentheses (e.g. `generic (antigravity, codex)`).
- Displays the actual install directory for each agent in the section header (e.g. `(installed at .agents/skills)`).
- Appends a note at the end indicating these are only managed skills and additional skills may be installed.
- Stores the relative repository path of skills in the manifest and displays it in `skills list` output (e.g. `- skill-name (repo path: path/to/skill)`).