### PR TITLE
fix(skills): Do not save repositories in skills add when git clone fails (fixes #561)

### DIFF
--- a/pkgs/skills/CHANGELOG.md
+++ b/pkgs/skills/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.0.0-wip
 
+- Fix bug where failing to clone a git repository in `skills add` still saved
+  it to configuration/manifest files.
 - Add a --version flag.
 - JSON encode descriptions in the `create` command.
 

--- a/pkgs/skills/lib/src/commands/add_command.dart
+++ b/pkgs/skills/lib/src/commands/add_command.dart
@@ -7,6 +7,7 @@ import 'package:skills/src/models/skill_manifest.dart';
 import '../core/dialog_support.dart';
 import '../core/git_repos.dart';
 import '../core/git_runner.dart';
+import '../core/git_sync.dart';
 import '../models/global_config.dart';
 
 import 'options.dart';
@@ -78,13 +79,33 @@ class AddCommand extends SkillsCommand {
     );
     if (agents.isEmpty) return;
 
+    final validRepos = <GitRepo>[];
+    if (await gitRunner.isAvailable) {
+      final gitSync = GitSync(gitRunner: gitRunner, repos: gitRepos.toList());
+      await gitSync.sync(rootPath, onProgress: logger.info);
+
+      for (final repo in gitRepos) {
+        final repoDir = Directory(gitRepoPath(rootPath, repo));
+        if (await repoDir.exists()) {
+          validRepos.add(repo);
+        } else {
+          logger.severe(
+            'Failed to clone or sync git repository: ${repo.cloneUrl}',
+          );
+        }
+      }
+      if (validRepos.isEmpty) return;
+    } else {
+      validRepos.addAll(gitRepos);
+    }
+
     if (isGlobal) {
       // Add the entry to the global config if not present.
       final globalConfigPath = GlobalConfig.globalPath;
       final globalConfigFile = File(globalConfigPath);
       var globalConfig = await GlobalConfig.loadOrEmpty(globalConfigFile);
 
-      for (var repo in gitRepos) {
+      for (var repo in validRepos) {
         if (!globalConfig.gitRepos.any((r) => r.cloneUrl == repo.cloneUrl)) {
           globalConfig = globalConfig.withGitRepo(repo);
           logger.info('Added ${repo.cloneUrl} to global config.');
@@ -96,7 +117,7 @@ class AddCommand extends SkillsCommand {
       final localFile = manifestFile(workspace.rootPath);
       var manifest = await SkillManifest.loadOrEmpty(localFile);
       for (var agent in agents) {
-        for (var repo in gitRepos) {
+        for (var repo in validRepos) {
           if (manifest
               .sourceUrisForAgent(agent.cliName)
               .containsKey(repo.cloneUrl)) {
@@ -118,7 +139,7 @@ class AddCommand extends SkillsCommand {
       workspace: workspace,
       dialogSupport: dialogSupport,
       usage: usage,
-      sourceUris: {for (var repo in gitRepos) repo.cloneUrl},
+      sourceUris: {for (var repo in validRepos) repo.cloneUrl},
       skillNames: skillNames,
       allFlag: allFlag,
       gitRunner: gitRunner,

--- a/pkgs/skills/lib/src/commands/add_command.dart
+++ b/pkgs/skills/lib/src/commands/add_command.dart
@@ -79,25 +79,26 @@ class AddCommand extends SkillsCommand {
     );
     if (agents.isEmpty) return;
 
-    final validRepos = <GitRepo>[];
-    if (await gitRunner.isAvailable) {
-      final gitSync = GitSync(gitRunner: gitRunner, repos: gitRepos.toList());
-      await gitSync.sync(rootPath, onProgress: logger.info);
-
-      for (final repo in gitRepos) {
-        final repoDir = Directory(gitRepoPath(rootPath, repo));
-        if (await repoDir.exists()) {
-          validRepos.add(repo);
-        } else {
-          logger.severe(
-            'Failed to clone or sync git repository: ${repo.cloneUrl}',
-          );
-        }
-      }
-      if (validRepos.isEmpty) return;
-    } else {
-      validRepos.addAll(gitRepos);
+    if (!await gitRunner.isAvailable) {
+      logger.severe('Git is required to add git skill repositories.');
+      return;
     }
+
+    final validRepos = <GitRepo>[];
+    final gitSync = GitSync(gitRunner: gitRunner, repos: gitRepos.toList());
+    await gitSync.sync(rootPath, onProgress: logger.info);
+
+    for (final repo in gitRepos) {
+      final repoDir = Directory(gitRepoPath(rootPath, repo));
+      if (await repoDir.exists()) {
+        validRepos.add(repo);
+      } else {
+        logger.severe(
+          'Failed to clone or sync git repository: ${repo.cloneUrl}',
+        );
+      }
+    }
+    if (validRepos.isEmpty) return;
 
     if (isGlobal) {
       // Add the entry to the global config if not present.

--- a/pkgs/skills/test/commands/add_command_test.dart
+++ b/pkgs/skills/test/commands/add_command_test.dart
@@ -148,5 +148,37 @@ void main() {
         isTrue,
       );
     });
+
+    test(
+      'does not add to manifest or config when repo sync fails and git is available',
+      () async {
+        final addCommandWithGit = AddCommand(
+          dialogSupport: fakeDialogSupport,
+          gitRunner: const GitRunner(),
+        );
+        final gitRunnerRunner = SkillsCommandRunner('skills', 'Test')
+          ..addCommand(addCommandWithGit);
+
+        await gitRunnerRunner.run([
+          'add',
+          '--directory',
+          projectPath,
+          '--agent',
+          'cursor',
+          'bad/nonexistent_repo_for_test',
+        ]);
+
+        final localFile = File(SkillManifest.pathIn(projectPath));
+        final manifest = await SkillManifest.loadOrEmpty(localFile);
+        expect(
+          manifest
+              .sourceUrisForAgent('cursor')
+              .containsKey(
+                'https://github.com/bad/nonexistent_repo_for_test.git',
+              ),
+          isFalse,
+        );
+      },
+    );
   });
 }

--- a/pkgs/skills/test/commands/add_command_test.dart
+++ b/pkgs/skills/test/commands/add_command_test.dart
@@ -73,112 +73,155 @@ void main() {
       );
     });
 
-    test('adds to global config when --global is passed', () async {
-      await runner.run(['add', '--global', '--agent', 'cursor', 'owner/repo']);
-
-      final globalConfig = await GlobalConfig.loadOrEmpty(
-        File(globalConfigPath),
-      );
-      expect(globalConfig.gitRepos, hasLength(1));
-      expect(
-        globalConfig.gitRepos.first.cloneUrl,
-        'https://github.com/owner/repo.git',
-      );
-    });
-
-    test('adds to local manifest when --global is not passed', () async {
-      await runner.run([
-        'add',
-        '--directory',
-        projectPath,
-        '--agent',
-        'cursor',
-        'owner/repo',
-      ]);
-
-      final localFile = File(SkillManifest.pathIn(projectPath));
-      final manifest = await SkillManifest.loadOrEmpty(localFile);
-      expect(
-        manifest
-            .sourceUrisForAgent('cursor')
-            .containsKey('https://github.com/owner/repo.git'),
-        isTrue,
-      );
-    });
-
-    test('succeeds when --all is passed', () async {
-      await runner.run([
-        'add',
-        '--directory',
-        projectPath,
-        '--agent',
-        'cursor',
-        '--all',
-        'owner/repo',
-      ]);
-
-      final localFile = File(SkillManifest.pathIn(projectPath));
-      final manifest = await SkillManifest.loadOrEmpty(localFile);
-      expect(
-        manifest
-            .sourceUrisForAgent('cursor')
-            .containsKey('https://github.com/owner/repo.git'),
-        isTrue,
-      );
-    });
-
-    test('succeeds when specific skill names are passed', () async {
-      await runner.run([
-        'add',
-        '--directory',
-        projectPath,
-        '--agent',
-        'cursor',
-        '--skill',
-        'my-skill',
-        'owner/repo',
-      ]);
-
-      final localFile = File(SkillManifest.pathIn(projectPath));
-      final manifest = await SkillManifest.loadOrEmpty(localFile);
-      expect(
-        manifest
-            .sourceUrisForAgent('cursor')
-            .containsKey('https://github.com/owner/repo.git'),
-        isTrue,
-      );
-    });
-
     test(
-      'does not add to manifest or config when repo sync fails and git is available',
+      'does not add to manifest or config when git is not available',
       () async {
-        final addCommandWithGit = AddCommand(
-          dialogSupport: fakeDialogSupport,
-          gitRunner: const GitRunner(),
-        );
-        final gitRunnerRunner = SkillsCommandRunner('skills', 'Test')
-          ..addCommand(addCommandWithGit);
-
-        await gitRunnerRunner.run([
+        await runner.run([
           'add',
           '--directory',
           projectPath,
           '--agent',
           'cursor',
-          'bad/nonexistent_repo_for_test',
+          'owner/repo',
+        ]);
+
+        final localFile = File(SkillManifest.pathIn(projectPath));
+        final manifest = await SkillManifest.loadOrEmpty(localFile);
+        expect(manifest.isEmpty, isTrue);
+      },
+    );
+
+    group('with valid local git repository', () {
+      late String fileUrl;
+      late SkillsCommandRunner realGitRunner;
+
+      setUp(() async {
+        await d.dir('local_repo', [
+          d.dir('skills', [
+            d.dir('my-skill', [
+              d.file('SKILL.md', '''
+---
+name: my-skill
+description: A test skill.
+---
+Test skill body.
+'''),
+            ]),
+          ]),
+        ]).create();
+        final localPath = p.normalize(p.absolute(d.path('local_repo')));
+        await Process.run('git', ['init'], workingDirectory: localPath);
+        await Process.run('git', [
+          'config',
+          'user.email',
+          'test@test',
+        ], workingDirectory: localPath);
+        await Process.run('git', [
+          'config',
+          'user.name',
+          'Test',
+        ], workingDirectory: localPath);
+        await Process.run('git', ['add', '.'], workingDirectory: localPath);
+        await Process.run('git', [
+          'commit',
+          '-m',
+          'init',
+        ], workingDirectory: localPath);
+
+        if (Platform.isWindows) {
+          fileUrl = 'file:///${localPath.replaceAll(r'\', '/')}';
+        } else {
+          fileUrl = 'file://$localPath';
+        }
+
+        final addCommand = AddCommand(
+          dialogSupport: fakeDialogSupport,
+          gitRunner: const GitRunner(),
+        );
+        realGitRunner = SkillsCommandRunner('skills', 'Test')
+          ..addCommand(addCommand);
+      });
+
+      test('adds to global config when --global is passed', () async {
+        await realGitRunner.run([
+          'add',
+          '--global',
+          '--agent',
+          'cursor',
+          '--all',
+          fileUrl,
+        ]);
+
+        final globalConfig = await GlobalConfig.loadOrEmpty(
+          File(globalConfigPath),
+        );
+        expect(globalConfig.gitRepos, hasLength(1));
+        expect(globalConfig.gitRepos.first.cloneUrl, fileUrl);
+      });
+
+      test('adds to local manifest when --global is not passed', () async {
+        await realGitRunner.run([
+          'add',
+          '--directory',
+          projectPath,
+          '--agent',
+          'cursor',
+          '--all',
+          fileUrl,
         ]);
 
         final localFile = File(SkillManifest.pathIn(projectPath));
         final manifest = await SkillManifest.loadOrEmpty(localFile);
         expect(
-          manifest
-              .sourceUrisForAgent('cursor')
-              .containsKey(
-                'https://github.com/bad/nonexistent_repo_for_test.git',
-              ),
-          isFalse,
+          manifest.sourceUrisForAgent('cursor').containsKey(fileUrl),
+          isTrue,
         );
-      },
-    );
+      });
+
+      test('succeeds when specific skill names are passed', () async {
+        await realGitRunner.run([
+          'add',
+          '--directory',
+          projectPath,
+          '--agent',
+          'cursor',
+          '--skill',
+          'my-skill',
+          fileUrl,
+        ]);
+
+        final localFile = File(SkillManifest.pathIn(projectPath));
+        final manifest = await SkillManifest.loadOrEmpty(localFile);
+        expect(
+          manifest.sourceUrisForAgent('cursor').containsKey(fileUrl),
+          isTrue,
+        );
+      });
+
+      test(
+        'does not add to manifest or config when repo sync fails and git is available',
+        () async {
+          await realGitRunner.run([
+            'add',
+            '--directory',
+            projectPath,
+            '--agent',
+            'cursor',
+            'bad/nonexistent_repo_for_test',
+          ]);
+
+          final localFile = File(SkillManifest.pathIn(projectPath));
+          final manifest = await SkillManifest.loadOrEmpty(localFile);
+          expect(
+            manifest
+                .sourceUrisForAgent('cursor')
+                .containsKey(
+                  'https://github.com/bad/nonexistent_repo_for_test.git',
+                ),
+            isFalse,
+          );
+        },
+      );
+    });
   });
 }


### PR DESCRIPTION
Fixes #561

### Description
In `skills add`, repositories were previously saved to `GlobalConfig` or local `SkillManifest` files before verification/installation of skills took place. If git clone failed (e.g. invalid repository URL or non-existent remote repository), the invalid repository was still recorded in configuration files, leaving the CLI in a broken state where future commands would continually attempt to sync the non-existent repository.

This change performs a pre-sync verification check in `AddCommand.run()` prior to updating configuration/manifest files. Any repository that fails to clone or sync is excluded and an error is logged. If all provided repositories fail, `AddCommand` bails out early without saving any entries.