### PR TITLE
add CacheableResult from protocol 2026-07-28

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -51,8 +51,10 @@
   https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549.
   `ttlMs` returns an `int`, reading `0` (immediately stale) for an absent or
   negative value, as the spec instructs clients; `cacheScope` returns a
-  `CacheScope?` which is `null` when the field is absent, since the spec
-  defines no default for it. `ListToolsResult`, `ListPromptsResult`,
+  `CacheScope?` which is `null` when the field is absent, rather than the
+  "public" default the schema comment mentions, because the same SEP calls the
+  field required "because there is no safe default for older servers" and
+  leaves a default to each SDK. `ListToolsResult`, `ListPromptsResult`,
   `ListResourcesResult`, `ListResourceTemplatesResult`, and
   `ReadResourceResult` now implement `CacheableResult`, so the hints are
   readable on responses from servers that send them.

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -45,6 +45,17 @@
   The getter returns a `String`, defaulting to `complete` when the field is
   absent, as the schema requires for backward compatibility with servers on
   earlier protocol versions.
+- Add `CacheableResult` and the `CacheScope` enum, modeling the `ttlMs` and
+  `cacheScope` caching hints which the 2026-07-28 draft schema attaches to
+  several result types, see
+  https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549.
+  `ttlMs` returns an `int`, reading `0` (immediately stale) for an absent or
+  negative value, as the spec instructs clients; `cacheScope` returns a
+  `CacheScope?` which is `null` when the field is absent, since the spec
+  defines no default for it. `ListToolsResult`, `ListPromptsResult`,
+  `ListResourcesResult`, `ListResourceTemplatesResult`, and
+  `ReadResourceResult` now implement `CacheableResult`, so the hints are
+  readable on responses from servers that send them.
 
 ## 0.5.2
 

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -343,9 +343,11 @@ extension type CacheableResult._fromMap(Map<String, Object?> _value)
   /// Servers on protocol versions before 2026-07-28 omit the field, and the
   /// spec defines no default for it, so an absent or unrecognized value is
   /// reported here as `null`.
-  CacheScope? get cacheScope => CacheScope.values.firstWhereOrNull(
-    (scope) => scope.name == (_value[Keys.cacheScope] as String?),
-  );
+  CacheScope? get cacheScope {
+    final name = _value[Keys.cacheScope] as String?;
+    if (name == null) return null;
+    return CacheScope.values.firstWhereOrNull((scope) => scope.name == name);
+  }
 }
 
 /// The intended scope of a cached [CacheableResult] response.

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -340,9 +340,15 @@ extension type CacheableResult._fromMap(Map<String, Object?> _value)
   /// The intended scope of the cached response, analogous to HTTP
   /// `Cache-Control: public` vs `Cache-Control: private`.
   ///
-  /// Servers on protocol versions before 2026-07-28 omit the field, and the
-  /// spec defines no default for it, so an absent or unrecognized value is
-  /// reported here as `null`.
+  /// An absent or unrecognized value is reported here as `null` rather than
+  /// as a default. The schema comment says the field defaults to "public",
+  /// but the same SEP argues the field is required precisely "because there
+  /// is no safe default for older servers", and leaves a default to the
+  /// discretion of each SDK. Reporting `null` follows the second reading:
+  /// synthesizing "public" for a server that never declared a scope is the
+  /// one guess that can leak a private response into a shared cache. Servers
+  /// on protocol versions before 2026-07-28 omit the field, and their results
+  /// also carry no `ttlMs`, so they are already immediately stale.
   CacheScope? get cacheScope {
     final name = _value[Keys.cacheScope] as String?;
     if (name == null) return null;

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -315,6 +315,50 @@ extension type PaginatedResult._fromMap(Map<String, Object?> _value)
   Cursor? get nextCursor => _value[Keys.nextCursor] as Cursor?;
 }
 
