### PR TITLE
Don't install skills from third_party directories

### DIFF
--- a/pkgs/skills/CHANGELOG.md
+++ b/pkgs/skills/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add a --version flag.
 - JSON encode descriptions in the `create` command.
+- Don't crawl into `third_party` directories when scanning Git repositories for skills.
 
 ## 1.0.0-beta.4
 

--- a/pkgs/skills/CHANGELOG.md
+++ b/pkgs/skills/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Add a --version flag.
 - JSON encode descriptions in the `create` command.
-- Don't crawl into `third_party` directories when scanning Git repositories for skills.
+- Don't crawl into `third_party` or hidden directories when scanning Git repositories for skills.
 - Update wording slightly for selection dialogs.
 
 ## 1.0.0-beta.4

--- a/pkgs/skills/README.md
+++ b/pkgs/skills/README.md
@@ -60,6 +60,7 @@ The `skills` package can also install skills from git repos, similar to how `npx
 Once a repo has been added, future calls to `dart run skills@ get` will also check those repos for updates to skills.
 
 - **Requirement:** Git must be installed and on your PATH. If git is not found, a warning is printed and only Dart package skills are used.
+- **Directory Filtering:** When crawling a Git repository for skills, directories named `third_party` or hidden directories (starting with `.`) are ignored.
 
 ### Pruning removed dependencies
 

--- a/pkgs/skills/lib/src/core/git_scanner.dart
+++ b/pkgs/skills/lib/src/core/git_scanner.dart
@@ -46,38 +46,47 @@ class GitScanner {
     bool isGlobal,
   ) async {
     final skills = <ScannedSkill>[];
-    await for (final entity in repoDir.list(
-      recursive: true,
-      followLinks: false,
-    )) {
-      if (entity is! File || p.basename(entity.path) != 'SKILL.md') continue;
-
-      SkillFrontmatter? frontmatter;
-      try {
-        frontmatter = SkillFrontmatter.fromSkillContent(
-          await entity.readAsString(),
-        );
-      } on FormatException catch (e) {
-        _logger.warning(
-          'Skipping skill at path ${entity.path} due to formatting '
-          'error: $e',
-        );
-        continue;
-      }
-      if (frontmatter.isInternal && !shouldInstallInternalSkills) continue;
-
-      final skillDir = entity.parent;
-      final skillName = p.basename(skillDir.path);
-
-      skills.add(
-        ScannedSkill(
-          gitUrl: gitUrl,
-          skillName: skillName,
-          skillPath: skillDir.path,
-          isGlobal: isGlobal,
-        ),
-      );
-    }
+    await _scanDirectory(repoDir, gitUrl, isGlobal, skills);
     return skills;
+  }
+
+  Future<void> _scanDirectory(
+    Directory dir,
+    String gitUrl,
+    bool isGlobal,
+    List<ScannedSkill> skills,
+  ) async {
+    await for (final entity in dir.list(followLinks: false)) {
+      if (entity is Directory) {
+        if (p.basename(entity.path) == 'third_party') continue;
+        await _scanDirectory(entity, gitUrl, isGlobal, skills);
+      } else if (entity is File && p.basename(entity.path) == 'SKILL.md') {
+        SkillFrontmatter? frontmatter;
+        try {
+          frontmatter = SkillFrontmatter.fromSkillContent(
+            await entity.readAsString(),
+          );
+        } on FormatException catch (e) {
+          _logger.warning(
+            'Skipping skill at path ${entity.path} due to formatting '
+            'error: $e',
+          );
+          continue;
+        }
+        if (frontmatter.isInternal && !shouldInstallInternalSkills) continue;
+
+        final skillDir = entity.parent;
+        final skillName = p.basename(skillDir.path);
+
+        skills.add(
+          ScannedSkill(
+            gitUrl: gitUrl,
+            skillName: skillName,
+            skillPath: skillDir.path,
+            isGlobal: isGlobal,
+          ),
+        );
+      }
+    }
   }
 }

--- a/pkgs/skills/lib/src/core/git_scanner.dart
+++ b/pkgs/skills/lib/src/core/git_scanner.dart
@@ -58,7 +58,8 @@ class GitScanner {
   ) async {
     await for (final entity in dir.list(followLinks: false)) {
       if (entity is Directory) {
-        if (p.basename(entity.path) == 'third_party') continue;
+        final name = p.basename(entity.path);
+        if (name == 'third_party' || name.startsWith('.')) continue;
         await _scanDirectory(entity, gitUrl, isGlobal, skills);
       } else if (entity is File && p.basename(entity.path) == 'SKILL.md') {
         SkillFrontmatter? frontmatter;

--- a/pkgs/skills/test/core/git_scanner_test.dart
+++ b/pkgs/skills/test/core/git_scanner_test.dart
@@ -152,6 +152,47 @@ void main() {
       expect(skills, isEmpty);
     });
 
+    test('when skill is inside third_party dir then it is skipped', () async {
+      final repo = const GitRepo(cloneUrl: 'https://github.com/a/b.git');
+      await d.dir('project', [
+        d.dir('.dart_tool', [
+          d.dir('skills', [
+            d.dir('repos', [
+              d.dir(repo.pathSegment, [
+                d.dir('skills', [
+                  d.dir('valid-skill', [
+                    d.file('SKILL.md', '---\nname: valid-skill\n---\n'),
+                  ]),
+                ]),
+                d.dir('third_party', [
+                  d.dir('vendor-skill', [
+                    d.file('SKILL.md', '---\nname: vendor-skill\n---\n'),
+                  ]),
+                  d.dir('nested', [
+                    d.dir('nested-vendor-skill', [
+                      d.file(
+                        'SKILL.md',
+                        '---\nname: nested-vendor-skill\n---\n',
+                      ),
+                    ]),
+                  ]),
+                ]),
+              ]),
+            ]),
+          ]),
+        ]),
+      ]).create();
+
+      const scanner = GitScanner();
+      final skills = await scanner.scan(
+        d.path('project'),
+        isGlobal: false,
+        repos: [repo],
+      );
+      expect(skills, hasLength(1));
+      expect(skills.first.skillName, equals('valid-skill'));
+    });
+
     test('when skill dir has no SKILL.md then skipped', () async {
       final repo = const GitRepo(cloneUrl: 'https://github.com/a/b.git');
       await d.dir('project', [

--- a/pkgs/skills/test/core/git_scanner_test.dart
+++ b/pkgs/skills/test/core/git_scanner_test.dart
@@ -193,6 +193,39 @@ void main() {
       expect(skills.first.skillName, equals('valid-skill'));
     });
 
+    test('when skill is inside hidden dir then it is skipped', () async {
+      final repo = const GitRepo(cloneUrl: 'https://github.com/a/b.git');
+      await d.dir('project', [
+        d.dir('.dart_tool', [
+          d.dir('skills', [
+            d.dir('repos', [
+              d.dir(repo.pathSegment, [
+                d.dir('skills', [
+                  d.dir('valid-skill', [
+                    d.file('SKILL.md', '---\nname: valid-skill\n---\n'),
+                  ]),
+                ]),
+                d.dir('.hidden_dir', [
+                  d.dir('hidden-skill', [
+                    d.file('SKILL.md', '---\nname: hidden-skill\n---\n'),
+                  ]),
+                ]),
+              ]),
+            ]),
+          ]),
+        ]),
+      ]).create();
+
+      const scanner = GitScanner();
+      final skills = await scanner.scan(
+        d.path('project'),
+        isGlobal: false,
+        repos: [repo],
+      );
+      expect(skills, hasLength(1));
+      expect(skills.first.skillName, equals('valid-skill'));
+    });
+
     test('when skill dir has no SKILL.md then skipped', () async {
       final repo = const GitRepo(cloneUrl: 'https://github.com/a/b.git');
       await d.dir('project', [


### PR DESCRIPTION
Skip recursive crawling into third_party directories when scanning Git repositories for skills.

Fixes #553