### PR TITLE
Auto-select suggested skill repos in source-selection dialog (#558)

### DIFF
--- a/pkgs/skills/CHANGELOG.md
+++ b/pkgs/skills/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Don't crawl into `third_party` or hidden directories when scanning Git repositories for skills.
 - Support hyphens instead of underscores in package name prefixes when matching and creating skills.
 - Update wording slightly for selection dialogs.
+- Auto-select newly accepted suggested skill repositories so they are not
+  prompted again in the source-selection dialog.
 
 ## 1.0.0-beta.4
 

--- a/pkgs/skills/lib/src/commands/get_skills.dart
+++ b/pkgs/skills/lib/src/commands/get_skills.dart
@@ -98,9 +98,14 @@ Future<bool> getSkills({
   final globalConfigFile = io.File(globalConfigPath);
   var globalConfig = await GlobalConfig.loadOrEmpty(globalConfigFile);
 
+  late final Set<String> newlyAcceptedRepos;
   {
     var (originalGlobalConfig, originalManifest) = (globalConfig, manifest);
-    (:globalConfig, :manifest) = await _maybePromptToInstallDashSkills(
+    (
+      :globalConfig,
+      :manifest,
+      :newlyAcceptedRepos,
+    ) = await _maybePromptToInstallDashSkills(
       dialogSupport: dialogSupport,
       globalConfig: globalConfig,
       agents: agents,
@@ -200,6 +205,7 @@ Future<bool> getSkills({
       skills: skills,
       dialogSupport: dialogSupport,
       logger: logger,
+      newlyAcceptedRepos: newlyAcceptedRepos,
     );
     if (!continueInstall) {
       return false;
@@ -264,6 +270,7 @@ Future<bool> getSkills({
 typedef DashSkillsPromptResult = ({
   GlobalConfig globalConfig,
   SkillManifest manifest,
+  Set<String> newlyAcceptedRepos,
 });
 
 /// Prompts the user to install dash skill repos if they have not already
@@ -284,7 +291,11 @@ Future<DashSkillsPromptResult> _maybePromptToInstallDashSkills({
       dialogSupport == null ||
       sourceUris.isNotEmpty ||
       skillNames.isNotEmpty) {
-    return (globalConfig: globalConfig, manifest: manifest);
+    return (
+      globalConfig: globalConfig,
+      manifest: manifest,
+      newlyAcceptedRepos: const <String>{},
+    );
   }
 
   const flutterSkillsRepo = 'https://github.com/flutter/agent-plugins.git';
@@ -305,6 +316,7 @@ Future<DashSkillsPromptResult> _maybePromptToInstallDashSkills({
     suggestedRepos.add(flutterSkillsRepo);
   }
 
+  final newlyAcceptedRepos = <String>{};
   if (suggestedRepos.isNotEmpty) {
     final options = [...suggestedRepos, 'Never ask again on this machine'];
     final selectedIndices = await dialogSupport.showMultiSelectDialog(
@@ -346,16 +358,22 @@ Future<DashSkillsPromptResult> _maybePromptToInstallDashSkills({
               );
             }
           }
+          newlyAcceptedRepos.addAll(selectedRepos);
         } else if (result == 1) {
           for (final repo in selectedRepos) {
             globalConfig = globalConfig.withGitRepo(GitRepo(cloneUrl: repo));
           }
+          newlyAcceptedRepos.addAll(selectedRepos);
         }
       }
     }
   }
 
-  return (globalConfig: globalConfig, manifest: manifest);
+  return (
+    globalConfig: globalConfig,
+    manifest: manifest,
+    newlyAcceptedRepos: newlyAcceptedRepos,
+  );
 }
 
 @visibleForTesting
@@ -588,33 +606,30 @@ Future<bool> _promptForSourcesWithDiffs({
   required List<ScannedSkill> skills,
   required DialogSupport dialogSupport,
   required Logger logger,
+  Set<String> newlyAcceptedRepos = const {},
 }) async {
-  final sourcesWithSkills = sourceIdsWithDiff.toList()..sort();
-  if (sourcesWithSkills.isNotEmpty) {
+  final candidateSources =
+      sourceIdsWithDiff.difference(newlyAcceptedRepos).toList()..sort();
+  if (candidateSources.isNotEmpty) {
     final initialSelected = Iterable<int>.generate(
-      sourcesWithSkills.length,
+      candidateSources.length,
     ).toSet();
     final selectedIndices = await dialogSupport.showMultiSelectDialog(
-      sourcesWithSkills,
+      candidateSources,
       title: 'Select which sources to browse skills from:',
       initialSelected: initialSelected,
     );
     if (selectedIndices != null) {
       final selectedSources = selectedIndices
-          .map((i) => sourcesWithSkills[i])
+          .map((i) => candidateSources[i])
           .toSet();
-      skills.removeWhere(
-        (s) =>
-            sourceIdsWithDiff.contains(s.sourceUri) &&
-            !selectedSources.contains(s.sourceUri),
+      final unselectedSources = candidateSources.toSet().difference(
+        selectedSources,
       );
+      skills.removeWhere((s) => unselectedSources.contains(s.sourceUri));
 
       for (final list in skillsBySource.values) {
-        list.removeWhere(
-          (s) =>
-              sourceIdsWithDiff.contains(s.sourceUri) &&
-              !selectedSources.contains(s.sourceUri),
-        );
+        list.removeWhere((s) => unselectedSources.contains(s.sourceUri));
       }
       skillsBySource.removeWhere((k, v) => v.isEmpty);
       sortedSourceIds.removeWhere((id) => !skillsBySource.containsKey(id));

--- a/pkgs/skills/test/commands/get_command_suggested_skills_test.dart
+++ b/pkgs/skills/test/commands/get_command_suggested_skills_test.dart
@@ -207,9 +207,39 @@ void main() {
     test(
       'newly accepted suggested repos are not prompted in source selection',
       () async {
-        fakeDialogSupport.multiSelectResults.add({
-          0,
-        }); // Select dart-lang/skills
+        final flutterSkillDir = Directory(
+          p.join(d.path('flutter'), 'skills', 'flutter-skill'),
+        );
+        await flutterSkillDir.create(recursive: true);
+        await File(
+          p.join(flutterSkillDir.path, 'SKILL.md'),
+        ).writeAsString('---\nname: flutter-skill\n---\n');
+
+        const gitRepo = GitRepo(
+          cloneUrl: 'https://github.com/dart-lang/skills.git',
+        );
+        final gitSkillDir = Directory(
+          p.join(
+            projectPath,
+            '.dart_tool',
+            'skills',
+            'repos',
+            gitRepo.pathSegment,
+            'skills',
+            'official-dart-skill',
+          ),
+        );
+        await gitSkillDir.create(recursive: true);
+        await File(
+          p.join(gitSkillDir.path, 'SKILL.md'),
+        ).writeAsString('---\nname: official-dart-skill\n---\n');
+
+        fakeDialogSupport.multiSelectResults.addAll([
+          {0}, // Select dart-lang/skills from suggested repos dialog
+          {0}, // Select package:flutter from source selection dialog
+          {0}, // Select flutter-skill from package:flutter
+          {0}, // Select official-dart-skill from dart-lang/skills
+        ]);
         fakeDialogSupport.singleSelectResults.add(0); // Select Local
 
         await runner.run([
@@ -220,9 +250,25 @@ void main() {
           'cursor',
         ]);
 
+        final sourcesDialogIndex = fakeDialogSupport.allTitles.indexOf(
+          'Select which sources to browse skills from:',
+        );
         expect(
-          fakeDialogSupport.allTitles,
-          isNot(contains('Select which sources to browse skills from:')),
+          sourcesDialogIndex,
+          isNot(-1),
+          reason:
+              'source-selection prompt should be displayed for package:flutter',
+        );
+        expect(
+          fakeDialogSupport.allMultiSelectOptions[sourcesDialogIndex],
+          contains('package:flutter'),
+        );
+        expect(
+          fakeDialogSupport.allMultiSelectOptions[sourcesDialogIndex],
+          isNot(contains('https://github.com/dart-lang/skills.git')),
+          reason:
+              'newly accepted suggested repo should be auto-selected and not '
+              'in source-selection prompt',
         );
       },
     );

--- a/pkgs/skills/test/commands/get_command_suggested_skills_test.dart
+++ b/pkgs/skills/test/commands/get_command_suggested_skills_test.dart
@@ -207,32 +207,42 @@ void main() {
     test(
       'newly accepted suggested repos are not prompted in source selection',
       () async {
-        final flutterSkillDir = Directory(
-          p.join(d.path('flutter'), 'skills', 'flutter-skill'),
-        );
-        await flutterSkillDir.create(recursive: true);
-        await File(
-          p.join(flutterSkillDir.path, 'SKILL.md'),
-        ).writeAsString('---\nname: flutter-skill\n---\n');
+        // Create a skill in package flutter so there is an existing package
+        // skill source. This ensures `skillsBySource` is non-empty so the
+        // `get` command reaches the source-selection prompt logic rather than
+        // returning early when no skills are found.
+        await d.dir('flutter', [
+          pubspec('flutter'),
+          d.dir('skills', [
+            d.dir('flutter-skill', [
+              d.file('SKILL.md', '---\nname: flutter-skill\n---\n'),
+            ]),
+          ]),
+        ]).create();
 
+        // Create pre-scanned skill in git repos cache for dart-lang/skills so
+        // that both sources have skills with differences to select from.
         const gitRepo = GitRepo(
           cloneUrl: 'https://github.com/dart-lang/skills.git',
         );
-        final gitSkillDir = Directory(
-          p.join(
-            projectPath,
-            '.dart_tool',
-            'skills',
-            'repos',
-            gitRepo.pathSegment,
-            'skills',
-            'official-dart-skill',
-          ),
-        );
-        await gitSkillDir.create(recursive: true);
-        await File(
-          p.join(gitSkillDir.path, 'SKILL.md'),
-        ).writeAsString('---\nname: official-dart-skill\n---\n');
+        await d.dir('project', [
+          d.dir('.dart_tool', [
+            d.dir('skills', [
+              d.dir('repos', [
+                d.dir(gitRepo.pathSegment, [
+                  d.dir('skills', [
+                    d.dir('official-dart-skill', [
+                      d.file(
+                        'SKILL.md',
+                        '---\nname: official-dart-skill\n---\n',
+                      ),
+                    ]),
+                  ]),
+                ]),
+              ]),
+            ]),
+          ]),
+        ]).create();
 
         fakeDialogSupport.multiSelectResults.addAll([
           {0}, // Select dart-lang/skills from suggested repos dialog

--- a/pkgs/skills/test/commands/get_command_suggested_skills_test.dart
+++ b/pkgs/skills/test/commands/get_command_suggested_skills_test.dart
@@ -203,5 +203,28 @@ void main() {
 
       expect(fakeDialogSupport.allTitles, isEmpty);
     });
+
+    test(
+      'newly accepted suggested repos are not prompted in source selection',
+      () async {
+        fakeDialogSupport.multiSelectResults.add({
+          0,
+        }); // Select dart-lang/skills
+        fakeDialogSupport.singleSelectResults.add(0); // Select Local
+
+        await runner.run([
+          'get',
+          '--directory',
+          projectPath,
+          '--ide',
+          'cursor',
+        ]);
+
+        expect(
+          fakeDialogSupport.allTitles,
+          isNot(contains('Select which sources to browse skills from:')),
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
When installing suggested skill repos in `skills get`, exclude them from the subsequent source-selection prompt since the user already accepted them.

Fixes #558