+/// A "mixin"-like extension type for any result type that contains caching
+/// hints at the keys "ttlMs" and "cacheScope".
+///
+/// Should be "mixed in" by implementing this type from other extension types.
+///
+/// This type is not intended to be constructed directly and thus has no public
+/// constructor.
+extension type CacheableResult._fromMap(Map<String, Object?> _value)
+    implements Result {
+  /// A hint for how long, in milliseconds, the client may cache this response
+  /// before re-fetching, analogous to HTTP `Cache-Control` max-age.
+  ///
+  /// A value of 0 marks the response as immediately stale.
+  ///
+  /// Servers on protocol versions before 2026-07-28 omit the field; the spec
+  /// says clients should assume 0 in that case, and should treat a negative
+  /// value from a non-conforming server as 0, so both are reported here as 0.
+  int get ttlMs {
+    final value = _value[Keys.ttlMs] as int? ?? 0;
+    return value < 0 ? 0 : value;
+  }
+
+  /// The intended scope of the cached response, analogous to HTTP
+  /// `Cache-Control: public` vs `Cache-Control: private`.
+  ///
+  /// Servers on protocol versions before 2026-07-28 omit the field, and the
+  /// spec defines no default for it, so an absent or unrecognized value is
+  /// reported here as `null`.
+  CacheScope? get cacheScope => CacheScope.values.firstWhereOrNull(
+    (scope) => scope.name == (_value[Keys.cacheScope] as String?),
+  );
+}
+
+/// The intended scope of a cached [CacheableResult] response.
+enum CacheScope {
+  /// The response contains no user-specific data; any client or intermediary
+  /// may cache it and serve it across authorization contexts.
+  public,
+
+  /// The response may be cached and reused only within the same authorization
+  /// context; caches must not be shared across authorization contexts.
+  private,
+}
+
 /// Could be either [TextContent], [ImageContent], [AudioContent] or
 /// [EmbeddedResource].
 ///

--- a/pkgs/dart_mcp/lib/src/api/prompts.dart
+++ b/pkgs/dart_mcp/lib/src/api/prompts.dart
@@ -19,7 +19,7 @@ extension type ListPromptsRequest.fromMap(Map<String, Object?> _value)
 
 /// The server's response to a prompts/list request from the client.
 extension type ListPromptsResult.fromMap(Map<String, Object?> _value)
