### PR TITLE
feat(skills): clean up unused git repo sources in skills prune and skills get

### DIFF
--- a/pkgs/skills/CHANGELOG.md
+++ b/pkgs/skills/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 ## 1.0.0-wip
 
-- Fix bug where failing to clone a git repository in `skills add` still saved
-  it to configuration/manifest files.
+- Fix bug where failing to clone a git repository in `skills add` still
+  saved it to configuration/manifest files.
 - Add a --version flag.
 - JSON encode descriptions in the `create` command.
-- Don't crawl into `third_party` or hidden directories when scanning Git repositories for skills.
-- Support hyphens instead of underscores in package name prefixes when matching and creating skills.
+- Don't crawl into `third_party` or hidden directories when scanning Git
+  repositories for skills.
+- Support hyphens instead of underscores in package name prefixes when matching
+  and creating skills.
 - Update wording slightly for selection dialogs.
+- Prompt user during `skills prune` (and after `skills get`) to remove local or
+  global git repository sources that have no installed skills.
 
 ## 1.0.0-beta.4
 

--- a/pkgs/skills/README.md
+++ b/pkgs/skills/README.md
@@ -55,22 +55,38 @@ The CLI will automatically run `pub get` if needed, scan your dependency package
 
 ### Installing skills from git
 
-The `skills` package can also install skills from git repos, similar to how `npx skills` works. Given an `npx skills` command from https://skills.sh, you can substitute `npx skills` for `dart run skills@` to install them without the need for Node/NPX.
+The `skills` package can also install skills from git repos, similar to how
+`npx skills` works. Given an `npx skills` command from https://skills.sh, you
+can substitute `npx skills` for `dart run skills@` to install them without the
+need for Node/NPX.
 
-Once a repo has been added, future calls to `dart run skills@ get` will also check those repos for updates to skills.
+Once a repo has been added, future calls to `dart run skills@ get` will also
+check those repos for updates to skills.
 
-- **Requirement:** Git must be installed and on your PATH. If git is not found, a warning is printed and only Dart package skills are used.
-- **Directory Filtering:** When crawling a Git repository for skills, directories named `third_party` or hidden directories (starting with `.`) are ignored.
+- **`--git <repo>` option:** You can pass `--git <repo>` (e.g.,
+  `--git https://github.com/owner/repo.git` or `--git owner/repo`) to `add`,
+  `get`, or `remove` commands to restrict operations to specific git repos.
+- **Requirement:** Git must be installed and on your PATH. If git is not
+  found, a warning is printed and only Dart package skills are used.
+- **Directory Filtering:** When crawling a Git repository for skills,
+  directories named `third_party` or hidden directories (starting with `.`)
+  are ignored.
 
-### Pruning removed dependencies
+### Pruning removed dependencies and unused sources
 
-When you remove a package from your `pubspec.yaml`, its skills stay in your agent directories until you clean them up. Run:
+When you remove a package from your `pubspec.yaml`, its skills stay in your
+agent directories until you clean them up. Run:
 
 ```bash
 dart run skills@ prune
 ```
 
-This removes only skills whose package is no longer in your dependency tree and updates the manifest. Use `--agent <agent>` to prune a single agent. If you have no managed skills, `prune` reports that and exits.
+This removes skills whose package is no longer in your dependency tree and
+updates the manifest. Use `--agent <agent>` to prune a single agent.
+
+The `prune` command also checks both local and global configurations for git
+repository sources that have no skills installed, and prompts whether to remove
+them. The pruning logic is automatically invoked after every `skills get`.
 
 ### Version control and .gitignore
 

--- a/pkgs/skills/lib/src/commands/get_skills.dart
+++ b/pkgs/skills/lib/src/commands/get_skills.dart
@@ -13,6 +13,7 @@ import 'package:skills/src/commands/skills_command.dart';
 import 'package:skills/src/core/advisory_checker.dart';
 import 'package:skills/src/core/git_runner.dart';
 import 'package:skills/src/core/package_resolver.dart';
+import 'package:skills/src/core/pruner.dart';
 import 'package:skills/src/core/pub_runner.dart';
 import 'package:skills/src/core/git_scanner.dart';
 import 'package:skills/src/core/git_sync.dart';
