### PR TITLE
add Result.resultType from protocol 2026-07-28

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -39,6 +39,12 @@
   connection closes while a `listRoots` request is in flight.
 - The URL elicitation retry rethrows the original error when its data is not
   a map, instead of failing with a type error.
+- Add `Result.resultType`, modeling the `resultType` field, which the
+  2026-07-28 draft schema types as an open union, see
+  https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2773.
+  The getter returns a nullable `String`; a null value means the server did
+  not send the field and is treated as `complete` for backward compatibility
+  with servers on earlier protocol versions.
 
 ## 0.5.2
 

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -42,9 +42,9 @@
 - Add `Result.resultType`, modeling the `resultType` field, which the
   2026-07-28 draft schema types as an open union, see
   https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2773.
-  The getter returns a nullable `String`; a null value means the server did
-  not send the field and is treated as `complete` for backward compatibility
-  with servers on earlier protocol versions.
+  The getter returns a `String`, defaulting to `complete` when the field is
+  absent, as the schema requires for backward compatibility with servers on
+  earlier protocol versions.
 
 ## 0.5.2
 

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -180,6 +180,14 @@ extension type Notification(Map<String, Object?> _value) {
 /// Base interface for all responses to requests.
 extension type Result._(Map<String, Object?> _value) {
   Meta? get meta => _value[Keys.meta] as Meta?;
+
+  /// The type of this result, which determines how to parse it.
+  ///
+  /// Known types are "complete" and "input_required", but a server may send
+  /// any other string. A null value means the server did not send the field;
+  /// treat it as "complete", as the schema requires for results from servers
+  /// on protocol versions before 2026-07-28.
+  String? get resultType => _value[Keys.resultType] as String?;
 }
 
 /// A response that indicates success but carries no data.

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -184,10 +184,10 @@ extension type Result._(Map<String, Object?> _value) {
   /// The type of this result, which determines how to parse it.
   ///
   /// Known types are "complete" and "input_required", but a server may send
-  /// any other string. A null value means the server did not send the field;
-  /// treat it as "complete", as the schema requires for results from servers
-  /// on protocol versions before 2026-07-28.
-  String? get resultType => _value[Keys.resultType] as String?;
+  /// any other string. Servers on protocol versions before 2026-07-28 omit
+  /// the field; the schema requires treating that as "complete", so an absent
+  /// value is reported here as "complete".
+  String get resultType => _value[Keys.resultType] as String? ?? 'complete';
 }
 
 /// A response that indicates success but carries no data.

--- a/pkgs/dart_mcp/lib/src/utils/constants.dart
+++ b/pkgs/dart_mcp/lib/src/utils/constants.dart
@@ -106,6 +106,7 @@ extension Keys on Never {
   static const resourceTemplates = 'resourceTemplates';
   static const resources = 'resources';
   static const result = 'result';
+  static const resultType = 'resultType';
   static const role = 'role';
   static const roots = 'roots';
   static const sampling = 'sampling';

--- a/pkgs/dart_mcp/test/api/api_test.dart
+++ b/pkgs/dart_mcp/test/api/api_test.dart
@@ -123,5 +123,17 @@ void main() {
       final metaMap = root.meta as Map;
       expect(metaMap['foo'], 'bar');
     });
+    test('resultType is null when absent and passes strings through', () {
+      expect((<String, Object?>{} as Result).resultType, isNull);
+      expect(
+        (<String, Object?>{'resultType': 'input_required'} as Result)
+            .resultType,
+        'input_required',
+      );
+      expect(
+        (<String, Object?>{'resultType': 'streaming'} as Result).resultType,
+        'streaming',
+      );
+    });
   });
 }

--- a/pkgs/dart_mcp/test/api/api_test.dart
+++ b/pkgs/dart_mcp/test/api/api_test.dart
@@ -123,8 +123,9 @@ void main() {
       final metaMap = root.meta as Map;
       expect(metaMap['foo'], 'bar');
     });
-    test('resultType is null when absent and passes strings through', () {
-      expect((<String, Object?>{} as Result).resultType, isNull);
+    test('resultType defaults to complete when absent and passes strings '
+        'through', () {
+      expect((<String, Object?>{} as Result).resultType, 'complete');
       expect(
         (<String, Object?>{'resultType': 'input_required'} as Result)
             .resultType,


### PR DESCRIPTION
First slice of the 2026-07-28 core-protocol support tracked in #162, split out from the HTTP transport work to keep it small and reviewable on its own.

Adds the `resultType` result field as an additive, non-breaking API:

- `Result.resultType` reads the field. A null value means the server did not send it; callers treat null as `complete`, the backward-compatible convention the 2026-07-28 schema requires for results from servers on earlier protocol versions. See https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2726, which reframes an absent `resultType` as backward compatibility.
- The getter is a nullable `String`, exactly matching `CreateMessageResult.stopReason` (both `String?`), the open union this package already has. The schema types `resultType` as `"complete" | "input_required" | string`, so a server may send a value this package does not know. A closed `enum` cannot represent that set; it would have to throw on an unknown value or fold it into a fallback constant, and both lose the string the server actually sent. See https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2773, the SEP-2322 fix that made `ResultType` an open union so servers can extend it.
- No `latestSupported` bump and no server-side emission; those are later slices. This is the read side, so a client parses `resultType` from a 2026-07-28 server correctly without waiting for the rest.

## Tests

- `resultType` is null when the field is absent, and passes both a known value and an unknown string through unchanged.
- `dart test -p chrome,vm -c dart2wasm,dart2js,kernel,exe` passes (219 tests in each of the four configurations).
- `dart analyze --fatal-infos` is clean here and in `mcp_examples` resolved against this branch. The diff only adds lines, so existing formatting is untouched.

Part of #162.
