### PR TITLE
Support hyphens in package name prefixes when matching and creating skills

### DIFF
--- a/pkgs/skills/CHANGELOG.md
+++ b/pkgs/skills/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add a --version flag.
 - JSON encode descriptions in the `create` command.
+- Support hyphens instead of underscores in package name prefixes when matching and creating skills.
 
 ## 1.0.0-beta.4
 

--- a/pkgs/skills/README.md
+++ b/pkgs/skills/README.md
@@ -118,7 +118,7 @@ my_package/
 
 ### Naming convention
 
-Every skill directory name **must** start with your package name followed by a hyphen. The CLI verifies this on installation and silently skips any skills that don't follow the convention.
+Every skill directory name **must** start with your package name (or your package name with underscores replaced by hyphens) followed by a hyphen. The CLI verifies this on installation and silently skips any skills that don't follow the convention.
 
 For a package named `serverpod`:
 
@@ -128,6 +128,8 @@ For a package named `serverpod`:
 | `serverpod-api-design` | Yes |
 | `code-generation` | No -- missing package prefix |
 | `other_pkg-code-generation` | No -- wrong prefix |
+
+For a package named `my_package`, both `my_package-code-generation` and `my-package-code-generation` are valid. Using hyphens (`my-package-code-generation`) is recommended to comply with the Agent Skills specification.
 
 This convention ensures skill names are globally unique and self-documenting. When a user sees `serverpod-code-generation` in their agent, they know exactly where it came from.
 

--- a/pkgs/skills/lib/src/commands/create_command.dart
+++ b/pkgs/skills/lib/src/commands/create_command.dart
@@ -78,7 +78,8 @@ class CreateCommand extends SkillsCommand {
       throw UsageException('Description is required.', usage);
     }
 
-    final fullSkillName = '${package.name}-$skillName';
+    final prefix = package.name.replaceAll('_', '-');
+    final fullSkillName = '$prefix-$skillName';
 
     final skillsDir = Directory(p.join(package.path, 'skills', fullSkillName));
 

--- a/pkgs/skills/lib/src/core/skill_scanner.dart
+++ b/pkgs/skills/lib/src/core/skill_scanner.dart
@@ -60,13 +60,17 @@ class SkillScanner {
   /// Scans a single [package] for its skills/ directory.
   ///
   /// Only includes skills whose directory name starts with the package name
-  /// followed by a hyphen (e.g., package `serverpod` must have skills named
-  /// `serverpod-*`). Skills that don't match are skipped with a warning.
+  /// (or hyphenated package name) followed by a hyphen (e.g., package `serverpod`
+  /// must have skills named `serverpod-*`, package `my_package` can have
+  /// `my_package-*` or `my-package-*`). Skills that don't match are skipped with
+  /// a warning.
   Future<List<ScannedSkill>> scanPackage(ResolvedPackage package) async {
     final skillsDir = Directory(p.join(package.rootPath, 'skills'));
     if (!await skillsDir.exists()) return [];
 
     final prefix = '${package.name}-';
+    final hyphenatedPrefix = '${package.name.replaceAll('_', '-')}-';
+    final validPrefixes = {prefix, hyphenatedPrefix};
     final skills = <ScannedSkill>[];
 
     await for (final entity in skillsDir.list()) {
@@ -91,10 +95,13 @@ class SkillScanner {
       }
       if (frontmatter.isInternal && !shouldInstallInternalSkills) continue;
 
-      if (!skillName.startsWith(prefix)) {
+      if (!validPrefixes.any(skillName.startsWith)) {
+        final expected = validPrefixes.length == 1
+            ? '"${validPrefixes.first}"'
+            : '"${validPrefixes.first}" or "${validPrefixes.last}"';
         logger.warning(
           'Skipping skill "$skillName" in ${package.name} '
-          '-- name must start with "${package.name}-"',
+          '-- name must start with $expected',
         );
         continue;
       }

--- a/pkgs/skills/lib/src/core/skill_scanner.dart
+++ b/pkgs/skills/lib/src/core/skill_scanner.dart
@@ -96,9 +96,7 @@ class SkillScanner {
       if (frontmatter.isInternal && !shouldInstallInternalSkills) continue;
 
       if (!validPrefixes.any(skillName.startsWith)) {
-        final expected = validPrefixes.length == 1
-            ? '"${validPrefixes.first}"'
-            : '"${validPrefixes.first}" or "${validPrefixes.last}"';
+        final expected = validPrefixes.map((p) => '"$p"').join(' or ');
         logger.warning(
           'Skipping skill "$skillName" in ${package.name} '
           '-- name must start with $expected',

--- a/pkgs/skills/test/commands/create_command_test.dart
+++ b/pkgs/skills/test/commands/create_command_test.dart
@@ -33,9 +33,9 @@ void main() {
 
       await d.dir('project', [
         d.dir('skills', [
-          d.dir('my_package-my-skill', [
+          d.dir('my-package-my-skill', [
             d.file('SKILL.md', '''---
-name: my_package-my-skill
+name: my-package-my-skill
 description: "my description"
 ---
 
@@ -92,7 +92,7 @@ Add your skill instructions here.
         await d.dir('project', [
           pubspec('my_package'),
           d.dir('skills', [
-            d.dir('my_package-existing-skill', [
+            d.dir('my-package-existing-skill', [
               d.file('SKILL.md', 'existing content'),
             ]),
           ]),
@@ -129,9 +129,9 @@ Add your skill instructions here.
 
         await d.dir('project', [
           d.dir('skills', [
-            d.dir('my_package-my-skill2', [
+            d.dir('my-package-my-skill2', [
               d.file('SKILL.md', r'''---
-name: my_package-my-skill2
+name: my-package-my-skill2
 description: "description with: a colon, \"quotes\", \nnewlines\tand backticks `like this`"
 ---
 

--- a/pkgs/skills/test/core/skill_scanner_test.dart
+++ b/pkgs/skills/test/core/skill_scanner_test.dart
@@ -31,10 +31,10 @@ description: Generates code.
 Instructions.
 '''),
           ]),
-          d.dir('my_package-api-design', [
+          d.dir('my-package-api-design', [
             d.file('SKILL.md', '''
 ---
-name: my_package-api-design
+name: my-package-api-design
 description: Designs APIs.
 ---
 
@@ -62,7 +62,7 @@ Instructions.
       expect(skills, hasLength(2));
       expect(
         skills.map((s) => s.skillName).toSet(),
-        equals({'my_package-code-gen', 'my_package-api-design'}),
+        equals({'my_package-code-gen', 'my-package-api-design'}),
       );
     });
 


### PR DESCRIPTION
Fixes #541.

- Support matching package names using hyphens instead of underscores in package name prefixes ( as well as ).
- Update `skills create` to generate hyphenated package prefixes ().
- Update documentation and unit tests.