### PR TITLE
update wording for selection dialogs

### DIFF
--- a/pkgs/skills/CHANGELOG.md
+++ b/pkgs/skills/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add a --version flag.
 - JSON encode descriptions in the `create` command.
+- Update wording slightly for selection dialogs.
 
 ## 1.0.0-beta.4
 

--- a/pkgs/skills/lib/src/commands/get_skills.dart
+++ b/pkgs/skills/lib/src/commands/get_skills.dart
@@ -596,7 +596,7 @@ Future<bool> _promptForSourcesWithDiffs({
     ).toSet();
     final selectedIndices = await dialogSupport.showMultiSelectDialog(
       sourcesWithSkills,
-      title: 'Select sources to install skills from:',
+      title: 'Select which sources to browse skills from:',
       initialSelected: initialSelected,
     );
     if (selectedIndices != null) {

--- a/pkgs/skills/lib/src/commands/remove_command.dart
+++ b/pkgs/skills/lib/src/commands/remove_command.dart
@@ -97,7 +97,7 @@ class RemoveCommand extends SkillsCommand {
       }.toList()..sort();
       final selectedIndices = await _dialogSupport.showMultiSelectDialog(
         allPackages,
-        title: 'Select sources to remove skills for:',
+        title: 'Select sources to remove skills from:',
       );
       if (selectedIndices != null) {
         sourcesToRemove.addAll(selectedIndices.map((i) => allPackages[i]));


### PR DESCRIPTION
This should make it more obvious that you won't be installing all skills, but will be presented with another dialog to choose which skills to install.