-    implements PaginatedResult {
+    implements PaginatedResult, CacheableResult {
   factory ListPromptsResult({
     required List<Prompt> prompts,
     Cursor? nextCursor,

--- a/pkgs/dart_mcp/lib/src/api/resources.dart
+++ b/pkgs/dart_mcp/lib/src/api/resources.dart
@@ -18,7 +18,7 @@ extension type ListResourcesRequest.fromMap(Map<String, Object?> _value)
 
 /// The server's response to a resources/list request from the client.
 extension type ListResourcesResult.fromMap(Map<String, Object?> _value)
-    implements PaginatedResult {
+    implements PaginatedResult, CacheableResult {
   factory ListResourcesResult({
     required List<Resource> resources,
     Cursor? nextCursor,
@@ -50,7 +50,7 @@ extension type ListResourceTemplatesRequest.fromMap(Map<String, Object?> _value)
 
 /// The server's response to a resources/templates/list request from the client.
 extension type ListResourceTemplatesResult.fromMap(Map<String, Object?> _value)
-    implements PaginatedResult {
+    implements PaginatedResult, CacheableResult {
   factory ListResourceTemplatesResult({
     required List<ResourceTemplate> resourceTemplates,
     Cursor? nextCursor,
@@ -91,7 +91,7 @@ extension type ReadResourceRequest.fromMap(Map<String, Object?> _value)
 
 /// The server's response to a resources/read request from the client.
 extension type ReadResourceResult.fromMap(Map<String, Object?> _value)
-    implements Result {
+    implements CacheableResult {
   factory ReadResourceResult({
     required List<ResourceContents> contents,
     Meta? meta,

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -18,7 +18,7 @@ extension type ListToolsRequest.fromMap(Map<String, Object?> _value)
 
 /// The server's response to a tools/list request from the client.
 extension type ListToolsResult.fromMap(Map<String, Object?> _value)
-    implements PaginatedResult {
+    implements PaginatedResult, CacheableResult {
   factory ListToolsResult({
     required List<Tool> tools,
     Cursor? nextCursor,

--- a/pkgs/dart_mcp/lib/src/utils/constants.dart
+++ b/pkgs/dart_mcp/lib/src/utils/constants.dart
@@ -14,6 +14,7 @@ extension Keys on Never {
   static const arguments = 'arguments';
   static const audience = 'audience';
   static const blob = 'blob';
+  static const cacheScope = 'cacheScope';
   static const cancel = 'cancel';
   static const capabilities = 'capabilities';
   static const clientInfo = 'clientInfo';
@@ -128,6 +129,7 @@ extension Keys on Never {
   static const toolChoice = 'toolChoice';
   static const tools = 'tools';
   static const total = 'total';
+  static const ttlMs = 'ttlMs';
   static const type = 'type';
   static const unevaluatedItems = 'unevaluatedItems';
   static const unevaluatedProperties = 'unevaluatedProperties';

--- a/pkgs/dart_mcp/test/api/api_test.dart
+++ b/pkgs/dart_mcp/test/api/api_test.dart
@@ -136,5 +136,36 @@ void main() {
         'streaming',
       );
     });
+    test('cacheable result fields default when absent and parse known '
+        'values', () {
+      final empty = <String, Object?>{} as CacheableResult;
+      expect(empty.ttlMs, 0);
+      expect(empty.cacheScope, null);
+      expect((<String, Object?>{'ttlMs': -5} as CacheableResult).ttlMs, 0);
+      final cacheable =
+          <String, Object?>{'ttlMs': 5000, 'cacheScope': 'private'}
+              as CacheableResult;
+      expect(cacheable.ttlMs, 5000);
+      expect(cacheable.cacheScope, CacheScope.private);
+      expect(
+        (<String, Object?>{'cacheScope': 'public'} as CacheableResult)
+            .cacheScope,
+        CacheScope.public,
+      );
+      expect(
+        (<String, Object?>{'cacheScope': 'session'} as CacheableResult)
+            .cacheScope,
+        null,
+      );
+      final listTools =
+          <String, Object?>{
+                'tools': <Object?>[],
+                'ttlMs': 5000,
+                'cacheScope': 'public',
+              }
+              as ListToolsResult;
+      expect(listTools.ttlMs, 5000);
+      expect(listTools.cacheScope, CacheScope.public);
+    });
   });
 }


### PR DESCRIPTION
Next 2026-07-28 core-protocol slice tracked in #162, following #565 and kept separate from the HTTP transport work.

Adds the `CacheableResult` "mixin" extension type and the `CacheScope` enum, modeling the caching hints from https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549:

- `CacheableResult.ttlMs` reads the TTL hint as an `int`. The spec requires servers to send `ttlMs >= 0` and tells clients to treat both an absent value and a negative one as `0` (https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/docs/specification/draft/server/utilities/caching.mdx; servers on earlier protocol versions never send the field), so the getter reads `0` for both. Same fold `Result.resultType` does with `complete`.
- `CacheableResult.cacheScope` reads the scope as a nullable `CacheScope`. The schema types the field as a closed `"public" | "private"` union with no absent-value default, so the getter is an enum like the package's other closed unions (`Role`, `LoggingLevel`) but resolves the way `Schema.type` does: an absent or unrecognized value reads as `null` instead of throwing, which keeps results from older servers readable and leaves room for the still-draft schema to grow the union before the RC.
- The type mirrors `PaginatedResult`: no public constructor, "mixed in" by other extension types. The schema attaches it to the four list results, `ReadResourceResult`, and the new `DiscoverResult`; the five that already exist in this package now implement it, so the hints are readable on the results the client API already returns. `DiscoverResult` itself and server-side emission of the hints (factory parameters) are follow-up slices.

## Tests

- `ttlMs` reads `0` on an empty result and for a negative value, `cacheScope` reads `null` when absent, both parse when present, an unrecognized scope string reads as `null`, and a `ListToolsResult` carrying the fields exposes both.
- `dart test -p chrome,vm -c dart2wasm,dart2js,kernel,exe` passes (220 tests in each of the four configurations).
- `dart analyze --fatal-infos` is clean here and in `mcp_examples` resolved against this branch.

Part of #162.