@@ -257,6 +258,14 @@ Future<bool> getSkills({
 
   await globalConfig.save(globalConfigFile);
   await manifest.save(manifestFile(rootPath));
+
+  await pruneSkills(
+    workspace: workspace,
+    logger: logger,
+    dialogSupport: dialogSupport,
+    targetAgents: agents,
+    quietIfNothingToPrune: true,
+  );
 
   return true;
 }

--- a/pkgs/skills/lib/src/commands/get_skills.dart
+++ b/pkgs/skills/lib/src/commands/get_skills.dart
@@ -265,6 +265,7 @@ Future<bool> getSkills({
     dialogSupport: dialogSupport,
     targetAgents: agents,
     quietIfNothingToPrune: true,
+    allFlag: allFlag,
   );
 
   return true;

--- a/pkgs/skills/lib/src/commands/get_skills.dart
+++ b/pkgs/skills/lib/src/commands/get_skills.dart
@@ -148,7 +148,7 @@ Future<bool> getSkills({
 
   final skills = [...dartSkills, ...gitData.gitSkills];
 
-  Map<Agent, Set<String>>? selectedSkillNamesByIde;
+  Map<Agent, Set<String>>? selectedSkillNamesByAgent;
 
   // Log about any unrecognized skills
   if (skillNames.isNotEmpty) {
@@ -216,9 +216,9 @@ Future<bool> getSkills({
   // Use `skillNames` or the `--all` flag as the selection if provided,
   // otherwise prompt for which skills to install or log the available skills.
   if (skillNames.isNotEmpty) {
-    selectedSkillNamesByIde = {};
+    selectedSkillNamesByAgent = {};
     for (final agent in agents) {
-      selectedSkillNamesByIde[agent] = skillNames;
+      selectedSkillNamesByAgent[agent] = skillNames;
     }
   } else if (!allFlag) {
     final promptResult = await _promptForSkillsToInstall(
@@ -234,16 +234,16 @@ Future<bool> getSkills({
     if (!promptResult.continueInstall) {
       return false;
     }
-    selectedSkillNamesByIde = promptResult.selectedSkillNamesByIde;
+    selectedSkillNamesByAgent = promptResult.selectedSkillNamesByAgent;
   }
 
   final installer = SkillInstaller(dialogSupport);
   for (final agent in agents) {
-    final result = await installer.installSkillsForIde(
+    final result = await installer.installSkillsForAgent(
       agent: agent,
       rootPath: rootPath,
       skills: skills,
-      selectedSkills: selectedSkillNamesByIde?[agent],
+      selectedSkills: selectedSkillNamesByAgent?[agent],
       previousManifest: manifest,
       globalConfig: globalConfig,
       sourceUris: sourceUris, // this still acts as source filter
@@ -668,7 +668,7 @@ Future<_PromptResult> _promptForSkillsToInstall({
   required DialogSupport? dialogSupport,
   required Logger logger,
 }) async {
-  final selectedSkillNamesByIde = <Agent, Set<String>>{
+  final selectedSkillNamesByAgent = <Agent, Set<String>>{
     for (final agent in agents) agent: {},
   };
   var hasAnyChangesToPrint = false;
@@ -752,19 +752,19 @@ Future<_PromptResult> _promptForSkillsToInstall({
         for (final index in selectedIndices) {
           final opt = dialogOptions[index];
           for (final adapter in opt.adapters) {
-            selectedSkillNamesByIde[adapter.agent]!.add(opt.skill.skillName);
+            selectedSkillNamesByAgent[adapter.agent]!.add(opt.skill.skillName);
           }
         }
       } else {
         logger.info('Installation aborted by user.');
-        return (continueInstall: false, selectedSkillNamesByIde: null);
+        return (continueInstall: false, selectedSkillNamesByAgent: null);
       }
     }
   }
 
   if (!hasAnyChangesToPrint) {
     logger.info('All skills are up to date.');
-    return (continueInstall: false, selectedSkillNamesByIde: null);
+    return (continueInstall: false, selectedSkillNamesByAgent: null);
   }
 
   if (dialogSupport == null) {
@@ -772,12 +772,12 @@ Future<_PromptResult> _promptForSkillsToInstall({
       'Rerun with `--skill <name>`, or `--all` to '
       'install, update, or remove the given skills.',
     );
-    return (continueInstall: false, selectedSkillNamesByIde: null);
+    return (continueInstall: false, selectedSkillNamesByAgent: null);
   }
 
   return (
     continueInstall: true,
-    selectedSkillNamesByIde: selectedSkillNamesByIde,
+    selectedSkillNamesByAgent: selectedSkillNamesByAgent,
   );
 }
 
@@ -836,7 +836,7 @@ typedef _SkillStatesResult = ({
 
 typedef _PromptResult = ({
   bool continueInstall,
-  Map<Agent, Set<String>>? selectedSkillNamesByIde,
+  Map<Agent, Set<String>>? selectedSkillNamesByAgent,
 });
 
 typedef _DialogOption = ({

--- a/pkgs/skills/lib/src/commands/prune_command.dart
+++ b/pkgs/skills/lib/src/commands/prune_command.dart
@@ -25,6 +25,12 @@ class PruneCommand extends SkillsCommand {
   PruneCommand({DialogSupport? dialogSupport})
     : _dialogSupport = dialogSupport {
     addAgentOption(argParser);
+    argParser.addFlag(
+      'all',
+      abbr: 'a',
+      help: 'Prune all unused packages and empty sources without prompting.',
+      negatable: false,
+    );
   }
 
   @override
@@ -45,11 +51,14 @@ class PruneCommand extends SkillsCommand {
       targetAgents = null;
     }
 
+    final allFlag = argResults.flag('all');
+
     await pruneSkills(
       workspace: workspace,
       logger: logger,
       dialogSupport: _dialogSupport,
       targetAgents: targetAgents,
+      allFlag: allFlag,
     );
   }
 }

--- a/pkgs/skills/lib/src/commands/prune_command.dart
+++ b/pkgs/skills/lib/src/commands/prune_command.dart
@@ -1,15 +1,17 @@
-import 'package:args/command_runner.dart';
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
-import '../core/package_resolver.dart';
-import '../core/pub_runner.dart';
-import '../core/skill_installer.dart';
+import 'package:args/command_runner.dart';
+import 'package:skills/src/core/dialog_support.dart';
+import 'package:skills/src/core/pruner.dart';
+import 'package:skills/src/core/pub_runner.dart';
 import '../agent/agent.dart';
-import '../models/skill_manifest.dart';
 import 'options.dart';
 import 'skills_command.dart';
-import 'package:skills/src/core/dialog_support.dart';
 
-/// Removes installed skills whose package is no longer in the dependency tree.
+/// Removes installed skills whose package is no longer in the dependency tree,
+/// and cleans up unused git skill sources.
 class PruneCommand extends SkillsCommand {
   @override
   final String name = 'prune';
@@ -29,76 +31,25 @@ class PruneCommand extends SkillsCommand {
   Future<void> run() async {
     final argResults = this.argResults!;
     final workspace = await resolveWorkspace();
-    final rootPath = workspace.rootPath;
 
     final ready = await PubRunner.ensureWorkspaceConfigs(workspace);
     if (!ready) {
       throw UsageException('Failed to run pub get.', usage);
     }
 
-    final packages = await PackageResolver.resolveWorkspace(workspace);
-    final referencedNames = packages.map((p) => p.name).toSet();
-
-    final loaded = await SkillManifest.loadOrEmptyFromRoot(rootPath);
-
-    if (loaded.isEmpty) {
-      logger.info('No managed skills found.');
-      return;
-    }
-
-    var manifest = loaded;
-
-    final List<Agent> targetIdes;
+    final List<Agent>? targetAgents;
     final parsedAgents = parseAgentOption(argResults);
     if (parsedAgents.isNotEmpty) {
-      targetIdes = parsedAgents;
+      targetAgents = parsedAgents;
     } else {
-      targetIdes = manifest.allAgents
-          .map((name) => Agent.fromCliName(name))
-          .whereType<Agent>()
-          .toList();
+      targetAgents = null;
     }
 
-    final installer = SkillInstaller(_dialogSupport);
-    var totalRemoved = 0;
-    final prunedPackages = <String>{};
-
-    for (final agent in targetIdes) {
-      final pkgs = manifest.sourceUrisForAgent(agent.cliName);
-      final pkgsToPrune = pkgs.keys
-          .where(
-            (uri) =>
-                uri.startsWith('package:') &&
-                !referencedNames.contains(uri.substring('package:'.length)),
-          )
-          .toSet();
-      prunedPackages.addAll(pkgsToPrune);
-      if (pkgsToPrune.isEmpty) continue;
-
-      final result = await installer.removeSkillsForIde(
-        agent: agent,
-        rootPath: rootPath,
-        manifest: manifest,
-        sourceUris: pkgsToPrune,
-      );
-      manifest = result.manifest;
-      totalRemoved += result.removedCount;
-      for (final info in result.removed) {
-        logger.info('  [${info.agentName}] Removed ${info.skillName}');
-      }
-    }
-
-    await manifest.save(manifestFile(rootPath));
-    if (manifest.isEmpty) {
-      await SkillManifest.cleanup(rootPath);
-    }
-
-    if (totalRemoved == 0) {
-      logger.info('No skills to prune.');
-    } else {
-      logger.info(
-        'Pruned $totalRemoved skill(s) from ${prunedPackages.length} package(s).',
-      );
-    }
+    await pruneSkills(
+      workspace: workspace,
+      logger: logger,
+      dialogSupport: _dialogSupport,
+      targetAgents: targetAgents,
+    );
   }
 }

--- a/pkgs/skills/lib/src/commands/remove_command.dart
+++ b/pkgs/skills/lib/src/commands/remove_command.dart
@@ -203,7 +203,7 @@ class RemoveCommand extends SkillsCommand {
     var totalRemoved = 0;
 
     for (final agent in targetAgents) {
-      final result = await installer.removeSkillsForIde(
+      final result = await installer.removeSkillsForAgent(
         agent: agent,
         rootPath: rootPath,
         manifest: manifest,

--- a/pkgs/skills/lib/src/core/migration.dart
+++ b/pkgs/skills/lib/src/core/migration.dart
@@ -160,7 +160,7 @@ Future<SkillManifest> maybeDoRegistryMigration(
             if (skillsToRemove.isNotEmpty) {
               for (final agentName in updatedManifest.allAgents.toList()) {
                 final agent = Agent.fromCliName(agentName)!;
-                final result = await installer.removeSkillsForIde(
+                final result = await installer.removeSkillsForAgent(
                   agent: agent,
                   rootPath: rootPath,
                   manifest: updatedManifest,

--- a/pkgs/skills/lib/src/core/pruner.dart
+++ b/pkgs/skills/lib/src/core/pruner.dart
@@ -14,19 +14,27 @@ import 'package:skills/src/core/workspace_resolver.dart';
 import 'package:skills/src/models/global_config.dart';
 import 'package:skills/src/models/skill_manifest.dart';
 
-/// Checks if a global [GitRepo] has any active skill installations on disk
-/// or in the local workspace [manifest].
-Future<bool> _hasActiveInstalls({
-  required GitRepo repo,
-  required SkillManifest manifest,
-}) async {
+/// Checks if a global [GitRepo] has active skill install files recorded on
+/// disk.
+///
+/// This check only applies to global repositories, whose installation paths are
+/// recorded in [GitRepo.installs].
+Future<bool> _hasActiveGlobalInstallsOnDisk(GitRepo repo) async {
   for (final path in repo.installs) {
     if (await File(path).exists() || await Directory(path).exists()) {
       return true;
     }
   }
+  return false;
+}
+
+/// Checks if any installed skill in [manifest] belongs to [cloneUrl].
+bool _hasActiveInstallsInManifest({
+  required String cloneUrl,
+  required SkillManifest manifest,
+}) {
   for (final agentName in manifest.allAgents) {
-    final entry = manifest.sourceUrisForAgent(agentName)[repo.cloneUrl];
+    final entry = manifest.sourceUrisForAgent(agentName)[cloneUrl];
     if (entry != null && entry.skills.isNotEmpty) {
       return true;
     }
@@ -35,15 +43,19 @@ Future<bool> _hasActiveInstalls({
 }
 
 /// Prunes skills whose package dependencies are no longer in the workspace,
-/// and prompts to remove git repository sources in local and global configs that
-/// have no installed skills.
+/// and cleans up unused git repository sources in local and global configs.
 Future<void> pruneSkills({
   required WorkspaceLayout workspace,
   required Logger logger,
   DialogSupport? dialogSupport,
   List<Agent>? targetAgents,
   bool quietIfNothingToPrune = false,
+  bool allFlag = false,
 }) async {
+  if (dialogSupport == null && !allFlag) {
+    return;
+  }
+
   final rootPath = workspace.rootPath;
   final packages = await PackageResolver.resolveWorkspace(workspace);
   final referencedNames = packages.map((p) => p.name).toSet();
@@ -72,79 +84,99 @@ Future<void> pruneSkills({
   final installer = SkillInstaller(dialogSupport);
   var totalRemoved = 0;
   final prunedPackages = <String>{};
+  var totalGitSourcesRemoved = 0;
 
   for (final agent in agentsToProcess) {
-    final pkgs = manifest.sourceUrisForAgent(agent.cliName);
-    final pkgsToPrune = pkgs.keys
+    final sourceEntries = manifest.sourceUrisForAgent(agent.cliName);
+
+    final unreferencedPackages = sourceEntries.keys
         .where(
           (uri) =>
               uri.startsWith('package:') &&
               !referencedNames.contains(uri.substring('package:'.length)),
         )
         .toSet();
-    prunedPackages.addAll(pkgsToPrune);
-    if (pkgsToPrune.isEmpty) continue;
 
-    final result = await installer.removeSkillsForIde(
-      agent: agent,
-      rootPath: rootPath,
-      manifest: manifest,
-      sourceUris: pkgsToPrune,
-    );
-    manifest = result.manifest;
-    totalRemoved += result.removedCount;
-    for (final info in result.removed) {
-      logger.info('  [${info.agentName}] Removed ${info.skillName}');
+    final emptyLocalGitSources = sourceEntries.entries
+        .where((e) => !e.key.startsWith('package:') && e.value.skills.isEmpty)
+        .map((e) => e.key)
+        .toSet();
+
+    final candidates = [...unreferencedPackages, ...emptyLocalGitSources]
+      ..sort();
+    if (candidates.isEmpty) continue;
+
+    final Set<String> selectedItems;
+    if (!allFlag) {
+      final selectedIndices = await dialogSupport!.showMultiSelectDialog(
+        candidates,
+        title:
+            'Select packages and local git sources to prune for '
+            '${agent.cliName}:',
+        initialSelected: {for (var i = 0; i < candidates.length; i++) i},
+      );
+      if (selectedIndices == null || selectedIndices.isEmpty) {
+        continue;
+      }
+      selectedItems = selectedIndices.map((i) => candidates[i]).toSet();
+    } else {
+      selectedItems = candidates.toSet();
     }
-  }
 
-  var totalGitSourcesRemoved = 0;
+    final pkgsToPrune = selectedItems
+        .where((item) => item.startsWith('package:'))
+        .toSet();
+    final localGitToPrune = selectedItems
+        .where((item) => !item.startsWith('package:'))
+        .toSet();
 
-  // Prompt to remove local git sources in manifest with no skills listed.
-  if (dialogSupport != null) {
-    final askedLocalUris = <String, bool>{};
-    for (final agent in agentsToProcess) {
-      final sourceEntries = manifest.sourceUrisForAgent(agent.cliName);
-      for (final MapEntry(key: uri, value: entry) in sourceEntries.entries) {
-        if (uri.startsWith('package:') || entry.skills.isNotEmpty) continue;
-
-        final shouldRemove =
-            askedLocalUris[uri] ??
-            await (() async {
-              final selection = await dialogSupport.showSingleSelectDialog(
-                const ['Yes', 'No'],
-                title:
-                    'Remove local git source "$uri" which has no skills '
-                    'installed?',
-              );
-              final remove = selection == 0;
-              askedLocalUris[uri] = remove;
-              return remove;
-            })();
-
-        if (shouldRemove) {
-          manifest = manifest.withoutSourceUri(agent.cliName, uri);
-          totalGitSourcesRemoved++;
-          logger.info('Removed local git source "$uri".');
-        }
+    if (pkgsToPrune.isNotEmpty) {
+      final result = await installer.removeSkillsForIde(
+        agent: agent,
+        rootPath: rootPath,
+        manifest: manifest,
+        sourceUris: pkgsToPrune,
+      );
+      manifest = result.manifest;
+      totalRemoved += result.removedCount;
+      prunedPackages.addAll(pkgsToPrune);
+      for (final info in result.removed) {
+        logger.info('  [${info.agentName}] Removed ${info.skillName}');
       }
     }
+
+    for (final uri in localGitToPrune) {
+      manifest = manifest.withoutSourceUri(agent.cliName, uri);
+      totalGitSourcesRemoved++;
+      logger.info('  [${agent.cliName}] Removed empty local git source "$uri"');
+    }
   }
 
-  // Prompt to remove global git sources with no skills installed.
-  if (dialogSupport != null && globalConfig.gitRepos.isNotEmpty) {
+  // Handle global repos with no active installations.
+  if (globalConfig.gitRepos.isNotEmpty) {
     var updatedRepos = globalConfig.gitRepos;
     for (final repo in globalConfig.gitRepos) {
-      final active = await _hasActiveInstalls(repo: repo, manifest: manifest);
-      if (active) continue;
-
-      final selection = await dialogSupport.showSingleSelectDialog(
-        const ['Yes', 'No'],
-        title:
-            'Remove global git source "${repo.cloneUrl}" which has no '
-            'skills installed?',
+      final activeOnDisk = await _hasActiveGlobalInstallsOnDisk(repo);
+      final activeInManifest = _hasActiveInstallsInManifest(
+        cloneUrl: repo.cloneUrl,
+        manifest: manifest,
       );
-      if (selection == 0) {
+      if (activeOnDisk || activeInManifest) continue;
+
+      final bool removeGlobal;
+      if (!allFlag) {
+        final selection = await dialogSupport!.showSingleSelectDialog(
+          const ['Yes', 'No'],
+          title:
+              'Remove global git source "${repo.cloneUrl}" which has no '
+              'skills installed?',
+        );
+        removeGlobal = selection == 0;
+      } else {
+        removeGlobal = true;
+      }
+
+      if (removeGlobal) {
         updatedRepos = updatedRepos
             .where((r) => r.cloneUrl != repo.cloneUrl)
             .toList();

--- a/pkgs/skills/lib/src/core/pruner.dart
+++ b/pkgs/skills/lib/src/core/pruner.dart
@@ -124,45 +124,46 @@ Future<void> pruneSkills({
     }
   }
 
+  await manifest.save(File(SkillManifest.pathIn(rootPath)));
+
   // Handle global repos with no active installations.
   if (globalConfig.gitRepos.isNotEmpty) {
-    var updatedRepos = globalConfig.gitRepos;
+    final candidateGlobalRepos = <GitRepo>[];
     for (final repo in globalConfig.gitRepos) {
       final activeOnDisk = await _hasActiveGlobalInstallsOnDisk(repo);
-      final activeInManifest = _hasActiveInstallsInManifest(
-        cloneUrl: repo.cloneUrl,
-        manifest: manifest,
-      );
-      if (activeOnDisk || activeInManifest) continue;
-
-      final bool removeGlobal;
-      if (!allFlag) {
-        final selection = await dialogSupport!.showSingleSelectDialog(
-          const ['Yes', 'No'],
-          title:
-              'Remove global git source "${repo.cloneUrl}" which has no '
-              'skills installed?',
-        );
-        removeGlobal = selection == 0;
-      } else {
-        removeGlobal = true;
-      }
-
-      if (removeGlobal) {
-        updatedRepos = updatedRepos
-            .where((r) => r.cloneUrl != repo.cloneUrl)
-            .toList();
-        totalGitSourcesRemoved++;
-        logger.info('Removed global git source "${repo.cloneUrl}".');
+      if (!activeOnDisk) {
+        candidateGlobalRepos.add(repo);
       }
     }
-    if (updatedRepos.length != globalConfig.gitRepos.length) {
-      globalConfig = GlobalConfig(
-        gitRepos: updatedRepos,
-        neverPromptForSuggestedSkills:
-            globalConfig.neverPromptForSuggestedSkills,
-      );
-      await globalConfig.save(globalConfigFile);
+
+    if (candidateGlobalRepos.isNotEmpty) {
+      final Set<GitRepo> reposToRemove;
+      if (!allFlag) {
+        final options = candidateGlobalRepos.map((r) => r.cloneUrl).toList();
+        final selectedIndices = await dialogSupport!.showMultiSelectDialog(
+          options,
+          title: 'Select global git sources to remove:',
+          initialSelected: {for (var i = 0; i < options.length; i++) i},
+        );
+        if (selectedIndices != null && selectedIndices.isNotEmpty) {
+          reposToRemove = selectedIndices
+              .map((i) => candidateGlobalRepos[i])
+              .toSet();
+        } else {
+          reposToRemove = const {};
+        }
+      } else {
+        reposToRemove = candidateGlobalRepos.toSet();
+      }
+
+      if (reposToRemove.isNotEmpty) {
+        totalGitSourcesRemoved += reposToRemove.length;
+        for (final repo in reposToRemove) {
+          logger.info('Removed global git source "${repo.cloneUrl}".');
+        }
+        globalConfig = globalConfig.withoutGitRepos(reposToRemove);
+        await globalConfig.save(globalConfigFile);
+      }
     }
   }
 
@@ -190,20 +191,6 @@ Future<void> pruneSkills({
 Future<bool> _hasActiveGlobalInstallsOnDisk(GitRepo repo) async {
   for (final path in repo.installs) {
     if (await File(path).exists() || await Directory(path).exists()) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/// Checks if any installed skill in [manifest] belongs to [cloneUrl].
-bool _hasActiveInstallsInManifest({
-  required String cloneUrl,
-  required SkillManifest manifest,
-}) {
-  for (final agentName in manifest.allAgents) {
-    final entry = manifest.sourceUrisForAgent(agentName)[cloneUrl];
-    if (entry != null && entry.skills.isNotEmpty) {
       return true;
     }
   }

--- a/pkgs/skills/lib/src/core/pruner.dart
+++ b/pkgs/skills/lib/src/core/pruner.dart
@@ -14,6 +14,8 @@ import 'package:skills/src/core/workspace_resolver.dart';
 import 'package:skills/src/models/global_config.dart';
 import 'package:skills/src/models/skill_manifest.dart';
 
+const _packagePrefix = 'package:';
+
 /// Prunes skills whose package dependencies are no longer in the workspace,
 /// and cleans up unused git repository sources in local and global configs.
 Future<void> pruneSkills({
@@ -65,73 +67,21 @@ Future<void> pruneSkills({
   var totalGitSourcesRemoved = 0;
 
   for (final agent in agentsToProcess) {
-    final sourceEntries = manifest.sourceUrisForAgent(agent.cliName);
-
-    final unreferencedPackages = sourceEntries.keys
-        .where(
-          (uri) =>
-              uri.startsWith('package:') &&
-              !referencedNames.contains(uri.substring('package:'.length)),
-        )
-        .toSet();
-
-    final emptyLocalGitSources = sourceEntries.entries
-        .where((e) => !e.key.startsWith('package:') && e.value.skills.isEmpty)
-        .map((e) => e.key)
-        .toSet();
-
-    final candidates = [...unreferencedPackages, ...emptyLocalGitSources]
-      ..sort();
-    if (candidates.isEmpty) continue;
-
-    final Set<String> selectedItems;
-    if (!allFlag) {
-      final selectedIndices = await dialogSupport!.showMultiSelectDialog(
-        candidates,
-        title:
-            'Select packages and local git sources to prune for '
-            '${agent.cliName}:',
-        initialSelected: {for (var i = 0; i < candidates.length; i++) i},
-      );
-      if (selectedIndices == null) {
-        logger.info('Prune aborted by user.');
-        return;
-      }
-      if (selectedIndices.isEmpty) {
-        continue;
-      }
-      selectedItems = selectedIndices.map((i) => candidates[i]).toSet();
-    } else {
-      selectedItems = candidates.toSet();
-    }
-
-    final pkgsToPrune = selectedItems
-        .where((item) => item.startsWith('package:'))
-        .toSet();
-    final localGitToPrune = selectedItems
-        .where((item) => !item.startsWith('package:'))
-        .toSet();
-
-    if (pkgsToPrune.isNotEmpty) {
-      final result = await installer.removeSkillsForIde(
-        agent: agent,
-        rootPath: rootPath,
-        manifest: manifest,
-        sourceUris: pkgsToPrune,
-      );
-      manifest = result.manifest;
-      totalRemoved += result.removedCount;
-      prunedPackages.addAll(pkgsToPrune);
-      for (final info in result.removed) {
-        logger.info('  [${info.agentName}] Removed ${info.skillName}');
-      }
-    }
-
-    for (final uri in localGitToPrune) {
-      manifest = manifest.withoutSourceUri(agent.cliName, uri);
-      totalGitSourcesRemoved++;
-      logger.info('  [${agent.cliName}] Removed empty local git source "$uri"');
-    }
+    final result = await _pruneSkillsForAgent(
+      agent: agent,
+      manifest: manifest,
+      referencedNames: referencedNames,
+      rootPath: rootPath,
+      installer: installer,
+      logger: logger,
+      dialogSupport: dialogSupport,
+      allFlag: allFlag,
+    );
+    if (result == null) return;
+    manifest = result.manifest;
+    totalRemoved += result.removedCount;
+    prunedPackages.addAll(result.prunedPackages);
+    totalGitSourcesRemoved += result.gitSourcesRemovedCount;
   }
 
   await manifest.save(File(SkillManifest.pathIn(rootPath)));
@@ -215,4 +165,114 @@ Future<bool> _hasActiveGlobalInstallsOnDisk(GitRepo repo) async {
     }
   }
   return false;
+}
+
+typedef _AgentPruneResult = ({
+  SkillManifest manifest,
+  int removedCount,
+  Set<String> prunedPackages,
+  int gitSourcesRemovedCount,
+});
+
+Future<_AgentPruneResult?> _pruneSkillsForAgent({
+  required Agent agent,
+  required SkillManifest manifest,
+  required Set<String> referencedNames,
+  required String rootPath,
+  required SkillInstaller installer,
+  required Logger logger,
+  DialogSupport? dialogSupport,
+  required bool allFlag,
+}) async {
+  final sourceEntries = manifest.sourceUrisForAgent(agent.cliName);
+
+  final unreferencedPackages = sourceEntries.keys
+      .where(
+        (uri) =>
+            uri.startsWith(_packagePrefix) &&
+            !referencedNames.contains(uri.substring(_packagePrefix.length)),
+      )
+      .toSet();
+
+  final emptyLocalGitSources = sourceEntries.entries
+      .where((e) => !e.key.startsWith(_packagePrefix) && e.value.skills.isEmpty)
+      .map((e) => e.key)
+      .toSet();
+
+  final candidates = [...unreferencedPackages, ...emptyLocalGitSources]..sort();
+  if (candidates.isEmpty) {
+    return (
+      manifest: manifest,
+      removedCount: 0,
+      prunedPackages: const <String>{},
+      gitSourcesRemovedCount: 0,
+    );
+  }
+
+  final Set<String> selectedItems;
+  if (!allFlag) {
+    final selectedIndices = await dialogSupport!.showMultiSelectDialog(
+      candidates,
+      title:
+          'Select packages and local git sources to prune for '
+          '${agent.cliName}:',
+      initialSelected: {for (var i = 0; i < candidates.length; i++) i},
+    );
+    if (selectedIndices == null) {
+      logger.info('Prune aborted by user.');
+      return null;
+    }
+    if (selectedIndices.isEmpty) {
+      return (
+        manifest: manifest,
+        removedCount: 0,
+        prunedPackages: const <String>{},
+        gitSourcesRemovedCount: 0,
+      );
+    }
+    selectedItems = selectedIndices.map((i) => candidates[i]).toSet();
+  } else {
+    selectedItems = candidates.toSet();
+  }
+
+  final pkgsToPrune = <String>{};
+  final localGitToPrune = <String>{};
+  for (final item in selectedItems) {
+    if (item.startsWith(_packagePrefix)) {
+      pkgsToPrune.add(item);
+    } else {
+      localGitToPrune.add(item);
+    }
+  }
+
+  var updatedManifest = manifest;
+  var removedCount = 0;
+  var gitSourcesRemovedCount = 0;
+
+  if (pkgsToPrune.isNotEmpty) {
+    final result = await installer.removeSkillsForIde(
+      agent: agent,
+      rootPath: rootPath,
+      manifest: updatedManifest,
+      sourceUris: pkgsToPrune,
+    );
+    updatedManifest = result.manifest;
+    removedCount += result.removedCount;
+    for (final info in result.removed) {
+      logger.info('  [${info.agentName}] Removed ${info.skillName}');
+    }
+  }
+
+  for (final uri in localGitToPrune) {
+    updatedManifest = updatedManifest.withoutSourceUri(agent.cliName, uri);
+    gitSourcesRemovedCount++;
+    logger.info('  [${agent.cliName}] Removed empty local git source "$uri"');
+  }
+
+  return (
+    manifest: updatedManifest,
+    removedCount: removedCount,
+    prunedPackages: pkgsToPrune,
+    gitSourcesRemovedCount: gitSourcesRemovedCount,
+  );
 }

--- a/pkgs/skills/lib/src/core/pruner.dart
+++ b/pkgs/skills/lib/src/core/pruner.dart
@@ -190,10 +190,17 @@ Future<void> pruneSkills({
     if (!quietIfNothingToPrune) {
       logger.info('No skills to prune.');
     }
-  } else if (totalRemoved > 0) {
-    logger.info(
-      'Pruned $totalRemoved skill(s) from ${prunedPackages.length} package(s).',
-    );
+  } else {
+    final summaryParts = <String>[];
+    if (totalRemoved > 0) {
+      summaryParts.add(
+        'Pruned $totalRemoved skill(s) from ${prunedPackages.length} package(s).',
+      );
+    }
+    if (totalGitSourcesRemoved > 0) {
+      summaryParts.add('Removed $totalGitSourcesRemoved empty git source(s).');
+    }
+    logger.info(summaryParts.join(' '));
   }
 }
 

--- a/pkgs/skills/lib/src/core/pruner.dart
+++ b/pkgs/skills/lib/src/core/pruner.dart
@@ -134,6 +134,8 @@ Future<void> pruneSkills({
     }
   }
 
+  await manifest.save(File(SkillManifest.pathIn(rootPath)));
+
   // Handle global repos with no active installations.
   if (globalConfig.gitRepos.isNotEmpty) {
     final candidateGlobalRepos = <GitRepo>[];

--- a/pkgs/skills/lib/src/core/pruner.dart
+++ b/pkgs/skills/lib/src/core/pruner.dart
@@ -14,34 +14,6 @@ import 'package:skills/src/core/workspace_resolver.dart';
 import 'package:skills/src/models/global_config.dart';
 import 'package:skills/src/models/skill_manifest.dart';
 
-/// Checks if a global [GitRepo] has active skill install files recorded on
-/// disk.
-///
-/// This check only applies to global repositories, whose installation paths are
-/// recorded in [GitRepo.installs].
-Future<bool> _hasActiveGlobalInstallsOnDisk(GitRepo repo) async {
-  for (final path in repo.installs) {
-    if (await File(path).exists() || await Directory(path).exists()) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/// Checks if any installed skill in [manifest] belongs to [cloneUrl].
-bool _hasActiveInstallsInManifest({
-  required String cloneUrl,
-  required SkillManifest manifest,
-}) {
-  for (final agentName in manifest.allAgents) {
-    final entry = manifest.sourceUrisForAgent(agentName)[cloneUrl];
-    if (entry != null && entry.skills.isNotEmpty) {
-      return true;
-    }
-  }
-  return false;
-}
-
 /// Prunes skills whose package dependencies are no longer in the workspace,
 /// and cleans up unused git repository sources in local and global configs.
 Future<void> pruneSkills({
@@ -208,4 +180,32 @@ Future<void> pruneSkills({
       'Pruned $totalRemoved skill(s) from ${prunedPackages.length} package(s).',
     );
   }
+}
+
+/// Checks if a global [GitRepo] has active skill install files recorded on
+/// disk.
+///
+/// This check only applies to global repositories, whose installation paths are
+/// recorded in [GitRepo.installs].
+Future<bool> _hasActiveGlobalInstallsOnDisk(GitRepo repo) async {
+  for (final path in repo.installs) {
+    if (await File(path).exists() || await Directory(path).exists()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// Checks if any installed skill in [manifest] belongs to [cloneUrl].
+bool _hasActiveInstallsInManifest({
+  required String cloneUrl,
+  required SkillManifest manifest,
+}) {
+  for (final agentName in manifest.allAgents) {
+    final entry = manifest.sourceUrisForAgent(agentName)[cloneUrl];
+    if (entry != null && entry.skills.isNotEmpty) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/pkgs/skills/lib/src/core/pruner.dart
+++ b/pkgs/skills/lib/src/core/pruner.dart
@@ -250,7 +250,7 @@ Future<_AgentPruneResult?> _pruneSkillsForAgent({
   var gitSourcesRemovedCount = 0;
 
   if (pkgsToPrune.isNotEmpty) {
-    final result = await installer.removeSkillsForIde(
+    final result = await installer.removeSkillsForAgent(
       agent: agent,
       rootPath: rootPath,
       manifest: updatedManifest,

--- a/pkgs/skills/lib/src/core/pruner.dart
+++ b/pkgs/skills/lib/src/core/pruner.dart
@@ -1,0 +1,179 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:logging/logging.dart';
+import 'package:skills/src/agent/agent.dart';
+import 'package:skills/src/core/dialog_support.dart';
+import 'package:skills/src/core/git_repos.dart';
+import 'package:skills/src/core/package_resolver.dart';
+import 'package:skills/src/core/skill_installer.dart';
+import 'package:skills/src/core/workspace_resolver.dart';
+import 'package:skills/src/models/global_config.dart';
+import 'package:skills/src/models/skill_manifest.dart';
+
+/// Checks if a global [GitRepo] has any active skill installations on disk
+/// or in the local workspace [manifest].
+Future<bool> _hasActiveInstalls({
+  required GitRepo repo,
+  required SkillManifest manifest,
+}) async {
+  for (final path in repo.installs) {
+    if (await File(path).exists() || await Directory(path).exists()) {
+      return true;
+    }
+  }
+  for (final agentName in manifest.allAgents) {
+    final entry = manifest.sourceUrisForAgent(agentName)[repo.cloneUrl];
+    if (entry != null && entry.skills.isNotEmpty) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// Prunes skills whose package dependencies are no longer in the workspace,
+/// and prompts to remove git repository sources in local and global configs that
+/// have no installed skills.
+Future<void> pruneSkills({
+  required WorkspaceLayout workspace,
+  required Logger logger,
+  DialogSupport? dialogSupport,
+  List<Agent>? targetAgents,
+  bool quietIfNothingToPrune = false,
+}) async {
+  final rootPath = workspace.rootPath;
+  final packages = await PackageResolver.resolveWorkspace(workspace);
+  final referencedNames = packages.map((p) => p.name).toSet();
+
+  var manifest = await SkillManifest.loadOrEmptyFromRoot(rootPath);
+  final globalConfigFile = File(GlobalConfig.globalPath);
+  var globalConfig = await GlobalConfig.loadOrEmpty(globalConfigFile);
+
+  if (manifest.isEmpty && globalConfig.gitRepos.isEmpty) {
+    if (!quietIfNothingToPrune) {
+      logger.info('No managed skills found.');
+    }
+    return;
+  }
+
+  final List<Agent> agentsToProcess;
+  if (targetAgents != null && targetAgents.isNotEmpty) {
+    agentsToProcess = targetAgents;
+  } else {
+    agentsToProcess = manifest.allAgents
+        .map((name) => Agent.fromCliName(name))
+        .whereType<Agent>()
+        .toList();
+  }
+
+  final installer = SkillInstaller(dialogSupport);
+  var totalRemoved = 0;
+  final prunedPackages = <String>{};
+
+  for (final agent in agentsToProcess) {
+    final pkgs = manifest.sourceUrisForAgent(agent.cliName);
+    final pkgsToPrune = pkgs.keys
+        .where(
+          (uri) =>
+              uri.startsWith('package:') &&
+              !referencedNames.contains(uri.substring('package:'.length)),
+        )
+        .toSet();
+    prunedPackages.addAll(pkgsToPrune);
+    if (pkgsToPrune.isEmpty) continue;
+
+    final result = await installer.removeSkillsForIde(
+      agent: agent,
+      rootPath: rootPath,
+      manifest: manifest,
+      sourceUris: pkgsToPrune,
+    );
+    manifest = result.manifest;
+    totalRemoved += result.removedCount;
+    for (final info in result.removed) {
+      logger.info('  [${info.agentName}] Removed ${info.skillName}');
+    }
+  }
+
+  var totalGitSourcesRemoved = 0;
+
+  // Prompt to remove local git sources in manifest with no skills listed.
+  if (dialogSupport != null) {
+    final askedLocalUris = <String, bool>{};
+    for (final agent in agentsToProcess) {
+      final sourceEntries = manifest.sourceUrisForAgent(agent.cliName);
+      for (final MapEntry(key: uri, value: entry) in sourceEntries.entries) {
+        if (uri.startsWith('package:') || entry.skills.isNotEmpty) continue;
+
+        final shouldRemove =
+            askedLocalUris[uri] ??
+            await (() async {
+              final selection = await dialogSupport.showSingleSelectDialog(
+                const ['Yes', 'No'],
+                title:
+                    'Remove local git source "$uri" which has no skills '
+                    'installed?',
+              );
+              final remove = selection == 0;
+              askedLocalUris[uri] = remove;
+              return remove;
+            })();
+
+        if (shouldRemove) {
+          manifest = manifest.withoutSourceUri(agent.cliName, uri);
+          totalGitSourcesRemoved++;
+          logger.info('Removed local git source "$uri".');
+        }
+      }
+    }
+  }
+
+  // Prompt to remove global git sources with no skills installed.
+  if (dialogSupport != null && globalConfig.gitRepos.isNotEmpty) {
+    var updatedRepos = globalConfig.gitRepos;
+    for (final repo in globalConfig.gitRepos) {
+      final active = await _hasActiveInstalls(repo: repo, manifest: manifest);
+      if (active) continue;
+
+      final selection = await dialogSupport.showSingleSelectDialog(
+        const ['Yes', 'No'],
+        title:
+            'Remove global git source "${repo.cloneUrl}" which has no '
+            'skills installed?',
+      );
+      if (selection == 0) {
+        updatedRepos = updatedRepos
+            .where((r) => r.cloneUrl != repo.cloneUrl)
+            .toList();
+        totalGitSourcesRemoved++;
+        logger.info('Removed global git source "${repo.cloneUrl}".');
+      }
+    }
+    if (updatedRepos.length != globalConfig.gitRepos.length) {
+      globalConfig = GlobalConfig(
+        gitRepos: updatedRepos,
+        neverPromptForSuggestedSkills:
+            globalConfig.neverPromptForSuggestedSkills,
+      );
+      await globalConfig.save(globalConfigFile);
+    }
+  }
+
+  await manifest.save(File(SkillManifest.pathIn(rootPath)));
+  if (manifest.isEmpty) {
+    await SkillManifest.cleanup(rootPath);
+  }
+
+  if (totalRemoved == 0 && totalGitSourcesRemoved == 0) {
+    if (!quietIfNothingToPrune) {
+      logger.info('No skills to prune.');
+    }
+  } else if (totalRemoved > 0) {
+    logger.info(
+      'Pruned $totalRemoved skill(s) from ${prunedPackages.length} package(s).',
+    );
+  }
+}

--- a/pkgs/skills/lib/src/core/pruner.dart
+++ b/pkgs/skills/lib/src/core/pruner.dart
@@ -25,6 +25,12 @@ Future<void> pruneSkills({
   bool allFlag = false,
 }) async {
   if (dialogSupport == null && !allFlag) {
+    if (!quietIfNothingToPrune) {
+      logger.info(
+        'No interactive terminal detected and --all was not specified. '
+        'Aborting prune. Run with --all to prune automatically.',
+      );
+    }
     return;
   }
 
@@ -87,7 +93,11 @@ Future<void> pruneSkills({
             '${agent.cliName}:',
         initialSelected: {for (var i = 0; i < candidates.length; i++) i},
       );
-      if (selectedIndices == null || selectedIndices.isEmpty) {
+      if (selectedIndices == null) {
+        logger.info('Prune aborted by user.');
+        return;
+      }
+      if (selectedIndices.isEmpty) {
         continue;
       }
       selectedItems = selectedIndices.map((i) => candidates[i]).toSet();
@@ -124,8 +134,6 @@ Future<void> pruneSkills({
     }
   }
 
-  await manifest.save(File(SkillManifest.pathIn(rootPath)));
-
   // Handle global repos with no active installations.
   if (globalConfig.gitRepos.isNotEmpty) {
     final candidateGlobalRepos = <GitRepo>[];
@@ -145,12 +153,16 @@ Future<void> pruneSkills({
           title: 'Select global git sources to remove:',
           initialSelected: {for (var i = 0; i < options.length; i++) i},
         );
-        if (selectedIndices != null && selectedIndices.isNotEmpty) {
+        if (selectedIndices == null) {
+          logger.info('Prune aborted by user.');
+          return;
+        }
+        if (selectedIndices.isEmpty) {
+          reposToRemove = const {};
+        } else {
           reposToRemove = selectedIndices
               .map((i) => candidateGlobalRepos[i])
               .toSet();
-        } else {
-          reposToRemove = const {};
         }
       } else {
         reposToRemove = candidateGlobalRepos.toSet();

--- a/pkgs/skills/lib/src/core/pruner.dart
+++ b/pkgs/skills/lib/src/core/pruner.dart
@@ -181,7 +181,6 @@ Future<void> pruneSkills({
     }
   }
 
-  await manifest.save(File(SkillManifest.pathIn(rootPath)));
   if (manifest.isEmpty) {
     await SkillManifest.cleanup(rootPath);
   }

--- a/pkgs/skills/lib/src/core/skill_installer.dart
+++ b/pkgs/skills/lib/src/core/skill_installer.dart
@@ -102,7 +102,7 @@ class SkillInstaller {
   ///
   /// If [selectedSkills] is provided, only skills with these names will be
   /// modified. This includes deleting of existing skills.
-  Future<SkillInstallResult?> installSkillsForIde({
+  Future<SkillInstallResult?> installSkillsForAgent({
     required Agent agent,
     required String rootPath,
     required List<ScannedSkill> skills,
@@ -412,7 +412,7 @@ class SkillInstaller {
   ///
   /// If [sourceUris] is not empty, only those sources skills are removed.
   /// If [skillNames] is not empty, only those specific skills are removed.
-  Future<SkillRemoveResult> removeSkillsForIde({
+  Future<SkillRemoveResult> removeSkillsForAgent({
     required Agent agent,
     required String rootPath,
     required SkillManifest manifest,
@@ -483,7 +483,7 @@ class SkillInstaller {
     for (final agentName in manifest.allAgents.toList()) {
       final agent = Agent.fromCliName(agentName);
       if (agent == null) continue;
-      final result = await removeSkillsForIde(
+      final result = await removeSkillsForAgent(
         agent: agent,
         rootPath: rootPath,
         manifest: updated,

--- a/pkgs/skills/lib/src/models/global_config.dart
+++ b/pkgs/skills/lib/src/models/global_config.dart
@@ -98,6 +98,15 @@ class GlobalConfig {
     );
   }
 
+  /// Returns a copy with [repos] removed.
+  GlobalConfig withoutGitRepos(Iterable<GitRepo> repos) {
+    final urlsSet = repos.map((r) => r.cloneUrl).toSet();
+    return GlobalConfig(
+      gitRepos: gitRepos.where((r) => !urlsSet.contains(r.cloneUrl)).toList(),
+      neverPromptForSuggestedSkills: neverPromptForSuggestedSkills,
+    );
+  }
+
   /// Returns a copy with [neverPrompt] set.
   GlobalConfig withNeverPromptForSuggestedSkills(bool neverPrompt) {
     return GlobalConfig(

--- a/pkgs/skills/test/commands/list_command_test.dart
+++ b/pkgs/skills/test/commands/list_command_test.dart
@@ -129,7 +129,7 @@ void main() {
       expect(manifest.allSkills, hasLength(6));
     });
 
-    test('when iterating allSkillsForIde then returns only that agent', () {
+    test('when iterating allSkillsForAgent then returns only that agent', () {
       expect(manifest.allSkillsForAgent('generic'), hasLength(2));
       expect(manifest.allSkillsForAgent('cursor'), hasLength(3));
       expect(manifest.allSkillsForAgent('claude'), hasLength(1));

--- a/pkgs/skills/test/commands/prune_command_test.dart
+++ b/pkgs/skills/test/commands/prune_command_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:io';
 
 import 'package:logging/logging.dart';
@@ -334,5 +338,99 @@ void main() {
         containsAll(['package:pkg_a', 'package:unref_pkg']),
       );
     });
+
+    test(
+      'prompts to remove local git source entry with no skills listed when user says YES',
+      () async {
+        final testRootPath = p.join(
+          Directory.systemTemp.path,
+          'skills_prune_test_${DateTime.now().millisecondsSinceEpoch}',
+        );
+        Directory(testRootPath).createSync();
+        addTearDown(() async {
+          await Directory(testRootPath).delete(recursive: true);
+        });
+
+        await d.dir('project', [pubspec('my_app')]).create(testRootPath);
+        final projectPath = p.join(testRootPath, 'project');
+
+        final manifest = SkillManifest(
+          installations: {
+            'cursor': {
+              'https://github.com/dart-lang/test.git': const SkillsEntry(
+                skills: [],
+              ),
+            },
+          },
+        );
+        await manifest.save(File(SkillManifest.pathIn(projectPath)));
+
+        final fakeDialog = FakeDialogSupport();
+        fakeDialog.singleSelectResults.add(0); // Yes, remove local git source
+
+        final pruneCommand = PruneCommand(dialogSupport: fakeDialog);
+        final runner = SkillsCommandRunner('skills', 'Test')
+          ..addCommand(pruneCommand);
+        await runner.run([
+          'prune',
+          '--directory',
+          projectPath,
+          '--agent',
+          'cursor',
+        ]);
+
+        final loaded = await SkillManifest.loadFromRoot(projectPath);
+        expect(loaded, isNull);
+      },
+    );
+
+    test(
+      'keeps local git source entry with no skills listed when user says NO',
+      () async {
+        final testRootPath = p.join(
+          Directory.systemTemp.path,
+          'skills_prune_test_${DateTime.now().millisecondsSinceEpoch}',
+        );
+        Directory(testRootPath).createSync();
+        addTearDown(() async {
+          await Directory(testRootPath).delete(recursive: true);
+        });
+
+        await d.dir('project', [pubspec('my_app')]).create(testRootPath);
+        final projectPath = p.join(testRootPath, 'project');
+
+        final manifest = SkillManifest(
+          installations: {
+            'cursor': {
+              'https://github.com/dart-lang/test.git': const SkillsEntry(
+                skills: [],
+              ),
+            },
+          },
+        );
+        await manifest.save(File(SkillManifest.pathIn(projectPath)));
+
+        final fakeDialog = FakeDialogSupport();
+        fakeDialog.singleSelectResults.add(1); // No, keep local git source
+
+        final pruneCommand = PruneCommand(dialogSupport: fakeDialog);
+        final runner = SkillsCommandRunner('skills', 'Test')
+          ..addCommand(pruneCommand);
+        await runner.run([
+          'prune',
+          '--directory',
+          projectPath,
+          '--agent',
+          'cursor',
+        ]);
+
+        final loaded = await SkillManifest.loadFromRoot(projectPath);
+        expect(loaded, isNotNull);
+        expect(
+          loaded!.sourceUrisForAgent('cursor').keys,
+          contains('https://github.com/dart-lang/test.git'),
+        );
+      },
+    );
   });
 }

--- a/pkgs/skills/test/commands/prune_command_test.dart
+++ b/pkgs/skills/test/commands/prune_command_test.dart
@@ -82,7 +82,10 @@ void main() {
         );
         await manifest.save(File(SkillManifest.pathIn(projectPath)));
 
-        final pruneCommand = PruneCommand(dialogSupport: FakeDialogSupport());
+        final fakeDialog = FakeDialogSupport();
+        fakeDialog.multiSelectResults.add({0}); // select package:pkg_b
+
+        final pruneCommand = PruneCommand(dialogSupport: fakeDialog);
         final runner = SkillsCommandRunner('skills', 'Test')
           ..addCommand(pruneCommand);
         await runner.run([
@@ -160,7 +163,10 @@ void main() {
         );
         await manifest.save(File(SkillManifest.pathIn(projectPath)));
 
-        final pruneCommand = PruneCommand(dialogSupport: FakeDialogSupport());
+        final fakeDialog = FakeDialogSupport();
+        fakeDialog.multiSelectResults.add({0});
+
+        final pruneCommand = PruneCommand(dialogSupport: fakeDialog);
         final runner = SkillsCommandRunner('skills', 'Test')
           ..addCommand(pruneCommand);
         await runner.run([
@@ -179,6 +185,73 @@ void main() {
           p.join(projectPath, SkillManifest.cacheDirPath),
         );
         expect(await dartSkillsDir.exists(), isFalse);
+      },
+    );
+
+    test(
+      'when --all flag is passed then dialog is skipped and all unreferenced packages are removed',
+      () async {
+        final testRootPath = p.join(
+          Directory.systemTemp.path,
+          'skills_prune_test_${DateTime.now().millisecondsSinceEpoch}',
+        );
+        Directory(testRootPath).createSync();
+        addTearDown(() async {
+          await Directory(testRootPath).delete(recursive: true);
+        });
+
+        await d
+            .dir('project', [
+              pubspec('my_app'),
+              d.dir('.cursor', [
+                d.dir('skills', [
+                  d.dir('old_pkg-skill', [
+                    d.file(
+                      'SKILL.md',
+                      '---\nname: old_pkg-skill\ndescription: x\n---\n',
+                    ),
+                  ]),
+                ]),
+              ]),
+            ])
+            .create(testRootPath);
+
+        final projectPath = p.join(testRootPath, 'project');
+        final manifest = SkillManifest(
+          installations: {
+            'cursor': {
+              'package:old_pkg': SkillsEntry(
+                skills: [
+                  InstalledSkillEntry(
+                    name: 'old_pkg-skill',
+                    installedAt: DateTime.utc(2026),
+                  ),
+                ],
+              ),
+            },
+          },
+        );
+        await manifest.save(File(SkillManifest.pathIn(projectPath)));
+
+        final fakeDialog = FakeDialogSupport();
+        // multiSelectResults left empty so error would be thrown if dialog called
+
+        final pruneCommand = PruneCommand(dialogSupport: fakeDialog);
+        final runner = SkillsCommandRunner('skills', 'Test')
+          ..addCommand(pruneCommand);
+        await runner.run([
+          'prune',
+          '--directory',
+          projectPath,
+          '--agent',
+          'cursor',
+          '--all',
+        ]);
+
+        expect(
+          await Directory('$projectPath/.cursor/skills/old_pkg-skill').exists(),
+          isFalse,
+        );
       },
     );
 
@@ -303,7 +376,10 @@ void main() {
       );
       await manifest.save(File(SkillManifest.pathIn(projectPath)));
 
-      final pruneCommand = PruneCommand(dialogSupport: FakeDialogSupport());
+      final fakeDialog = FakeDialogSupport();
+      fakeDialog.multiSelectResults.add({0});
+
+      final pruneCommand = PruneCommand(dialogSupport: fakeDialog);
       final runner = SkillsCommandRunner('skills', 'Test')
         ..addCommand(pruneCommand);
       await runner.run([
@@ -340,7 +416,7 @@ void main() {
     });
 
     test(
-      'prompts to remove local git source entry with no skills listed when user says YES',
+      'prompts with multi-select to remove local git source entry with no skills listed when selected',
       () async {
         final testRootPath = p.join(
           Directory.systemTemp.path,
@@ -366,7 +442,7 @@ void main() {
         await manifest.save(File(SkillManifest.pathIn(projectPath)));
 
         final fakeDialog = FakeDialogSupport();
-        fakeDialog.singleSelectResults.add(0); // Yes, remove local git source
+        fakeDialog.multiSelectResults.add({0}); // Select index 0 (the git repo)
 
         final pruneCommand = PruneCommand(dialogSupport: fakeDialog);
         final runner = SkillsCommandRunner('skills', 'Test')
@@ -385,7 +461,7 @@ void main() {
     );
 
     test(
-      'keeps local git source entry with no skills listed when user says NO',
+      'keeps local git source entry with no skills listed when unselected in multi-select',
       () async {
         final testRootPath = p.join(
           Directory.systemTemp.path,
@@ -411,7 +487,9 @@ void main() {
         await manifest.save(File(SkillManifest.pathIn(projectPath)));
 
         final fakeDialog = FakeDialogSupport();
-        fakeDialog.singleSelectResults.add(1); // No, keep local git source
+        fakeDialog.multiSelectResults.add(
+          {},
+        ); // Empty selection, keep git source
 
         final pruneCommand = PruneCommand(dialogSupport: fakeDialog);
         final runner = SkillsCommandRunner('skills', 'Test')

--- a/pkgs/skills/test/commands/prune_command_test.dart
+++ b/pkgs/skills/test/commands/prune_command_test.dart
@@ -8,6 +8,8 @@ import 'package:logging/logging.dart';
 import 'package:skills/src/commands/skills_command_runner.dart';
 import 'package:path/path.dart' as p;
 import 'package:skills/src/commands/prune_command.dart';
+import 'package:skills/src/core/git_repos.dart';
+import 'package:skills/src/models/global_config.dart';
 import 'package:skills/src/models/skill_manifest.dart';
 import '../fake_dialog_support.dart';
 import '../utils.dart';
@@ -517,6 +519,78 @@ void main() {
           loaded!.sourceUrisForAgent('cursor').keys,
           contains('https://github.com/dart-lang/test.git'),
         );
+      },
+    );
+
+    test(
+      'prompts with multi-select to remove empty global git repo sources when selected',
+      () async {
+        await d.dir('project', [pubspec('my_app')]).create();
+        final projectPath = d.path('project');
+
+        await d.dir('global', []).create();
+        final globalConfigPath = p.join(d.path('global'), 'global_config.json');
+        GlobalConfig.globalPathOverride = globalConfigPath;
+        addTearDown(() {
+          GlobalConfig.globalPathOverride = null;
+        });
+
+        final globalConfig = GlobalConfig(
+          gitRepos: [
+            const GitRepo(
+              cloneUrl: 'https://github.com/dart-lang/test-global.git',
+              installs: [],
+            ),
+          ],
+        );
+        await globalConfig.save(File(globalConfigPath));
+
+        final fakeDialog = FakeDialogSupport();
+        fakeDialog.multiSelectResults.add({0});
+
+        final pruneCommand = PruneCommand(dialogSupport: fakeDialog);
+        final runner = SkillsCommandRunner('skills', 'Test')
+          ..addCommand(pruneCommand);
+        await runner.run(['prune', '--directory', projectPath]);
+
+        final loaded = await GlobalConfig.load(File(globalConfigPath));
+        expect(loaded, isNotNull);
+        expect(loaded!.gitRepos, isEmpty);
+      },
+    );
+
+    test(
+      'when --all flag is passed then dialog is skipped and empty global git repo sources are removed',
+      () async {
+        await d.dir('project', [pubspec('my_app')]).create();
+        final projectPath = d.path('project');
+
+        await d.dir('global', []).create();
+        final globalConfigPath = p.join(d.path('global'), 'global_config.json');
+        GlobalConfig.globalPathOverride = globalConfigPath;
+        addTearDown(() {
+          GlobalConfig.globalPathOverride = null;
+        });
+
+        final globalConfig = GlobalConfig(
+          gitRepos: [
+            const GitRepo(
+              cloneUrl: 'https://github.com/dart-lang/test-global.git',
+              installs: [],
+            ),
+          ],
+        );
+        await globalConfig.save(File(globalConfigPath));
+
+        final fakeDialog = FakeDialogSupport();
+        final pruneCommand = PruneCommand(dialogSupport: fakeDialog);
+        final runner = SkillsCommandRunner('skills', 'Test')
+          ..addCommand(pruneCommand);
+        await runner.run(['prune', '--directory', projectPath, '--all']);
+
+        final loaded = await GlobalConfig.load(File(globalConfigPath));
+        expect(loaded, isNotNull);
+        expect(loaded!.gitRepos, isEmpty);
       },
     );
   });

--- a/pkgs/skills/test/commands/prune_command_test.dart
+++ b/pkgs/skills/test/commands/prune_command_test.dart
@@ -96,14 +96,16 @@ void main() {
           'cursor',
         ]);
 
-        expect(
-          await Directory('$projectPath/.cursor/skills/pkg_a-skill-1').exists(),
-          isTrue,
-        );
-        expect(
-          await Directory('$projectPath/.cursor/skills/pkg_b-skill-2').exists(),
-          isFalse,
-        );
+        await d
+            .dir('project', [
+              d.dir('.cursor', [
+                d.dir('skills', [
+                  d.dir('pkg_a-skill-1'),
+                  d.nothing('pkg_b-skill-2'),
+                ]),
+              ]),
+            ])
+            .validate(testRootPath);
 
         final loaded = await SkillManifest.loadFromRoot(projectPath);
         expect(loaded, isNotNull);
@@ -177,14 +179,14 @@ void main() {
           'cursor',
         ]);
 
-        expect(
-          await Directory('$projectPath/.cursor/skills/old_pkg-skill').exists(),
-          isFalse,
-        );
-        final dartSkillsDir = Directory(
-          p.join(projectPath, SkillManifest.cacheDirPath),
-        );
-        expect(await dartSkillsDir.exists(), isFalse);
+        await d
+            .dir('project', [
+              d.dir('.cursor', [
+                d.dir('skills', [d.nothing('old_pkg-skill')]),
+              ]),
+              d.nothing(SkillManifest.cacheDirPath),
+            ])
+            .validate(testRootPath);
       },
     );
 
@@ -248,10 +250,13 @@ void main() {
           '--all',
         ]);
 
-        expect(
-          await Directory('$projectPath/.cursor/skills/old_pkg-skill').exists(),
-          isFalse,
-        );
+        await d
+            .dir('project', [
+              d.dir('.cursor', [
+                d.dir('skills', [d.nothing('old_pkg-skill')]),
+              ]),
+            ])
+            .validate(testRootPath);
       },
     );
 
@@ -279,7 +284,9 @@ void main() {
         ..addCommand(pruneCommand);
       await runner.run(['prune', '--directory', projectPath]);
 
-      expect(File(SkillManifest.pathIn(projectPath)).existsSync(), isFalse);
+      await d
+          .dir('no_skills_project', [d.nothing(SkillManifest.configDirPath)])
+          .validate(testRootPath);
     });
 
     test('when --agent is set then only that agent is pruned', () async {
@@ -390,14 +397,16 @@ void main() {
         'cursor',
       ]);
 
-      expect(
-        Directory('$projectPath/.cursor/skills/unref-skill').existsSync(),
-        isFalse,
-      );
-      expect(
-        Directory('$projectPath/.claude/skills/unref-skill').existsSync(),
-        isTrue,
-      );
+      await d
+          .dir('project', [
+            d.dir('.cursor', [
+              d.dir('skills', [d.nothing('unref-skill')]),
+            ]),
+            d.dir('.claude', [
+              d.dir('skills', [d.dir('unref-skill')]),
+            ]),
+          ])
+          .validate(testRootPath);
 
       final loaded = await SkillManifest.loadFromRoot(projectPath);
       expect(loaded, isNotNull);

--- a/pkgs/skills/test/core/skill_installer_test.dart
+++ b/pkgs/skills/test/core/skill_installer_test.dart
@@ -63,7 +63,7 @@ void main() {
     test('when installing skills then migrations are performed', () async {
       final installer = SkillInstaller(null);
 
-      final result = await installer.installSkillsForIde(
+      final result = await installer.installSkillsForAgent(
         agent: Agent.generic,
         rootPath: rootPath,
         skills: scannedSkills,
@@ -141,7 +141,7 @@ void main() {
       final sub = Logger.root.onRecord.listen(logs.add);
       addTearDown(sub.cancel);
 
-      final result = await installer.installSkillsForIde(
+      final result = await installer.installSkillsForAgent(
         agent: Agent.generic,
         rootPath: rootPath,
         skills: scannedSkills,

--- a/pkgs/skills/test/integration/multi_agent_lifecycle_test.dart
+++ b/pkgs/skills/test/integration/multi_agent_lifecycle_test.dart
@@ -104,7 +104,7 @@ Instructions for debugging.
       manifest = const SkillManifest();
 
       final installer = SkillInstaller(fakeDialogSupport);
-      var result = await installer.installSkillsForIde(
+      var result = await installer.installSkillsForAgent(
         agent: Agent.cursor,
         rootPath: rootPath,
         skills: [...pkgASkills, ...pkgBSkills],
@@ -112,7 +112,7 @@ Instructions for debugging.
         globalConfig: const GlobalConfig(),
       );
       manifest = result!.manifest;
-      result = await installer.installSkillsForIde(
+      result = await installer.installSkillsForAgent(
         agent: Agent.generic,
         rootPath: rootPath,
         skills: [...pkgASkills, ...pkgBSkills],
@@ -168,11 +168,12 @@ Instructions for debugging.
 
     test('when removing one agent then the other remains intact', () async {
       // Remove only Cursor.
-      final result = await SkillInstaller(fakeDialogSupport).removeSkillsForIde(
-        agent: Agent.cursor,
-        rootPath: rootPath,
-        manifest: manifest,
-      );
+      final result = await SkillInstaller(fakeDialogSupport)
+          .removeSkillsForAgent(
+            agent: Agent.cursor,
+            rootPath: rootPath,
+            manifest: manifest,
+          );
       manifest = result.manifest;
 
       // Cursor files gone.
@@ -206,7 +207,7 @@ Instructions for debugging.
         final installer = SkillInstaller(fakeDialogSupport);
         for (final agentName in manifest.allAgents.toList()) {
           final agent = Agent.fromCliName(agentName)!;
-          final result = await installer.removeSkillsForIde(
+          final result = await installer.removeSkillsForAgent(
             agent: agent,
             rootPath: rootPath,
             manifest: manifest,
@@ -265,7 +266,7 @@ Instructions for debugging.
       manifest = const SkillManifest();
 
       final installer = SkillInstaller(fakeDialogSupport);
-      var result = await installer.installSkillsForIde(
+      var result = await installer.installSkillsForAgent(
         agent: Agent.cursor,
         rootPath: rootPath,
         skills: pkgASkills,
@@ -273,7 +274,7 @@ Instructions for debugging.
         globalConfig: const GlobalConfig(),
       );
       manifest = result!.manifest;
-      result = await installer.installSkillsForIde(
+      result = await installer.installSkillsForAgent(
         agent: Agent.generic,
         rootPath: rootPath,
         skills: pkgASkills,
@@ -311,13 +312,14 @@ Instructions for debugging.
     test('when some skills are manually deleted then remaining are still '
         'removed correctly', () async {
       // Install a second package too.
-      var result = await SkillInstaller(fakeDialogSupport).installSkillsForIde(
-        agent: Agent.cursor,
-        rootPath: rootPath,
-        skills: [...pkgASkills, ...pkgBSkills],
-        previousManifest: manifest,
-        globalConfig: const GlobalConfig(),
-      );
+      var result = await SkillInstaller(fakeDialogSupport)
+          .installSkillsForAgent(
+            agent: Agent.cursor,
+            rootPath: rootPath,
+            skills: [...pkgASkills, ...pkgBSkills],
+            previousManifest: manifest,
+            globalConfig: const GlobalConfig(),
+          );
       manifest = result!.manifest;
 
       // Manually delete pkg_a skill from cursor.
@@ -353,7 +355,7 @@ Instructions for debugging.
       manifest = const SkillManifest();
 
       final installer = SkillInstaller(fakeDialogSupport);
-      var result = await installer.installSkillsForIde(
+      var result = await installer.installSkillsForAgent(
         agent: Agent.cursor,
         rootPath: rootPath,
         skills: pkgASkills,
@@ -361,7 +363,7 @@ Instructions for debugging.
         globalConfig: const GlobalConfig(),
       );
       manifest = result!.manifest;
-      result = await installer.installSkillsForIde(
+      result = await installer.installSkillsForAgent(
         agent: Agent.generic,
         rootPath: rootPath,
         skills: pkgASkills,
@@ -377,7 +379,7 @@ Instructions for debugging.
         // Reinstall to Cursor only (simulating `skills get --agent cursor`).
         // SkillInstaller removes existing before installing.
         final result = await SkillInstaller(fakeDialogSupport)
-            .installSkillsForIde(
+            .installSkillsForAgent(
               agent: Agent.cursor,
               rootPath: rootPath,
               skills: pkgASkills,
@@ -417,7 +419,7 @@ Instructions for debugging.
       manifest = const SkillManifest();
 
       final installer = SkillInstaller(fakeDialogSupport);
-      var result = await installer.installSkillsForIde(
+      var result = await installer.installSkillsForAgent(
         agent: Agent.cursor,
         rootPath: rootPath,
         skills: [...pkgASkills, ...pkgBSkills],
@@ -425,7 +427,7 @@ Instructions for debugging.
         globalConfig: const GlobalConfig(),
       );
       manifest = result!.manifest;
-      result = await installer.installSkillsForIde(
+      result = await installer.installSkillsForAgent(
         agent: Agent.claude,
         rootPath: rootPath,
         skills: [...pkgASkills, ...pkgBSkills],
@@ -497,7 +499,7 @@ Instructions for debugging.
 
         var manifest = const SkillManifest();
         final result = await SkillInstaller(fakeDialogSupport)
-            .installSkillsForIde(
+            .installSkillsForAgent(
               agent: Agent.generic,
               rootPath: rootPath,
               skills: pkgASkills,


### PR DESCRIPTION
Resolves #562

### Summary of Changes

- **Prune Utility (`lib/src/core/pruner.dart`)**:
  - Extracted package dependency skill pruning and git repository source cleanup into a reusable `pruneSkills` function.
  - Checks both local (`skills_config.json`) and global (`global_config.json`) configurations for git repo sources with 0 installed skills.
  - Presents candidate unreferenced package dependencies and empty local git repo sources to the user in a unified multi-select dialog (`showMultiSelectDialog`).
  - Presents candidate empty global git repo sources in a multi-select dialog.
  - Early-bails if dialog support is unavailable and `--all` flag is false.
  - Supports `--all` (`allFlag: true`) to skip prompts and automatically prune all candidate packages and empty git sources.

- **Commands**:
  - **`skills prune`**: Updated `PruneCommand` to support `-a`/`--all` flag and delegate to `pruneSkills`.
  - **`skills get`**: Invokes `pruneSkills` with `quietIfNothingToPrune: true` at the completion of `getSkills` so unused skills and zero-skill git sources are cleaned up automatically after getting skills.

- **Tests & Docs**:
  - Added unit tests for package and local/global git repo pruning in `test/commands/prune_command_test.dart` using declarative `test_descriptor` `.validate()` assertions.
  - Updated `README.md` to document the new `prune` source cleanup behavior and highlight `--git <repo>` options.
  - Updated `CHANGELOG.md`.
