### PR TITLE
add the error code constants from protocol 2026-07-28

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -58,6 +58,13 @@
   `ListResourcesResult`, `ListResourceTemplatesResult`, and
   `ReadResourceResult` now implement `CacheableResult`, so the hints are
   readable on responses from servers that send them.
+- Add the `headerMismatch` (`-32020`), `missingRequiredClientCapability`
+  (`-32021`), and `unsupportedProtocolVersion` (`-32022`) error-code
+  constants, renumbered from the RC by the finalized 2026-07-28 revision,
+  which reserves `-32020` to `-32099` for the specification, see
+  https://modelcontextprotocol.io/specification/2026-07-28/basic#error-codes.
+  The same registry reserves `-32042`, so `urlElicitationRequired` now
+  documents that only the 2025-11-25 revision emits it.
 
 ## 0.5.2
 

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -58,13 +58,15 @@
   `ListResourcesResult`, `ListResourceTemplatesResult`, and
   `ReadResourceResult` now implement `CacheableResult`, so the hints are
   readable on responses from servers that send them.
-- Add the `headerMismatch` (`-32020`), `missingRequiredClientCapability`
-  (`-32021`), and `unsupportedProtocolVersion` (`-32022`) error-code
-  constants, renumbered from the RC by the finalized 2026-07-28 revision,
-  which reserves `-32020` to `-32099` for the specification, see
+- Add `McpErrorCodes.headerMismatch` (`-32020`),
+  `.missingRequiredClientCapability` (`-32021`), and
+  `.unsupportedProtocolVersion` (`-32022`), the error codes the 2026-07-28
+  revision allocates from the `-32020` to `-32099` range it reserves for the
+  specification, see
   https://modelcontextprotocol.io/specification/2026-07-28/basic#error-codes.
-  The same registry reserves `-32042`, so `urlElicitationRequired` now
-  documents that only the 2025-11-25 revision emits it.
+  Nothing emits them yet; the Streamable HTTP handler lands separately. The
+  same registry reserves `-32042`, so `urlElicitationRequired` now documents
+  that only the 2025-11-25 revision emits it.
 
 ## 0.5.2
 

--- a/pkgs/dart_mcp/lib/src/api/error_codes.dart
+++ b/pkgs/dart_mcp/lib/src/api/error_codes.dart
@@ -6,5 +6,22 @@ part of 'api.dart';
 
 extension McpErrorCodes on Never {
   /// Error code for when a URL elicitation is required.
+  ///
+  /// Defined by the 2025-11-25 revision only; the 2026-07-28 revision
+  /// reserves this code, and implementations of it must not emit it.
   static const int urlElicitationRequired = -32042;
+
+  /// Error code for a Streamable HTTP request whose required headers are
+  /// missing, malformed, or do not match the request body.
+  ///
+  /// From the 2026-07-28 revision, which reserves `-32020` to `-32099` for
+  /// the specification.
+  static const int headerMismatch = -32020;
+
+  /// Error code for a request missing a required client capability.
+  static const int missingRequiredClientCapability = -32021;
+
+  /// Error code for a request on a protocol version the server does not
+  /// support.
+  static const int unsupportedProtocolVersion = -32022;
 }

--- a/pkgs/dart_mcp/lib/src/api/error_codes.dart
+++ b/pkgs/dart_mcp/lib/src/api/error_codes.dart
@@ -19,9 +19,13 @@ extension McpErrorCodes on Never {
   static const int headerMismatch = -32020;
 
   /// Error code for a request missing a required client capability.
+  ///
+  /// From the 2026-07-28 revision.
   static const int missingRequiredClientCapability = -32021;
 
   /// Error code for a request on a protocol version the server does not
   /// support.
+  ///
+  /// From the 2026-07-28 revision.
   static const int unsupportedProtocolVersion = -32022;
 }


### PR DESCRIPTION
Next 2026-07-28 slice tracked in #162, split out ahead of the HTTP transport work as laid out in the [finalized-spec diff report](https://github.com/dart-lang/ai/issues/162#issuecomment-5108248966).

Adds the three error-code constants the finalized revision renumbered into the range it reserves for the specification, see the new [error-code registry](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/docs/specification/2026-07-28/basic/index.mdx):

- `headerMismatch` (`-32020`), for a Streamable HTTP request whose required headers are missing or do not match the body. The RC carried this as `-32001` in transport prose only; the final schema types it as `HeaderMismatchError`.
- `missingRequiredClientCapability` (`-32021`) and `unsupportedProtocolVersion` (`-32022`), renumbered from the RC's `-32003`/`-32004` into the reserved `-32020..-32099` range.
- `urlElicitationRequired`'s doc now records that the registry reserves `-32042` and only the 2025-11-25 revision emits it.

Nothing emits these yet; the POST handler slice picks them up next.

## Tests

- Constants only, no behavior change; `dart test -p chrome,vm -c dart2wasm,dart2js,kernel,exe` passes (220 tests in each of the four configurations).
