### PR TITLE
add the streamable HTTP POST handler from protocol 2026-07-28

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -79,8 +79,9 @@
   Each POST carries one JSON-RPC request or notification which is validated
   against the required headers and `_meta` envelope, then dispatched to a
   fresh server instance via `handleRequestScopedMessage`. Responses are JSON
-  only. Does not add SSE response streams, the legacy session routes, or an
-  HTTP client; those land as separate changes.
+  only. See `example/streamable_http_server.dart`. Does not add SSE response
+  streams, the legacy session routes, or an HTTP client; those land as
+  separate changes.
 
 ## 0.5.2
 

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -64,9 +64,10 @@
   revision allocates from the `-32020` to `-32099` range it reserves for the
   specification, see
   https://modelcontextprotocol.io/specification/2026-07-28/basic#error-codes.
-  Nothing emits them yet; the Streamable HTTP handler lands separately. The
-  same registry reserves `-32042`, so `urlElicitationRequired` now documents
-  that only the 2025-11-25 revision emits it.
+  The Streamable HTTP handler below now emits `McpErrorCodes.headerMismatch`
+  and `.unsupportedProtocolVersion`. The same registry reserves `-32042`, so
+  `urlElicitationRequired` now documents that only the 2025-11-25 revision
+  emits it.
 - Add `ProtocolVersion.v2026_07_28`. `ProtocolVersion.latestSupported` still
   points at 2025-11-25, the newest version the legacy `initialize` handshake
   negotiates; transports for the request-scoped protocol carry their own set

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -34,7 +34,7 @@
   decoded JSON-RPC message on a fresh server instance for request-scoped
   transports. Successful results record the server implementation under the
   reserved `io.modelcontextprotocol/serverInfo` result metadata key. Does
-  **not** add any transport; wire formats and HTTP support land separately.
+  **not** add any transport.
 - `RootsTrackingSupport` no longer surfaces an unhandled error when the
   connection closes while a `listRoots` request is in flight.
 - The URL elicitation retry rethrows the original error when its data is not

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -67,6 +67,19 @@
   Nothing emits them yet; the Streamable HTTP handler lands separately. The
   same registry reserves `-32042`, so `urlElicitationRequired` now documents
   that only the 2025-11-25 revision emits it.
+- Add `ProtocolVersion.v2026_07_28`. `ProtocolVersion.latestSupported` still
+  points at 2025-11-25, the newest version the legacy `initialize` handshake
+  negotiates; transports for the request-scoped protocol carry their own set
+  of supported versions.
+- Add `package:dart_mcp/streamable_http.dart` with
+  `handleStreamableHttpRequest`, the server side of the Streamable HTTP
+  transport from the 2026-07-28 revision, see
+  https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http.
+  Each POST carries one JSON-RPC request or notification which is validated
+  against the required headers and `_meta` envelope, then dispatched to a
+  fresh server instance via `handleRequestScopedMessage`. Responses are JSON
+  only. Does not add SSE response streams, the legacy session routes, or an
+  HTTP client; those land as separate changes.
 
 ## 0.5.2
 

--- a/pkgs/dart_mcp/README.md
+++ b/pkgs/dart_mcp/README.md
@@ -127,7 +127,7 @@ can be used, but some are directly supported out of the box.
 | Transport | Support | Notes |
 | --- | --- | --- |
 | [Stdio](https://modelcontextprotocol.io/specification/2025-11-05/basic/transports#stdio) | :heavy_check_mark: |  |
-| [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-11-05/basic/transports#streamable-http) | :x: | Unsupported at this time, may come in the future. |
+| [Streamable HTTP](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http) | :construction: | Server side only, as `handleStreamableHttpRequest` in `package:dart_mcp/streamable_http.dart`. Answers with JSON bodies; SSE response streams and the client side are not implemented yet. |
 
 ## Batching Requests
 

--- a/pkgs/dart_mcp/example/README.md
+++ b/pkgs/dart_mcp/example/README.md
@@ -12,7 +12,9 @@ tools, connected to the example server that provides tools
 
 `streamable_http_server.dart` has no client pair, since this package does not
 have an HTTP client yet. Run it directly and it prints a `curl` command which
-calls its tool.
+calls its tool. The package does not implement `server/discover` either, which
+the 2026-07-28 revision requires of servers; a client that calls it gets
+`-32601` back, though it can skip the call and use the server anyway.
 
 # Full Featured Examples
 

--- a/pkgs/dart_mcp/example/README.md
+++ b/pkgs/dart_mcp/example/README.md
@@ -10,6 +10,10 @@ To run the examples, run the client file directly, so for instance
 tools, connected to the example server that provides tools
 (at `example/tools_server.dart`).
 
+`streamable_http_server.dart` has no client pair, since this package does not
+have an HTTP client yet. Run it directly and it prints a `curl` command which
+calls its tool.
+
 # Full Featured Examples
 
 See https://github.com/dart-lang/ai/tree/main/mcp_examples for some more full

--- a/pkgs/dart_mcp/example/streamable_http_server.dart
+++ b/pkgs/dart_mcp/example/streamable_http_server.dart
@@ -7,16 +7,25 @@
 ///
 /// Run it with `dart run example/streamable_http_server.dart`. It prints a
 /// `curl` command for the tool it registers; the transport has no client in
-/// this package yet, so that is how to drive it.
+/// this package yet, so that is how to drive it. The command is answered
+/// with 200 and a JSON body containing `Hello, world!`.
 library;
 
-import 'dart:io';
+import 'dart:io' as io;
 
 import 'package:dart_mcp/server.dart';
 import 'package:dart_mcp/streamable_http.dart';
 
 void main() async {
-  final httpServer = await HttpServer.bind(InternetAddress.loopbackIPv4, 8080);
+  // Loopback is not protection on its own, since DNS rebinding reaches it
+  // from a remote page. The specification requires a server to validate
+  // `Origin` on every connection and answer with 403 when it is present
+  // and invalid. The handler leaves that check and authentication to whoever
+  // owns the `HttpServer`.
+  final httpServer = await io.HttpServer.bind(
+    io.InternetAddress.loopbackIPv4,
+    8080,
+  );
 
   // Every POST gets its own server: this protocol revision carries the client
   // context on the request instead of an `initialize` handshake, so there is
@@ -26,14 +35,18 @@ void main() async {
       request,
       MCPServerWithGreeting.new,
       // A JSON response body cannot carry notifications, so anything the
-      // server logs while handling the request is dropped without this.
+      // server logs while handling the request is dropped without this. The
+      // `greet` tool below never sends one.
       onNotification:
-          (notification) => stderr.writeln('notification: $notification'),
+          (notification) => io.stderr.writeln('notification: $notification'),
     ),
   );
 
   final endpoint = 'http://${httpServer.address.host}:${httpServer.port}/mcp';
   print('Listening on $endpoint\n');
+  // `Mcp-Method` and `Mcp-Name` mirror the body so that intermediaries can
+  // route and inspect the request without parsing it; `Mcp-Name` is only
+  // required for the methods that name a target, such as `tools/call`.
   print('''
 curl -sS $endpoint \\
   -H 'Content-Type: application/json' \\
@@ -50,6 +63,7 @@ curl -sS $endpoint \\
       "arguments": {"name": "world"},
       "_meta": {
         "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientInfo": {"name": "curl", "version": "0"},
         "io.modelcontextprotocol/clientCapabilities": {}
       }
     }
@@ -69,6 +83,7 @@ base class MCPServerWithGreeting extends MCPServer with ToolsSupport {
     registerTool(greetTool, _greet);
   }
 
+  /// A tool that says hello to the name it is given.
   final greetTool = Tool(
     name: 'greet',
     description: 'greets whoever it is given',
@@ -78,6 +93,7 @@ base class MCPServerWithGreeting extends MCPServer with ToolsSupport {
     ),
   );
 
+  /// The implementation of the `greet` tool.
   CallToolResult _greet(CallToolRequest request) => CallToolResult(
     content: [TextContent(text: 'Hello, ${request.arguments!['name']}!')],
   );

--- a/pkgs/dart_mcp/example/streamable_http_server.dart
+++ b/pkgs/dart_mcp/example/streamable_http_server.dart
@@ -49,6 +49,10 @@ void main() async {
       return;
     }
 
+    // The handler leaves two more jobs to the host, and this example does
+    // neither: authenticating the caller, and bounding the size of the body it
+    // reads. A server reachable from anywhere but this machine needs both.
+
     // Every POST gets its own server: this protocol revision carries the client
     // context on the request instead of an `initialize` handshake, so there is
     // no connection to keep around between requests.
@@ -57,8 +61,9 @@ void main() async {
         request,
         MCPServerWithGreeting.new,
         // A JSON response body cannot carry notifications, so anything the
-        // server logs while handling the request is dropped without this. The
-        // `greet` tool below never sends one.
+        // server sends while handling the request is dropped without this.
+        // `greet` sends one when the request carries a progress token, which
+        // the command below does.
         onNotification:
             (notification) => io.stderr.writeln('notification: $notification'),
       );
@@ -89,7 +94,8 @@ curl -sS $endpoint \\
       "_meta": {
         "io.modelcontextprotocol/protocolVersion": "2026-07-28",
         "io.modelcontextprotocol/clientInfo": {"name": "curl", "version": "0"},
-        "io.modelcontextprotocol/clientCapabilities": {}
+        "io.modelcontextprotocol/clientCapabilities": {},
+        "progressToken": 1
       }
     }
   }'
@@ -119,7 +125,21 @@ base class MCPServerWithGreeting extends MCPServer with ToolsSupport {
   );
 
   /// The implementation of the `greet` tool.
-  CallToolResult _greet(CallToolRequest request) => CallToolResult(
-    content: [TextContent(text: 'Hello, ${request.arguments!['name']}!')],
-  );
+  CallToolResult _greet(CallToolRequest request) {
+    // The JSON body carries the result and nothing else, so this notification
+    // reaches the host through `onNotification` or not at all.
+    if (request.meta?.progressToken case final progressToken?) {
+      notifyProgress(
+        ProgressNotification(
+          progressToken: progressToken,
+          progress: 1,
+          total: 1,
+          message: 'Greeting ${request.arguments!['name']}',
+        ),
+      );
+    }
+    return CallToolResult(
+      content: [TextContent(text: 'Hello, ${request.arguments!['name']}!')],
+    );
+  }
 }

--- a/pkgs/dart_mcp/example/streamable_http_server.dart
+++ b/pkgs/dart_mcp/example/streamable_http_server.dart
@@ -17,32 +17,57 @@ import 'package:dart_mcp/server.dart';
 import 'package:dart_mcp/streamable_http.dart';
 
 void main() async {
-  // Loopback is not protection on its own, since DNS rebinding reaches it
-  // from a remote page. The specification requires a server to validate
-  // `Origin` on every connection and answer with 403 when it is present
-  // and invalid. The handler leaves that check and authentication to whoever
-  // owns the `HttpServer`.
+  // The one path this server answers on.
+  const path = '/mcp';
   final httpServer = await io.HttpServer.bind(
     io.InternetAddress.loopbackIPv4,
-    8080,
+    0,
   );
+  final endpoint = 'http://${httpServer.address.host}:${httpServer.port}$path';
 
-  // Every POST gets its own server: this protocol revision carries the client
-  // context on the request instead of an `initialize` handshake, so there is
-  // no connection to keep around between requests.
-  httpServer.listen(
-    (request) => handleStreamableHttpRequest(
-      request,
-      MCPServerWithGreeting.new,
-      // A JSON response body cannot carry notifications, so anything the
-      // server logs while handling the request is dropped without this. The
-      // `greet` tool below never sends one.
-      onNotification:
-          (notification) => io.stderr.writeln('notification: $notification'),
-    ),
-  );
+  httpServer.listen((request) async {
+    // The handler reads no path, so the one this server answers on is the
+    // host's to choose and to enforce.
+    if (request.uri.path != path) {
+      request.response
+        ..statusCode = io.HttpStatus.notFound
+        ..contentLength = 0;
+      await request.response.close();
+      return;
+    }
 
-  final endpoint = 'http://${httpServer.address.host}:${httpServer.port}/mcp';
+    // Loopback is not protection on its own, since DNS rebinding reaches it
+    // from a remote page. The specification requires a server to answer 403
+    // when `Origin` is present and invalid; nothing here is meant to be driven
+    // from a page, so no origin is valid. Read the header as a list: `value`
+    // throws when a request repeats it, and a caller chooses that.
+    if (request.headers['origin'] != null) {
+      request.response
+        ..statusCode = io.HttpStatus.forbidden
+        ..contentLength = 0;
+      await request.response.close();
+      return;
+    }
+
+    // Every POST gets its own server: this protocol revision carries the client
+    // context on the request instead of an `initialize` handshake, so there is
+    // no connection to keep around between requests.
+    try {
+      await handleStreamableHttpRequest(
+        request,
+        MCPServerWithGreeting.new,
+        // A JSON response body cannot carry notifications, so anything the
+        // server logs while handling the request is dropped without this. The
+        // `greet` tool below never sends one.
+        onNotification:
+            (notification) => io.stderr.writeln('notification: $notification'),
+      );
+    } catch (error) {
+      // The request already has its 500; this is the copy the host keeps.
+      io.stderr.writeln('request failed: $error');
+    }
+  });
+
   print('Listening on $endpoint\n');
   // `Mcp-Method` and `Mcp-Name` mirror the body so that intermediaries can
   // route and inspect the request without parsing it; `Mcp-Name` is only

--- a/pkgs/dart_mcp/example/streamable_http_server.dart
+++ b/pkgs/dart_mcp/example/streamable_http_server.dart
@@ -1,0 +1,84 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// A server reachable over the Streamable HTTP transport from the 2026-07-28
+/// revision of the protocol.
+///
+/// Run it with `dart run example/streamable_http_server.dart`. It prints a
+/// `curl` command for the tool it registers; the transport has no client in
+/// this package yet, so that is how to drive it.
+library;
+
+import 'dart:io';
+
+import 'package:dart_mcp/server.dart';
+import 'package:dart_mcp/streamable_http.dart';
+
+void main() async {
+  final httpServer = await HttpServer.bind(InternetAddress.loopbackIPv4, 8080);
+
+  // Every POST gets its own server: this protocol revision carries the client
+  // context on the request instead of an `initialize` handshake, so there is
+  // no connection to keep around between requests.
+  httpServer.listen(
+    (request) => handleStreamableHttpRequest(
+      request,
+      MCPServerWithGreeting.new,
+      // A JSON response body cannot carry notifications, so anything the
+      // server logs while handling the request is dropped without this.
+      onNotification:
+          (notification) => stderr.writeln('notification: $notification'),
+    ),
+  );
+
+  final endpoint = 'http://${httpServer.address.host}:${httpServer.port}/mcp';
+  print('Listening on $endpoint\n');
+  print('''
+curl -sS $endpoint \\
+  -H 'Content-Type: application/json' \\
+  -H 'Accept: application/json, text/event-stream' \\
+  -H 'MCP-Protocol-Version: 2026-07-28' \\
+  -H 'Mcp-Method: tools/call' \\
+  -H 'Mcp-Name: greet' \\
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "greet",
+      "arguments": {"name": "world"},
+      "_meta": {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {}
+      }
+    }
+  }'
+''');
+}
+
+/// A server with one tool, built fresh for each request.
+base class MCPServerWithGreeting extends MCPServer with ToolsSupport {
+  MCPServerWithGreeting(super.channel)
+    : super.fromStreamChannel(
+        implementation: Implementation(
+          name: 'An example dart server on Streamable HTTP',
+          version: '0.1.0',
+        ),
+      ) {
+    registerTool(greetTool, _greet);
+  }
+
+  final greetTool = Tool(
+    name: 'greet',
+    description: 'greets whoever it is given',
+    inputSchema: Schema.object(
+      properties: {'name': Schema.string(description: 'Who to greet')},
+      required: ['name'],
+    ),
+  );
+
+  CallToolResult _greet(CallToolRequest request) => CallToolResult(
+    content: [TextContent(text: 'Hello, ${request.arguments!['name']}!')],
+  );
+}

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -30,7 +30,8 @@ enum ProtocolVersion {
   v2024_11_05('2024-11-05'),
   v2025_03_26('2025-03-26'),
   v2025_06_18('2025-06-18'),
-  v2025_11_25('2025-11-25');
+  v2025_11_25('2025-11-25'),
+  v2026_07_28('2026-07-28');
 
   const ProtocolVersion(this.versionString);
 
@@ -43,6 +44,11 @@ enum ProtocolVersion {
   static const oldestSupported = ProtocolVersion.v2024_11_05;
 
   /// The most recent version supported by the current API.
+  ///
+  /// This is the newest version the legacy `initialize` handshake negotiates.
+  /// A transport for a request-scoped protocol revision, such as
+  /// `handleStreamableHttpRequest` in `package:dart_mcp/streamable_http.dart`,
+  /// carries its own set of supported versions.
   static const latestSupported = ProtocolVersion.v2025_11_25;
 
   /// The version string used over the wire to identify this version.

--- a/pkgs/dart_mcp/lib/src/utils/constants.dart
+++ b/pkgs/dart_mcp/lib/src/utils/constants.dart
@@ -17,7 +17,10 @@ extension Keys on Never {
   static const cacheScope = 'cacheScope';
   static const cancel = 'cancel';
   static const capabilities = 'capabilities';
+  static const clientCapabilitiesMeta =
+      'io.modelcontextprotocol/clientCapabilities';
   static const clientInfo = 'clientInfo';
+  static const clientInfoMeta = 'io.modelcontextprotocol/clientInfo';
   static const code = 'code';
   static const completion = 'completion';
   static const completions = 'completions';
@@ -97,10 +100,12 @@ extension Keys on Never {
   static const properties = 'properties';
   static const propertyNames = 'propertyNames';
   static const protocolVersion = 'protocolVersion';
+  static const protocolVersionMeta = 'io.modelcontextprotocol/protocolVersion';
   static const readOnlyHint = 'readOnlyHint';
   static const reason = 'reason';
   static const ref = 'ref';
   static const requestId = 'requestId';
+  static const requested = 'requested';
   static const requestedSchema = 'requestedSchema';
   static const required = 'required';
   static const resource = 'resource';
@@ -121,6 +126,7 @@ extension Keys on Never {
   static const stopSequences = 'stopSequences';
   static const structuredContent = 'structuredContent';
   static const subscribe = 'subscribe';
+  static const supported = 'supported';
   static const systemPrompt = 'systemPrompt';
   static const temperature = 'temperature';
   static const text = 'text';

--- a/pkgs/dart_mcp/lib/src/utils/constants.dart
+++ b/pkgs/dart_mcp/lib/src/utils/constants.dart
@@ -104,6 +104,7 @@ extension Keys on Never {
   static const readOnlyHint = 'readOnlyHint';
   static const reason = 'reason';
   static const ref = 'ref';
+  static const request = 'request';
   static const requestId = 'requestId';
   static const requested = 'requested';
   static const requestedSchema = 'requestedSchema';

--- a/pkgs/dart_mcp/lib/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/streamable_http.dart
@@ -22,32 +22,6 @@ import 'server.dart';
 import 'src/utils/constants.dart';
 import 'src/utils/json_rpc_2_object.dart';
 
-// Header field names are case insensitive, so these are used both to look
-// headers up and to name them in error messages, in the casing the
-// specification writes them in.
-const _protocolVersionHeader = 'MCP-Protocol-Version';
-const _mcpMethodHeader = 'Mcp-Method';
-const _mcpNameHeader = 'Mcp-Name';
-
-/// The media type of the SSE response streams this protocol revision allows a
-/// server to answer with.
-const _eventStreamMimeType = 'text/event-stream';
-
-/// The protocol versions this handler implements.
-///
-/// The legacy handshake negotiates [ProtocolVersion.latestSupported] instead;
-/// the request-scoped protocol this transport speaks was introduced later, so
-/// the two sets are deliberately separate.
-const _supportedVersions = {ProtocolVersion.v2026_07_28};
-
-/// The methods whose `name` or `uri` parameter is mirrored in the `Mcp-Name`
-/// header, mapping each method to the parameter that carries it.
-const _mcpNameParams = {
-  CallToolRequest.methodName: Keys.name,
-  GetPromptRequest.methodName: Keys.name,
-  ReadResourceRequest.methodName: Keys.uri,
-};
-
 /// Handles one Streamable HTTP POST [request] by validating its headers and
 /// `_meta` envelope, dispatching the decoded message to a fresh server
 /// created by [serverFactory] via [handleRequestScopedMessage], and writing
@@ -85,7 +59,11 @@ const _mcpNameParams = {
 /// error a request handler throws reaches the client with whatever payload
 /// `package:json_rpc_2` attached to it, including a Dart stack trace for
 /// errors which are not an [RpcException]. Handlers which must not disclose
-/// server internals to a remote client throw [RpcException]s instead.
+/// server internals to a remote client throw [RpcException]s instead. The
+/// status such a body gets follows its error code: an internal or server
+/// error is a 500, so a handler which fails is visible to intermediaries
+/// which never read the body, and a code the specification has not mapped to
+/// a status keeps 200.
 ///
 /// If [serverFactory] or [MCPServer.initialize] throws, the request is
 /// answered with 500 and an internal-error body, and the returned future then
@@ -468,6 +446,10 @@ Future<void> handleStreamableHttpRequest(
 }
 
 /// The HTTP status for a dispatched JSON-RPC [response] map.
+///
+/// Unmapped codes keep 200 rather than falling back to an error status: the
+/// specification reserves `-32020` to `-32099` for itself, and a revision
+/// which allocates a code from there names the status it wants with it.
 int _statusFor(Map<String, Object?> response) {
   final error = response[Keys.error];
   if (error is! Map<String, Object?>) return HttpStatus.ok;
@@ -479,6 +461,8 @@ int _statusFor(Map<String, Object?> response) {
     McpErrorCodes.missingRequiredClientCapability ||
     McpErrorCodes.unsupportedProtocolVersion => HttpStatus.badRequest,
     error_code.METHOD_NOT_FOUND => HttpStatus.notFound,
+    error_code.INTERNAL_ERROR ||
+    error_code.SERVER_ERROR => HttpStatus.internalServerError,
     _ => HttpStatus.ok,
   };
 }
@@ -547,3 +531,29 @@ String _decodeSentinel(String value) =>
     value.length >= 11 && value.startsWith('=?base64?') && value.endsWith('?=')
         ? utf8.decode(base64.decode(value.substring(9, value.length - 2)))
         : value;
+
+// Header field names are case insensitive, so these are used both to look
+// headers up and to name them in error messages, in the casing the
+// specification writes them in.
+const _protocolVersionHeader = 'MCP-Protocol-Version';
+const _mcpMethodHeader = 'Mcp-Method';
+const _mcpNameHeader = 'Mcp-Name';
+
+/// The media type of the SSE response streams this protocol revision allows a
+/// server to answer with.
+const _eventStreamMimeType = 'text/event-stream';
+
+/// The protocol versions this handler implements.
+///
+/// The legacy handshake negotiates [ProtocolVersion.latestSupported] instead;
+/// the request-scoped protocol this transport speaks was introduced later, so
+/// the two sets are deliberately separate.
+const _supportedVersions = {ProtocolVersion.v2026_07_28};
+
+/// The methods whose `name` or `uri` parameter is mirrored in the `Mcp-Name`
+/// header, mapping each method to the parameter that carries it.
+const _mcpNameParams = {
+  CallToolRequest.methodName: Keys.name,
+  GetPromptRequest.methodName: Keys.name,
+  ReadResourceRequest.methodName: Keys.uri,
+};

--- a/pkgs/dart_mcp/lib/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/streamable_http.dart
@@ -1,0 +1,518 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// The server side of the Streamable HTTP transport described by the
+/// 2026-07-28 revision of the Model Context Protocol specification,
+/// https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http.
+///
+/// Every POST carries a single JSON-RPC request or notification along with
+/// its own client context; there is no session state between requests. This
+/// library only answers with JSON bodies; SSE response streams are not
+/// implemented yet.
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:json_rpc_2/error_code.dart' as error_code;
+import 'package:json_rpc_2/json_rpc_2.dart';
+
+import 'server.dart';
+import 'src/utils/constants.dart';
+import 'src/utils/json_rpc_2_object.dart';
+
+// Header field names are case insensitive, so these are used both to look
+// headers up and to name them in error messages, in the casing the
+// specification writes them in.
+const _protocolVersionHeader = 'MCP-Protocol-Version';
+const _mcpMethodHeader = 'Mcp-Method';
+const _mcpNameHeader = 'Mcp-Name';
+
+/// The media type of the SSE response streams this protocol revision allows a
+/// server to answer with.
+const _eventStreamMimeType = 'text/event-stream';
+
+/// The protocol versions this handler implements.
+///
+/// The legacy handshake negotiates [ProtocolVersion.latestSupported] instead;
+/// the request-scoped protocol this transport speaks was introduced later, so
+/// the two sets are deliberately separate.
+const _supportedVersions = {ProtocolVersion.v2026_07_28};
+
+/// The methods whose `name` or `uri` parameter is mirrored in the `Mcp-Name`
+/// header, mapping each method to the parameter that carries it.
+const _mcpNameParams = {
+  CallToolRequest.methodName: Keys.name,
+  GetPromptRequest.methodName: Keys.name,
+  ReadResourceRequest.methodName: Keys.uri,
+};
+
+/// Handles one Streamable HTTP POST [request] by validating its headers and
+/// `_meta` envelope, dispatching the decoded message to a fresh server
+/// created by [serverFactory] via [handleRequestScopedMessage], and writing
+/// the HTTP response.
+///
+/// Spec-defined failures are answered with their JSON-RPC error codes and
+/// HTTP statuses: 400 for a malformed message or a failed header or envelope
+/// validation, 404 for a method this transport does not serve, 406 for an
+/// `Accept` header which is absent or does not cover both response shapes,
+/// and 415 for a `Content-Type` which is not `application/json`. Every one of
+/// those bodies also echoes the message which produced it under
+/// `error.data.request`, as the rest of this package does. A non-POST request
+/// is answered with 405 and an `Allow` header but no body, which is all this
+/// revision defines for `GET` and `DELETE`.
+///
+/// The `MCP-Protocol-Version` header is checked against the versions this
+/// handler implements before the body is inspected. A client speaking another
+/// revision cannot produce this revision's `_meta` envelope, so answering on
+/// the header alone is what lets it receive the `supported` list it needs to
+/// renegotiate with.
+///
+/// Notifications are acknowledged with `202 Accepted` and not dispatched,
+/// since this protocol revision defines no client-to-server notifications
+/// over HTTP. This handler reads the whole request body into memory, so
+/// origin validation, authentication, and request size limits are the
+/// embedding HTTP server's responsibility.
+///
+/// Responses produced by the dispatched server are written unchanged, so an
+/// error a request handler throws reaches the client with whatever payload
+/// `package:json_rpc_2` attached to it, including a Dart stack trace for
+/// errors which are not an [RpcException]. Handlers which must not disclose
+/// server internals to a remote client throw [RpcException]s instead.
+///
+/// If [serverFactory] or [MCPServer.initialize] throws, the request is
+/// answered with 500 and an internal-error body, and the returned future then
+/// completes with that error so an embedder which awaits it can log or rethrow
+/// it.
+///
+/// `Mcp-Session-Id` and `Last-Event-ID` headers are ignored, and no session
+/// id is ever minted: sessions and resumable streams were removed in this
+/// revision. Headers this revision does not define, including the
+/// `Mcp-Param-{Name}` headers a server opts into with `x-mcp-header`, are
+/// ignored as RFC 9110 requires.
+///
+/// Notifications the server produces while handling the request are passed
+/// to [onNotification]; a JSON response body cannot carry them, so without a
+/// handler they are dropped.
+Future<void> handleStreamableHttpRequest(
+  HttpRequest request,
+  MCPServerFactory serverFactory, {
+  void Function(Map<String, Object?> notification)? onNotification,
+}) async {
+  final response = request.response;
+  if (request.method != 'POST') {
+    response
+      ..statusCode = HttpStatus.methodNotAllowed
+      ..headers.set(HttpHeaders.allowHeader, 'POST')
+      ..contentLength = 0;
+    await response.close();
+    return;
+  }
+
+  // A body cannot be parsed before its media type is known, so this precedes
+  // even the notification acknowledgement.
+  if (request.headers.contentType?.mimeType != ContentType.json.mimeType) {
+    await request.drain<void>();
+    return _reject(
+      response,
+      HttpStatus.unsupportedMediaType,
+      RpcException(
+        McpErrorCodes.headerMismatch,
+        'The request body must be sent as ${ContentType.json.mimeType}',
+      ),
+      null,
+    );
+  }
+
+  final Object? decoded;
+  String? body;
+  try {
+    body = await utf8.decodeStream(request);
+    decoded = jsonDecode(body);
+  } on FormatException catch (e) {
+    return _reject(
+      response,
+      HttpStatus.badRequest,
+      RpcException(error_code.PARSE_ERROR, 'Invalid JSON: ${e.message}'),
+      body,
+    );
+  }
+
+  if (decoded is List) {
+    return _reject(
+      response,
+      HttpStatus.badRequest,
+      RpcException(
+        error_code.INVALID_REQUEST,
+        'Batch messages are not supported. Batching was removed in MCP '
+        'specification version 2025-06-18.',
+      ),
+      decoded,
+    );
+  }
+  if (decoded is! Map<String, Object?>) {
+    return _reject(
+      response,
+      HttpStatus.badRequest,
+      RpcException(
+        error_code.INVALID_REQUEST,
+        'A message must be a JSON object',
+      ),
+      decoded,
+    );
+  }
+
+  final object = JsonRpc2Object.fromMap(decoded);
+  if (object.kind == JsonRpc2Kind.response) {
+    return _reject(
+      response,
+      HttpStatus.badRequest,
+      RpcException(
+        error_code.INVALID_REQUEST,
+        'The client must not send JSON-RPC responses over this transport',
+      ),
+      decoded,
+    );
+  }
+
+  final method = decoded[Keys.method];
+  if (method is! String) {
+    return _reject(
+      response,
+      HttpStatus.badRequest,
+      RpcException(
+        error_code.INVALID_REQUEST,
+        'A message requires a String method',
+      ),
+      decoded,
+    );
+  }
+
+  if (object.kind == JsonRpc2Kind.notification) {
+    // This protocol revision defines no client-to-server notifications over
+    // HTTP, so there is no server to deliver them to; acknowledge and drop.
+    response
+      ..statusCode = HttpStatus.accepted
+      ..contentLength = 0;
+    await response.close();
+    return;
+  }
+
+  if (object.id == null) {
+    return _reject(
+      response,
+      HttpStatus.badRequest,
+      RpcException(
+        error_code.INVALID_REQUEST,
+        'The request id must not be null',
+      ),
+      decoded,
+    );
+  }
+
+  // A request may be answered with either a JSON object or an SSE stream, so
+  // the client has to accept both shapes even though this handler only sends
+  // the first.
+  if (!_accepts(request, ContentType.json.mimeType) ||
+      !_accepts(request, _eventStreamMimeType)) {
+    return _reject(
+      response,
+      HttpStatus.notAcceptable,
+      RpcException(
+        McpErrorCodes.headerMismatch,
+        'A request must accept both ${ContentType.json.mimeType} and '
+        '$_eventStreamMimeType',
+      ),
+      decoded,
+    );
+  }
+
+  final headerVersion = _singleTokenHeader(request, _protocolVersionHeader);
+  if (headerVersion == null) {
+    return _reject(
+      response,
+      HttpStatus.badRequest,
+      RpcException(
+        McpErrorCodes.headerMismatch,
+        'A single $_protocolVersionHeader header is required',
+      ),
+      decoded,
+    );
+  }
+  final protocolVersion = ProtocolVersion.tryParse(headerVersion);
+  if (protocolVersion == null ||
+      !_supportedVersions.contains(protocolVersion)) {
+    return _reject(
+      response,
+      HttpStatus.badRequest,
+      RpcException(
+        McpErrorCodes.unsupportedProtocolVersion,
+        'Unsupported protocol version',
+        data: {
+          Keys.supported: [
+            for (final supported in _supportedVersions) supported.versionString,
+          ],
+          Keys.requested: headerVersion,
+        },
+      ),
+      decoded,
+    );
+  }
+
+  final headerMethod = _singleTokenHeader(request, _mcpMethodHeader);
+  if (headerMethod == null) {
+    return _reject(
+      response,
+      HttpStatus.badRequest,
+      RpcException(
+        McpErrorCodes.headerMismatch,
+        'A single $_mcpMethodHeader header is required',
+      ),
+      decoded,
+    );
+  }
+
+  final params = decoded[Keys.params];
+  final meta = params is Map<String, Object?> ? params[Keys.meta] : null;
+  if (params is! Map<String, Object?> || meta is! Map<String, Object?>) {
+    return _reject(
+      response,
+      HttpStatus.badRequest,
+      RpcException.invalidParams(
+        'The request requires a params.${Keys.meta} envelope object',
+      ),
+      decoded,
+    );
+  }
+  final bodyVersion = meta[Keys.protocolVersionMeta];
+  if (bodyVersion is! String) {
+    return _reject(
+      response,
+      HttpStatus.badRequest,
+      RpcException.invalidParams(
+        'The envelope requires a ${Keys.protocolVersionMeta} String',
+      ),
+      decoded,
+    );
+  }
+  final capabilities = meta[Keys.clientCapabilitiesMeta];
+  if (capabilities is! Map<String, Object?>) {
+    return _reject(
+      response,
+      HttpStatus.badRequest,
+      RpcException.invalidParams(
+        'The envelope requires a ${Keys.clientCapabilitiesMeta} object',
+      ),
+      decoded,
+    );
+  }
+  final clientInfo = meta[Keys.clientInfoMeta];
+  if (clientInfo is! Map<String, Object?>?) {
+    return _reject(
+      response,
+      HttpStatus.badRequest,
+      RpcException.invalidParams(
+        'The envelope ${Keys.clientInfoMeta} must be an object',
+      ),
+      decoded,
+    );
+  }
+
+  if (headerVersion != bodyVersion) {
+    return _reject(
+      response,
+      HttpStatus.badRequest,
+      RpcException(
+        McpErrorCodes.headerMismatch,
+        'The $_protocolVersionHeader header does not match the '
+        '${Keys.protocolVersionMeta} envelope value',
+      ),
+      decoded,
+    );
+  }
+  if (headerMethod != method) {
+    return _reject(
+      response,
+      HttpStatus.badRequest,
+      RpcException(
+        McpErrorCodes.headerMismatch,
+        'The $_mcpMethodHeader header does not match the request method',
+      ),
+      decoded,
+    );
+  }
+
+  final nameParam = _mcpNameParams[method];
+  if (nameParam != null) {
+    final headerName = _singleHeader(request, _mcpNameHeader);
+    if (headerName == null) {
+      return _reject(
+        response,
+        HttpStatus.badRequest,
+        RpcException(
+          McpErrorCodes.headerMismatch,
+          'A single $_mcpNameHeader header is required for $method',
+        ),
+        decoded,
+      );
+    }
+    final String decodedName;
+    try {
+      decodedName = _decodeSentinel(headerName);
+    } on FormatException {
+      return _reject(
+        response,
+        HttpStatus.badRequest,
+        RpcException(
+          McpErrorCodes.headerMismatch,
+          'The $_mcpNameHeader header is not valid base64',
+        ),
+        decoded,
+      );
+    }
+    if (decodedName != params[nameParam]) {
+      return _reject(
+        response,
+        HttpStatus.badRequest,
+        RpcException(
+          McpErrorCodes.headerMismatch,
+          'The $_mcpNameHeader header does not match params.$nameParam',
+        ),
+        decoded,
+      );
+    }
+  }
+
+  if (method == InitializeRequest.methodName ||
+      method == InitializedNotification.methodName) {
+    // The legacy lifecycle is not part of the request-scoped protocol, so its
+    // methods are unknown here rather than dispatcher errors, which is also
+    // what `handleRequestScopedMessage` requires of its callers. A legacy
+    // client never reaches this point: it fails the version or header checks
+    // above, which is the `400 Bad Request` the compatibility matrix
+    // prescribes for a legacy client talking to a modern HTTP server.
+    return _reject(
+      response,
+      HttpStatus.notFound,
+      RpcException.methodNotFound(method),
+      decoded,
+    );
+  }
+
+  final Map<String, Object?>? result;
+  try {
+    result = await handleRequestScopedMessage(
+      decoded,
+      MCPServerInitialization(
+        protocolVersion: protocolVersion,
+        clientCapabilities: ClientCapabilities.fromMap(capabilities),
+        clientInfo:
+            clientInfo == null ? null : Implementation.fromMap(clientInfo),
+      ),
+      serverFactory,
+      onNotification: onNotification,
+    );
+  } catch (_) {
+    // The server could not be built for this request. Answer before the error
+    // leaves this function, so an embedder which discards the returned future
+    // does not leave the connection open.
+    await _reject(
+      response,
+      HttpStatus.internalServerError,
+      RpcException(
+        error_code.INTERNAL_ERROR,
+        'The server failed to initialize',
+      ),
+      decoded,
+    );
+    rethrow;
+  }
+
+  // Notifications returned above, so a dispatched request always has a
+  // response.
+  response.statusCode = _statusFor(result!);
+  response.headers.contentType = ContentType.json;
+  response.write(jsonEncode(result));
+  await response.close();
+}
+
+/// The HTTP status for a dispatched JSON-RPC [response] map.
+int _statusFor(Map<String, Object?> response) {
+  final error = response[Keys.error];
+  if (error is! Map<String, Object?>) return HttpStatus.ok;
+  return switch (error[Keys.code]) {
+    error_code.PARSE_ERROR ||
+    error_code.INVALID_REQUEST ||
+    error_code.INVALID_PARAMS ||
+    McpErrorCodes.headerMismatch ||
+    McpErrorCodes.missingRequiredClientCapability ||
+    McpErrorCodes.unsupportedProtocolVersion => HttpStatus.badRequest,
+    error_code.METHOD_NOT_FOUND => HttpStatus.notFound,
+    _ => HttpStatus.ok,
+  };
+}
+
+/// Writes [exception] serialized against [origin] as a JSON body with
+/// [status] and closes the response.
+Future<void> _reject(
+  HttpResponse response,
+  int status,
+  RpcException exception,
+  Object? origin,
+) async {
+  response
+    ..statusCode = status
+    ..headers.contentType = ContentType.json
+    ..write(jsonEncode(exception.serialize(origin)));
+  await response.close();
+}
+
+/// Returns the single value of [name], or `null` if it is missing or was sent
+/// more than once as separate values.
+String? _singleHeader(HttpRequest request, String name) {
+  final values = request.headers[name];
+  return values == null || values.length != 1 ? null : values.single;
+}
+
+/// Returns the single value of [name] when it is a token which cannot contain
+/// a comma, and `null` if it is missing or was sent more than once.
+///
+/// A recipient may combine repeated field lines into one comma separated
+/// value (RFC 9110 section 5.3), which `dart:io` does, so for these headers a
+/// comma is how a repeat arrives.
+String? _singleTokenHeader(HttpRequest request, String name) {
+  final value = _singleHeader(request, name);
+  return value == null || value.contains(',') ? null : value;
+}
+
+/// Whether the `Accept` header of [request] covers [mimeType], either by
+/// listing it or through the `type/*` or `*/*` wildcards.
+///
+/// Quality values are not weighed; a media range which appears at all counts
+/// as accepted. A request without an `Accept` header accepts nothing here,
+/// because the spec requires clients to send one.
+bool _accepts(HttpRequest request, String mimeType) {
+  final values = request.headers[HttpHeaders.acceptHeader];
+  if (values == null) return false;
+  final wildcard = '${mimeType.split('/').first}/*';
+  return values.any(
+    (value) => value
+        .split(',')
+        .map((range) => range.split(';').first.trim().toLowerCase())
+        .any(
+          (range) => range == mimeType || range == wildcard || range == '*/*',
+        ),
+  );
+}
+
+/// Decodes the `=?base64?...?=` sentinel encoding, passing other values
+/// through unchanged.
+///
+/// Throws a [FormatException] if the sentinel payload is not valid base64.
+String _decodeSentinel(String value) =>
+    // The `=?base64?` prefix is 9 characters and the `?=` suffix is 2; under
+    // 11 characters they overlap, so guard the length before slicing.
+    value.length >= 11 && value.startsWith('=?base64?') && value.endsWith('?=')
+        ? utf8.decode(base64.decode(value.substring(9, value.length - 2)))
+        : value;

--- a/pkgs/dart_mcp/lib/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/streamable_http.dart
@@ -86,7 +86,9 @@ const _mcpNameParams = {
 /// If [serverFactory] or [MCPServer.initialize] throws, the request is
 /// answered with 500 and an internal-error body, and the returned future then
 /// completes with that error so an embedder which awaits it can log or rethrow
-/// it.
+/// it. A client which disconnects while its body is still arriving leaves
+/// nothing to answer, so the returned future completes normally without
+/// writing a response.
 ///
 /// `Mcp-Session-Id` and `Last-Event-ID` headers are ignored, and no session
 /// id is ever minted: sessions and resumable streams were removed in this
@@ -113,9 +115,23 @@ Future<void> handleStreamableHttpRequest(
   }
 
   // A body cannot be parsed before its media type is known, so this precedes
-  // even the notification acknowledgement.
-  if (request.headers.contentType?.mimeType != ContentType.json.mimeType) {
-    await request.drain<void>();
+  // even the notification acknowledgement. dart:io parses the header lazily
+  // and throws right here on a value it cannot parse, which is as much of a
+  // mismatch as a wrong one.
+  ContentType? contentType;
+  try {
+    contentType = request.headers.contentType;
+  } on HttpException {
+    contentType = null;
+  }
+  if (contentType?.mimeType != ContentType.json.mimeType) {
+    try {
+      await request.drain<void>();
+    } on IOException {
+      // The client disconnected before its body arrived; there is no
+      // response left to write.
+      return;
+    }
     return _reject(
       response,
       HttpStatus.badRequest,
@@ -139,6 +155,10 @@ Future<void> handleStreamableHttpRequest(
       RpcException(error_code.PARSE_ERROR, 'Invalid JSON: ${e.message}'),
       body,
     );
+  } on IOException {
+    // The client disconnected before its body arrived; there is no response
+    // left to write.
+    return;
   }
 
   if (decoded is List) {

--- a/pkgs/dart_mcp/lib/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/streamable_http.dart
@@ -60,8 +60,10 @@ const _mcpNameParams = {
 /// 404 for a method this transport does not serve. The specification requires
 /// `400 Bad Request` on every `HeaderMismatch` body and names no other status
 /// for content negotiation, so 406 and 415 are not used. Every one of
-/// those bodies also echoes the message which produced it under
-/// `error.data.request`, as the rest of this package does. A non-POST request
+/// those bodies also carries the message which produced it under
+/// `error.data.request`, as the rest of this package does: the decoded
+/// message when there is one, the raw body text when it was not valid JSON,
+/// and `null` when the body was never read into text. A non-POST request
 /// is answered with 405 and an `Allow` header but no body, which is all this
 /// revision defines for `GET` and `DELETE`.
 ///

--- a/pkgs/dart_mcp/lib/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/streamable_http.dart
@@ -54,10 +54,12 @@ const _mcpNameParams = {
 /// the HTTP response.
 ///
 /// Spec-defined failures are answered with their JSON-RPC error codes and
-/// HTTP statuses: 400 for a malformed message or a failed header or envelope
-/// validation, 404 for a method this transport does not serve, 406 for an
-/// `Accept` header which is absent or does not cover both response shapes,
-/// and 415 for a `Content-Type` which is not `application/json`. Every one of
+/// HTTP statuses: 400 for a malformed message, a failed header or envelope
+/// validation, an `Accept` header which is absent or does not cover both
+/// response shapes, or a `Content-Type` which is not `application/json`, and
+/// 404 for a method this transport does not serve. The specification requires
+/// `400 Bad Request` on every `HeaderMismatch` body and names no other status
+/// for content negotiation, so 406 and 415 are not used. Every one of
 /// those bodies also echoes the message which produced it under
 /// `error.data.request`, as the rest of this package does. A non-POST request
 /// is answered with 405 and an `Allow` header but no body, which is all this
@@ -116,7 +118,7 @@ Future<void> handleStreamableHttpRequest(
     await request.drain<void>();
     return _reject(
       response,
-      HttpStatus.unsupportedMediaType,
+      HttpStatus.badRequest,
       RpcException(
         McpErrorCodes.headerMismatch,
         'The request body must be sent as ${ContentType.json.mimeType}',
@@ -192,6 +194,9 @@ Future<void> handleStreamableHttpRequest(
   if (object.kind == JsonRpc2Kind.notification) {
     // This protocol revision defines no client-to-server notifications over
     // HTTP, so there is no server to deliver them to; acknowledge and drop.
+    // This acknowledgement deliberately precedes the header checks below:
+    // per the specification, "header requirements for notification POSTs are
+    // not defined by this revision".
     response
       ..statusCode = HttpStatus.accepted
       ..contentLength = 0;
@@ -218,7 +223,7 @@ Future<void> handleStreamableHttpRequest(
       !_accepts(request, _eventStreamMimeType)) {
     return _reject(
       response,
-      HttpStatus.notAcceptable,
+      HttpStatus.badRequest,
       RpcException(
         McpErrorCodes.headerMismatch,
         'A request must accept both ${ContentType.json.mimeType} and '

--- a/pkgs/dart_mcp/lib/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/streamable_http.dart
@@ -75,9 +75,11 @@ const _mcpNameParams = {
 ///
 /// Notifications are acknowledged with `202 Accepted` and not dispatched,
 /// since this protocol revision defines no client-to-server notifications
-/// over HTTP. This handler reads the whole request body into memory, so
-/// origin validation, authentication, and request size limits are the
-/// embedding HTTP server's responsibility.
+/// over HTTP. This handler reads the whole request body into memory, and it
+/// does not read the `Origin` header, which the specification requires a
+/// server to validate and answer with 403: that check needs deployment
+/// knowledge this handler does not have, so it belongs to the embedding
+/// HTTP server, along with authentication and request size limits.
 ///
 /// Responses produced by the dispatched server are written unchanged, so an
 /// error a request handler throws reaches the client with whatever payload

--- a/pkgs/dart_mcp/lib/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/streamable_http.dart
@@ -94,9 +94,10 @@ const _mcpNameParams = {
 ///
 /// `Mcp-Session-Id` and `Last-Event-ID` headers are ignored, and no session
 /// id is ever minted: sessions and resumable streams were removed in this
-/// revision. Headers this revision does not define, including the
-/// `Mcp-Param-{Name}` headers a server opts into with `x-mcp-header`, are
-/// ignored as RFC 9110 requires.
+/// revision. The `Mcp-Param-{Name}` headers this revision defines are not
+/// supported either: nothing here opts into `x-mcp-header`, so no such
+/// header is ever recognized, and it is ignored along with every other
+/// header this handler does not read.
 ///
 /// Notifications the server produces while handling the request are passed
 /// to [onNotification]; a JSON response body cannot carry them, so without a

--- a/pkgs/dart_mcp/lib/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/streamable_http.dart
@@ -66,10 +66,10 @@ const _mcpNameParams = {
 /// revision defines for `GET` and `DELETE`.
 ///
 /// The `MCP-Protocol-Version` header is checked against the versions this
-/// handler implements before the body is inspected. A client speaking another
-/// revision cannot produce this revision's `_meta` envelope, so answering on
-/// the header alone is what lets it receive the `supported` list it needs to
-/// renegotiate with.
+/// handler implements before the `_meta` envelope is validated. A client
+/// speaking another revision cannot produce this revision's `_meta` envelope,
+/// so answering on the header alone is what lets it receive the `supported`
+/// list it needs to renegotiate with.
 ///
 /// Notifications are acknowledged with `202 Accepted` and not dispatched,
 /// since this protocol revision defines no client-to-server notifications

--- a/pkgs/dart_mcp/lib/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/streamable_http.dart
@@ -508,9 +508,10 @@ String? _singleHeader(HttpRequest request, String name) {
 /// Returns the single value of [name] when it is a token which cannot contain
 /// a comma, and `null` if it is missing or was sent more than once.
 ///
-/// A recipient may combine repeated field lines into one comma separated
-/// value (RFC 9110 section 5.3), which `dart:io` does, so for these headers a
-/// comma is how a repeat arrives.
+/// A sender may combine repeated field lines into one comma separated value
+/// (RFC 9110 section 5.3), which `dart:io`'s own client does, so for these
+/// headers a comma is one way a repeat arrives. Separate field lines are the
+/// other, which `dart:io`'s server keeps separate and [_singleHeader] counts.
 String? _singleTokenHeader(HttpRequest request, String name) {
   final value = _singleHeader(request, name);
   return value == null || value.contains(',') ? null : value;

--- a/pkgs/dart_mcp/test/api/api_test.dart
+++ b/pkgs/dart_mcp/test/api/api_test.dart
@@ -59,6 +59,15 @@ void main() {
     );
   });
 
+  test('the legacy handshake does not support the request-scoped era', () {
+    // The 2026-07-28 revision is spoken by its own transport; the legacy
+    // handshake refusing it is what downgrades a modern server talking to a
+    // legacy client, so this must stay false until that handshake learns
+    // the revision.
+    expect(ProtocolVersion.v2026_07_28.isSupported, false);
+    expect(ProtocolVersion.v2026_07_28 > ProtocolVersion.latestSupported, true);
+  });
+
   group('API object validation', () {
     test('throws when required fields are missing', () {
       expect(() => Root.fromMap({}).uri, throwsA(isA<ArgumentError>()));

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -829,15 +829,15 @@ void main() {
       expect(result[Keys.isError], isTrue);
     });
 
-    test('keeps unmapped dispatcher errors as 200', () async {
+    test('maps a crashed handler to 500', () async {
       // A handler which throws something other than an RpcException surfaces
-      // as an internal JSON-RPC error; only spec-mapped codes change the
-      // HTTP status.
+      // as a server error, the same class of failure as a server which cannot
+      // be built, which is answered with 500 as well.
       final (status, _, text) = await post(
         headers: headers('test/crash'),
         json: body('test/crash'),
       );
-      expect(status, 200);
+      expect(status, 500);
       expect(errorCode(text), error_code.SERVER_ERROR);
     });
 
@@ -848,6 +848,24 @@ void main() {
       );
       expect(status, 400);
       expect(errorCode(text), error_code.INVALID_PARAMS);
+    });
+
+    test('keeps an error the spec defines no status for at 200', () async {
+      final (status, _, text) = await post(
+        headers: {...headers(callTool), 'Mcp-Name': 'test/unmappedCode'},
+        json: body(callTool, params: {Keys.name: 'test/unmappedCode'}),
+      );
+      expect(status, 200);
+      expect(errorCode(text), -32099);
+    });
+
+    test('maps an internal error from a dispatched response to 500', () async {
+      final (status, _, text) = await post(
+        headers: {...headers(callTool), 'Mcp-Name': 'test/internalError'},
+        json: body(callTool, params: {Keys.name: 'test/internalError'}),
+      );
+      expect(status, 500);
+      expect(errorCode(text), error_code.INTERNAL_ERROR);
     });
 
     test('maps a missing client capability error to 400', () async {
@@ -1088,6 +1106,24 @@ base class _HttpTestServer extends MCPServer with ToolsSupport {
           throw RpcException(
             McpErrorCodes.missingRequiredClientCapability,
             'This tool needs the sampling capability',
+          ),
+    );
+    registerTool(
+      Tool(name: 'test/unmappedCode', inputSchema: ObjectSchema()),
+      // The far end of the range the specification reserves for itself, which
+      // no revision has allocated, so nothing defines a status for it.
+      (_) =>
+          throw RpcException(
+            -32099,
+            'This tool fails with a code no status is defined for',
+          ),
+    );
+    registerTool(
+      Tool(name: 'test/internalError', inputSchema: ObjectSchema()),
+      (_) =>
+          throw RpcException(
+            error_code.INTERNAL_ERROR,
+            'This tool reports an internal error',
           ),
     );
     registerTool(Tool(name: 'test/notify', inputSchema: ObjectSchema()), (_) {

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -1,0 +1,904 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_mcp/server.dart';
+import 'package:dart_mcp/src/utils/constants.dart';
+import 'package:dart_mcp/streamable_http.dart';
+import 'package:json_rpc_2/json_rpc_2.dart';
+import 'package:test/test.dart';
+
+/// The protocol version this transport speaks.
+const version = '2026-07-28';
+
+/// The headers every POST carries, whatever its body is.
+const transportHeaders = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json, text/event-stream',
+};
+
+void main() {
+  late HttpServer httpServer;
+  late Uri uri;
+  final servers = <_HttpTestServer>[];
+  final notifications = <Map<String, Object?>>[];
+
+  setUp(() async {
+    servers.clear();
+    notifications.clear();
+    httpServer = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    uri = Uri.http('${httpServer.address.host}:${httpServer.port}', '/mcp');
+    httpServer.listen(
+      (request) => handleStreamableHttpRequest(request, (channel) {
+        final server = _HttpTestServer(channel);
+        servers.add(server);
+        return server;
+      }, onNotification: notifications.add),
+    );
+    addTearDown(() => httpServer.close(force: true));
+  });
+
+  /// A request body for [method] carrying the standard envelope.
+  Map<String, Object?> body(
+    String method, {
+    Object? id = 1,
+    Map<String, Object?>? params,
+    Object? bodyVersion,
+    Object? capabilities = const <String, Object?>{},
+  }) => {
+    'jsonrpc': '2.0',
+    if (id != null) 'id': id,
+    'method': method,
+    'params': {
+      ...?params,
+      Keys.meta: {
+        Keys.protocolVersionMeta: bodyVersion ?? version,
+        Keys.clientCapabilitiesMeta: capabilities,
+      },
+    },
+  };
+
+  /// The transport and mirrored headers for [method].
+  Map<String, String> headers(
+    String method, {
+    String? headerVersion,
+    String? headerMethod,
+  }) => {
+    ...transportHeaders,
+    'Mcp-Protocol-Version': headerVersion ?? version,
+    'Mcp-Method': headerMethod ?? method,
+  };
+
+  Future<(int, HttpHeaders, String)> post({
+    Map<String, String> headers = const {},
+    Object? json,
+    String? raw,
+    String method = 'POST',
+  }) async {
+    final client = HttpClient();
+    addTearDown(client.close);
+    final request = await client.openUrl(method, uri);
+    headers.forEach(request.headers.set);
+    if (raw != null || json != null) {
+      request.write(raw ?? jsonEncode(json));
+    }
+    final response = await request.close();
+    final text = await utf8.decodeStream(response);
+    return (response.statusCode, response.headers, text);
+  }
+
+  Map<String, Object?> decode(String text) =>
+      jsonDecode(text) as Map<String, Object?>;
+
+  Object? errorCode(String text) =>
+      (decode(text)['error'] as Map<String, Object?>?)?['code'];
+
+  group('happy path', () {
+    test('answers tools/list with JSON and server info', () async {
+      final (status, responseHeaders, text) = await post(
+        headers: headers('tools/list'),
+        json: body('tools/list'),
+      );
+      expect(status, 200);
+      expect(responseHeaders.contentType?.mimeType, 'application/json');
+      expect(responseHeaders.contentType?.charset, 'utf-8');
+      expect(responseHeaders.value('Mcp-Session-Id'), isNull);
+      final response = decode(text);
+      expect(response['id'], 1);
+      final result = response['result'] as Map<String, Object?>;
+      final tools = result['tools'] as List;
+      expect(
+        tools.map((tool) => (tool as Map<String, Object?>)['name']),
+        contains('test/version'),
+      );
+      expect(
+        (result['_meta']
+            as Map<String, Object?>)['io.modelcontextprotocol/serverInfo'],
+        isNotNull,
+      );
+    });
+
+    test('answers tools/call with the tool result', () async {
+      final (status, _, text) = await post(
+        headers: {...headers('tools/call'), 'Mcp-Name': 'test/version'},
+        json: body('tools/call', params: {'name': 'test/version'}),
+      );
+      expect(status, 200);
+      final result = decode(text)['result'] as Map<String, Object?>;
+      final content = result['content'] as List;
+      expect((content.single as Map<String, Object?>)['text'], '1.2.3');
+    });
+  });
+
+  group('notifications and responses', () {
+    test('acknowledges a notification without headers or dispatch', () async {
+      final (status, _, text) = await post(
+        headers: transportHeaders,
+        json: {'jsonrpc': '2.0', 'method': 'notifications/progress'},
+      );
+      expect(status, 202);
+      expect(text, isEmpty);
+      expect(servers, isEmpty);
+    });
+
+    test('acknowledges an unknown notification', () async {
+      final (status, _, text) = await post(
+        headers: headers('no/such/notification'),
+        json: {'jsonrpc': '2.0', 'method': 'no/such/notification'},
+      );
+      expect(status, 202);
+      expect(text, isEmpty);
+      expect(servers, isEmpty);
+    });
+
+    test('rejects a JSON-RPC response body', () async {
+      final (status, _, text) = await post(
+        headers: transportHeaders,
+        json: {'jsonrpc': '2.0', 'id': 1, 'result': <String, Object?>{}},
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32600);
+      expect(servers, isEmpty);
+    });
+
+    test('rejects a message without a method before acknowledging', () async {
+      // A body with neither an id nor a method is a notification by shape,
+      // but the missing method is caught first, so it is a 400 not a 202.
+      final (status, _, text) = await post(
+        headers: transportHeaders,
+        json: {'jsonrpc': '2.0'},
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32600);
+      expect(servers, isEmpty);
+    });
+
+    test('rejects a non-string method', () async {
+      final (status, _, text) = await post(
+        headers: transportHeaders,
+        json: {'jsonrpc': '2.0', 'id': 1, 'method': 42},
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32600);
+    });
+
+    test('rejects a scalar body', () async {
+      final (status, _, text) = await post(
+        headers: transportHeaders,
+        raw: '42',
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32600);
+    });
+  });
+
+  group('content negotiation', () {
+    test('rejects a request without a Content-Type header', () async {
+      final (status, _, text) = await post(
+        headers: {
+          'Accept': 'application/json, text/event-stream',
+          'Mcp-Protocol-Version': version,
+          'Mcp-Method': 'tools/list',
+        },
+        json: body('tools/list'),
+      );
+      expect(status, 415);
+      expect(errorCode(text), -32020);
+      expect(servers, isEmpty);
+    });
+
+    test('rejects a text/plain Content-Type', () async {
+      final (status, responseHeaders, text) = await post(
+        headers: {...headers('tools/list'), 'Content-Type': 'text/plain'},
+        json: body('tools/list'),
+      );
+      expect(status, 415);
+      expect(responseHeaders.contentType?.mimeType, 'application/json');
+      expect(errorCode(text), -32020);
+    });
+
+    test('tolerates a charset on the Content-Type', () async {
+      final (status, _, text) = await post(
+        headers: {
+          ...headers('tools/list'),
+          'Content-Type': 'application/json; charset=utf-8',
+        },
+        json: body('tools/list'),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
+
+    test('rejects a request without an Accept header', () async {
+      final (status, _, text) = await post(
+        headers: {
+          'Content-Type': 'application/json',
+          'Mcp-Protocol-Version': version,
+          'Mcp-Method': 'tools/list',
+        },
+        json: body('tools/list'),
+      );
+      expect(status, 406);
+      expect(errorCode(text), -32020);
+      expect(servers, isEmpty);
+    });
+
+    test('rejects an Accept header without text/event-stream', () async {
+      final (status, responseHeaders, text) = await post(
+        headers: {...headers('tools/list'), 'Accept': 'application/json'},
+        json: body('tools/list'),
+      );
+      expect(status, 406);
+      expect(responseHeaders.contentType?.mimeType, 'application/json');
+      expect(errorCode(text), -32020);
+    });
+
+    test('rejects an Accept header without application/json', () async {
+      final (status, _, text) = await post(
+        headers: {...headers('tools/list'), 'Accept': 'text/event-stream'},
+        json: body('tools/list'),
+      );
+      expect(status, 406);
+      expect(errorCode(text), -32020);
+    });
+
+    test('accepts the */* wildcard', () async {
+      final (status, _, text) = await post(
+        headers: {...headers('tools/list'), 'Accept': '*/*'},
+        json: body('tools/list'),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
+
+    test('accepts type wildcards with quality values', () async {
+      final (status, _, text) = await post(
+        headers: {
+          ...headers('tools/list'),
+          'Accept': 'application/*;q=0.9, text/*;q=0.8',
+        },
+        json: body('tools/list'),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
+
+    test('acknowledges a notification which accepts nothing', () async {
+      // The Accept rule only applies to requests, which are the only messages
+      // that get a body back.
+      final (status, _, text) = await post(
+        headers: {'Content-Type': 'application/json'},
+        json: {'jsonrpc': '2.0', 'method': 'notifications/progress'},
+      );
+      expect(status, 202);
+      expect(text, isEmpty);
+    });
+  });
+
+  group('required headers', () {
+    test('rejects a missing protocol version header', () async {
+      final (status, _, text) = await post(
+        headers: {...transportHeaders, 'Mcp-Method': 'tools/list'},
+        json: body('tools/list'),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32020);
+    });
+
+    test('rejects a header and body version mismatch', () async {
+      final (status, _, text) = await post(
+        headers: headers('tools/list'),
+        json: body('tools/list', bodyVersion: '2025-06-18'),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32020);
+    });
+
+    test('rejects a missing Mcp-Method header', () async {
+      final (status, _, text) = await post(
+        headers: {...transportHeaders, 'Mcp-Protocol-Version': version},
+        json: body('tools/list'),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32020);
+    });
+
+    test('rejects an Mcp-Method header mismatch', () async {
+      final (status, _, text) = await post(
+        headers: headers('tools/call'),
+        json: body('tools/list'),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32020);
+      expect(servers, isEmpty);
+    });
+
+    test('compares Mcp-Method values case sensitively', () async {
+      // Header names are case insensitive, header values are not.
+      final (status, _, text) = await post(
+        headers: {
+          ...headers('tools/call', headerMethod: 'Tools/Call'),
+          'Mcp-Name': 'test/version',
+        },
+        json: body('tools/call', params: {'name': 'test/version'}),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32020);
+      expect(servers, isEmpty);
+    });
+
+    test('rejects a tools/call without an Mcp-Name header', () async {
+      final (status, _, text) = await post(
+        headers: headers('tools/call'),
+        json: body('tools/call', params: {'name': 'test/version'}),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32020);
+      // Messages name the headers in the casing the specification writes
+      // them in, not the lower case dart:io looks them up by.
+      expect(
+        decode(text)['error'],
+        containsPair('message', contains('Mcp-Name header is required')),
+      );
+    });
+
+    test('requires an Mcp-Name header even without a body name', () async {
+      // The header is required for the method, not merely mirrored when the
+      // body happens to carry a value, so this never reaches the dispatcher.
+      final (status, _, text) = await post(
+        headers: headers('tools/call'),
+        json: body('tools/call'),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32020);
+      expect(servers, isEmpty);
+    });
+
+    test('rejects a repeated Mcp-Method header', () async {
+      final client = HttpClient();
+      addTearDown(client.close);
+      final request = await client.postUrl(uri);
+      transportHeaders.forEach(request.headers.set);
+      request.headers
+        ..set('Mcp-Protocol-Version', version)
+        ..add('Mcp-Method', 'tools/list')
+        ..add('Mcp-Method', 'tools/list');
+      request.write(jsonEncode(body('tools/list')));
+      final response = await request.close();
+      final text = await utf8.decodeStream(response);
+      expect(response.statusCode, 400);
+      expect(errorCode(text), -32020);
+    });
+
+    test('rejects a prompts/get without an Mcp-Name header', () async {
+      final (status, _, text) = await post(
+        headers: headers('prompts/get'),
+        json: body('prompts/get', params: {'name': 'test/prompt'}),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32020);
+      expect(servers, isEmpty);
+    });
+
+    test('matches a prompts/get Mcp-Name against the name', () async {
+      final (status, _, _) = await post(
+        headers: {...headers('prompts/get'), 'Mcp-Name': 'test/prompt'},
+        json: body('prompts/get', params: {'name': 'test/prompt'}),
+      );
+      // The method reaches the dispatcher, which supports no prompts.
+      expect(status, 404);
+    });
+
+    test('decodes a base64 sentinel Mcp-Name header', () async {
+      final encoded = base64.encode(utf8.encode('test/version'));
+      final (status, _, _) = await post(
+        headers: {...headers('tools/call'), 'Mcp-Name': '=?base64?$encoded?='},
+        json: body('tools/call', params: {'name': 'test/version'}),
+      );
+      expect(status, 200);
+    });
+
+    test('rejects a base64 sentinel Mcp-Name for another tool', () async {
+      final encoded = base64.encode(utf8.encode('test/throw'));
+      final (status, _, text) = await post(
+        headers: {...headers('tools/call'), 'Mcp-Name': '=?base64?$encoded?='},
+        json: body('tools/call', params: {'name': 'test/version'}),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32020);
+      expect(servers, isEmpty);
+    });
+
+    test('rejects a repeated protocol version header', () async {
+      final client = HttpClient();
+      addTearDown(client.close);
+      final request = await client.postUrl(uri);
+      transportHeaders.forEach(request.headers.set);
+      request.headers
+        ..add('Mcp-Protocol-Version', version)
+        ..add('Mcp-Protocol-Version', version)
+        ..set('Mcp-Method', 'tools/list');
+      request.write(jsonEncode(body('tools/list')));
+      final response = await request.close();
+      final text = await utf8.decodeStream(response);
+      expect(response.statusCode, 400);
+      expect(errorCode(text), -32020);
+    });
+
+    test('rejects an Mcp-Name sentinel that is not valid base64', () async {
+      final (status, _, text) = await post(
+        headers: {...headers('tools/call'), 'Mcp-Name': '=?base64?%%%?='},
+        json: body('tools/call', params: {'name': 'test/version'}),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32020);
+    });
+
+    test('rejects an overlapping base64 sentinel without hanging', () async {
+      // '=?base64?=' is 10 characters: the prefix and suffix share a '?', so
+      // a naive slice throws a RangeError the handler would never answer.
+      final (status, _, text) = await post(
+        headers: {...headers('tools/call'), 'Mcp-Name': '=?base64?='},
+        json: body('tools/call', params: {'name': 'test/version'}),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32020);
+    });
+
+    test('rejects a resources/read without an Mcp-Name header', () async {
+      final (status, _, text) = await post(
+        headers: headers('resources/read'),
+        json: body('resources/read', params: {'uri': 'file:///doc.txt'}),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32020);
+      expect(servers, isEmpty);
+    });
+
+    test('matches a resources/read Mcp-Name against the uri', () async {
+      final (status, _, _) = await post(
+        headers: {...headers('resources/read'), 'Mcp-Name': 'file:///doc.txt'},
+        json: body('resources/read', params: {'uri': 'file:///doc.txt'}),
+      );
+      // The method reaches the dispatcher, which has no such resource.
+      expect(status, 404);
+    });
+  });
+
+  group('removed 2025-11-25 mechanisms', () {
+    test('ignores an Mcp-Session-Id header and mints none', () async {
+      final (status, responseHeaders, text) = await post(
+        headers: {...headers('tools/list'), 'Mcp-Session-Id': 'abc'},
+        json: body('tools/list'),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+      expect(responseHeaders.value('Mcp-Session-Id'), isNull);
+    });
+
+    test('ignores a Last-Event-ID header', () async {
+      final (status, _, text) = await post(
+        headers: {...headers('tools/list'), 'Last-Event-ID': '42'},
+        json: body('tools/list'),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
+
+    test('ignores an Mcp-Param header which contradicts the body', () async {
+      // Nothing here opts into `x-mcp-header`, so `Mcp-Param-*` is a header
+      // this handler does not recognize and RFC 9110 has it ignore it rather
+      // than guess which parameter it mirrors.
+      final (status, _, text) = await post(
+        headers: {
+          ...headers('tools/call'),
+          'Mcp-Name': 'test/version',
+          'Mcp-Param-Region': 'eu-west1',
+        },
+        json: body(
+          'tools/call',
+          params: {
+            'name': 'test/version',
+            'arguments': {'region': 'us-west1'},
+          },
+        ),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
+  });
+
+  group('http methods', () {
+    for (final method in ['GET', 'DELETE', 'PUT']) {
+      test('rejects $method with 405', () async {
+        final (status, responseHeaders, _) = await post(
+          method: method,
+          headers: method == 'DELETE' ? {'Mcp-Session-Id': 'abc'} : const {},
+        );
+        expect(status, 405);
+        expect(responseHeaders.value(HttpHeaders.allowHeader), 'POST');
+        expect(servers, isEmpty);
+      });
+    }
+  });
+
+  group('malformed bodies', () {
+    test('rejects malformed JSON', () async {
+      final (status, _, text) = await post(
+        headers: transportHeaders,
+        raw: '{"jsonrpc": "2.0",',
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32700);
+    });
+
+    test('rejects a batch array', () async {
+      final (status, _, text) = await post(
+        headers: transportHeaders,
+        raw: jsonEncode([body('tools/list'), body('tools/list')]),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32600);
+      expect(decode(text)['error'], containsPair('message', contains('Batch')));
+    });
+
+    test('rejects an empty body', () async {
+      final (status, _, text) = await post(headers: transportHeaders, raw: '');
+      expect(status, 400);
+      expect(errorCode(text), -32700);
+    });
+
+    test('rejects an explicit null request id', () async {
+      final (status, _, text) = await post(
+        headers: headers('tools/list'),
+        json: {'jsonrpc': '2.0', 'id': null, 'method': 'tools/list'},
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32600);
+    });
+  });
+
+  group('dispatch mappings', () {
+    test('maps an unknown method to 404', () async {
+      final (status, _, text) = await post(
+        headers: headers('no/such/method'),
+        json: body('no/such/method'),
+      );
+      expect(status, 404);
+      expect(errorCode(text), -32601);
+    });
+
+    test('maps an initialize request from a modern client to 404', () async {
+      final (status, _, text) = await post(
+        headers: headers('initialize'),
+        json: body('initialize'),
+      );
+      expect(status, 404);
+      expect(errorCode(text), -32601);
+      expect(servers, isEmpty);
+    });
+
+    test('maps an initialized notification carrying an id to 404', () async {
+      // Without an id this is a notification and gets a 202; with one it is a
+      // request for a method the request-scoped lifecycle does not have.
+      final (status, _, text) = await post(
+        headers: headers('notifications/initialized'),
+        json: body('notifications/initialized'),
+      );
+      expect(status, 404);
+      expect(errorCode(text), -32601);
+      expect(servers, isEmpty);
+    });
+
+    test('answers a legacy client with the versions it supports', () async {
+      // What a 2025-11-25 client actually sends: no `Mcp-Method` header and
+      // no `_meta` envelope, both of which this revision introduced.
+      final (status, _, text) = await post(
+        headers: {...transportHeaders, 'Mcp-Protocol-Version': '2025-11-25'},
+        json: {'jsonrpc': '2.0', 'id': 1, 'method': 'initialize'},
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32022);
+      final data =
+          (decode(text)['error'] as Map<String, Object?>)['data']
+              as Map<String, Object?>;
+      expect(data[Keys.supported], [version]);
+      expect(servers, isEmpty);
+    });
+
+    test('keeps a tool error result as 200', () async {
+      final (status, _, text) = await post(
+        headers: {...headers('tools/call'), 'Mcp-Name': 'no/such/tool'},
+        json: body('tools/call', params: {'name': 'no/such/tool'}),
+      );
+      expect(status, 200);
+      final result = decode(text)['result'] as Map<String, Object?>;
+      expect(result['isError'], isTrue);
+    });
+
+    test('keeps unmapped dispatcher errors as 200', () async {
+      // A handler which throws something other than an RpcException surfaces
+      // as an internal JSON-RPC error; only spec-mapped codes change the
+      // HTTP status.
+      final (status, _, text) = await post(
+        headers: headers('test/crash'),
+        json: body('test/crash'),
+      );
+      expect(status, 200);
+      expect(errorCode(text), -32000);
+    });
+
+    test('maps an RpcException from a tool to its HTTP status', () async {
+      final (status, _, text) = await post(
+        headers: {...headers('tools/call'), 'Mcp-Name': 'test/throw'},
+        json: body('tools/call', params: {'name': 'test/throw'}),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32602);
+    });
+
+    test('maps a missing client capability error to 400', () async {
+      final (status, _, text) = await post(
+        headers: {...headers('tools/call'), 'Mcp-Name': 'test/needsSampling'},
+        json: body('tools/call', params: {'name': 'test/needsSampling'}),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32021);
+    });
+
+    test('rejects an envelope without client capabilities', () async {
+      final request = body('tools/list');
+      final params = request['params'] as Map<String, Object?>;
+      final meta = params[Keys.meta] as Map<String, Object?>;
+      meta.remove(Keys.clientCapabilitiesMeta);
+      final (status, _, text) = await post(
+        headers: headers('tools/list'),
+        json: request,
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32602);
+      expect(servers, isEmpty);
+    });
+
+    test('rejects a request without an envelope', () async {
+      final (status, _, text) = await post(
+        headers: headers('tools/list'),
+        json: {'jsonrpc': '2.0', 'id': 1, 'method': 'tools/list'},
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32602);
+      expect(servers, isEmpty);
+    });
+
+    test('rejects an unknown protocol version', () async {
+      final (status, _, text) = await post(
+        headers: headers('tools/list', headerVersion: '2099-01-01'),
+        json: body('tools/list', bodyVersion: '2099-01-01'),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32022);
+      final data =
+          (decode(text)['error'] as Map<String, Object?>)['data']
+              as Map<String, Object?>;
+      expect(data['requested'], '2099-01-01');
+      expect(data['supported'], [version]);
+      expect(servers, isEmpty);
+    });
+
+    test('rejects an earlier protocol version before the envelope', () async {
+      // The envelope is itself a 2026-07-28 construct, so a client on an
+      // earlier version cannot send one; the version answer has to come first
+      // or that client never learns what to renegotiate to.
+      final (status, _, text) = await post(
+        headers: headers('tools/list', headerVersion: '2025-11-25'),
+        json: {'jsonrpc': '2.0', 'id': 1, 'method': 'tools/list'},
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32022);
+      final data =
+          (decode(text)['error'] as Map<String, Object?>)['data']
+              as Map<String, Object?>;
+      expect(data['requested'], '2025-11-25');
+      expect(data['supported'], [version]);
+      expect(servers, isEmpty);
+    });
+
+    test('rejects a malformed client info', () async {
+      final request = body('tools/list');
+      final params = request['params'] as Map<String, Object?>;
+      final meta = params[Keys.meta] as Map<String, Object?>;
+      meta[Keys.clientInfoMeta] = 'test client';
+      final (status, _, text) = await post(
+        headers: headers('tools/list'),
+        json: request,
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32602);
+      expect(servers, isEmpty);
+    });
+
+    test('answers 500 when the server cannot be created', () async {
+      final failing = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => failing.close(force: true));
+      final failure = Completer<Object>();
+      failing.listen(
+        (request) => handleStreamableHttpRequest(
+          request,
+          (_) => throw StateError('no server today'),
+        ).onError<Object>((error, _) => failure.complete(error)),
+      );
+      final client = HttpClient();
+      addTearDown(client.close);
+      final request = await client.postUrl(
+        Uri.http('${failing.address.host}:${failing.port}', '/mcp'),
+      );
+      headers('tools/list').forEach(request.headers.set);
+      request.write(jsonEncode(body('tools/list')));
+      final response = await request.close();
+      final text = await utf8.decodeStream(response);
+      expect(response.statusCode, 500);
+      expect(errorCode(text), -32603);
+      expect(await failure.future, isStateError);
+    });
+  });
+
+  group('request isolation', () {
+    String probed(String text) =>
+        (((decode(text)['result'] as Map<String, Object?>)['content'] as List)
+                    .single
+                as Map<String, Object?>)['text']
+            as String;
+
+    test('gives every request a fresh server and context', () async {
+      final probeHeaders = {
+        ...headers('tools/call'),
+        'Mcp-Name': 'test/capabilities',
+      };
+      final probeBody = {'name': 'test/capabilities'};
+      final (_, _, first) = await post(
+        headers: probeHeaders,
+        json: body(
+          'tools/call',
+          params: probeBody,
+          capabilities: {'sampling': <String, Object?>{}},
+        ),
+      );
+      final (_, _, second) = await post(
+        headers: probeHeaders,
+        json: body('tools/call', params: probeBody),
+      );
+      expect(probed(first), 'true');
+      expect(probed(second), 'false');
+      expect(servers, hasLength(2));
+      expect(servers[0], isNot(same(servers[1])));
+    });
+
+    test('gives concurrent requests independent contexts', () async {
+      final probeHeaders = {
+        ...headers('tools/call'),
+        'Mcp-Name': 'test/capabilities',
+      };
+      final probeBody = {'name': 'test/capabilities'};
+      final withSampling = post(
+        headers: probeHeaders,
+        json: body(
+          'tools/call',
+          params: probeBody,
+          capabilities: {'sampling': <String, Object?>{}},
+        ),
+      );
+      final without = post(
+        headers: probeHeaders,
+        json: body('tools/call', params: probeBody),
+      );
+      final [(_, _, first), (_, _, second)] = await Future.wait([
+        withSampling,
+        without,
+      ]);
+      expect(probed(first), 'true');
+      expect(probed(second), 'false');
+      expect(servers, hasLength(2));
+    });
+
+    test('accepts an optional client info', () async {
+      final request = body('tools/list');
+      final params = request['params'] as Map<String, Object?>;
+      final meta = params[Keys.meta] as Map<String, Object?>;
+      meta[Keys.clientInfoMeta] = {'name': 'test client', 'version': '1.0.0'};
+      final (status, _, text) = await post(
+        headers: headers('tools/list'),
+        json: request,
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
+
+    test('passes server notifications to the handler', () async {
+      final (status, _, text) = await post(
+        headers: {...headers('tools/call'), 'Mcp-Name': 'test/notify'},
+        json: body('tools/call', params: {'name': 'test/notify'}),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+      expect(notifications, hasLength(1));
+      expect(
+        notifications.single['method'],
+        LoggingMessageNotification.methodName,
+      );
+    });
+  });
+}
+
+base class _HttpTestServer extends MCPServer with ToolsSupport {
+  bool get _declaredSampling => clientCapabilities.sampling != null;
+
+  _HttpTestServer(super.channel)
+    : super.fromStreamChannel(
+        implementation: Implementation(
+          name: 'http test server',
+          version: '0.1.0',
+        ),
+      ) {
+    registerTool(
+      Tool(name: 'test/version', inputSchema: ObjectSchema()),
+      (_) => CallToolResult(content: [TextContent(text: '1.2.3')]),
+    );
+    registerTool(
+      Tool(name: 'test/throw', inputSchema: ObjectSchema()),
+      (_) => throw RpcException.invalidParams('This tool always throws'),
+    );
+    registerRequestHandler<Request?, Result?>(
+      'test/crash',
+      (_) => throw StateError('This handler always crashes'),
+    );
+    registerTool(
+      Tool(name: 'test/capabilities', inputSchema: ObjectSchema()),
+      (_) => CallToolResult(content: [TextContent(text: '$_declaredSampling')]),
+    );
+    registerTool(
+      Tool(name: 'test/needsSampling', inputSchema: ObjectSchema()),
+      (_) =>
+          throw RpcException(
+            McpErrorCodes.missingRequiredClientCapability,
+            'This tool needs the sampling capability',
+          ),
+    );
+    registerTool(Tool(name: 'test/notify', inputSchema: ObjectSchema()), (_) {
+      sendNotification(
+        LoggingMessageNotification.methodName,
+        LoggingMessageNotification(
+          level: LoggingLevel.error,
+          data: 'from tool',
+        ),
+      );
+      return CallToolResult(content: [TextContent(text: 'notified')]);
+    });
+  }
+}

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -114,6 +114,27 @@ void main() {
   Object? errorCode(String text) =>
       (decode(text)[Keys.error] as Map<String, Object?>?)?[Keys.code];
 
+  /// Sends [payload] over a raw socket and returns the raw response text.
+  ///
+  /// [HttpClient] refuses to send the malformed header values some tests
+  /// probe with and folds repeated header lines into one, so those requests
+  /// have to go over a socket. The payload must ask for `Connection: close`
+  /// or the read below never finishes.
+  Future<String> rawRequest(String payload) async {
+    final socket = await Socket.connect(httpServer.address, httpServer.port);
+    socket.write(payload);
+    await socket.flush();
+    final response = utf8.decode(
+      await socket.fold(<int>[], (bytes, chunk) => bytes..addAll(chunk)),
+    );
+    socket.destroy();
+    return response;
+  }
+
+  /// The JSON body of a raw response, cut out of its framing.
+  String jsonBody(String response) =>
+      response.substring(response.indexOf('{'), response.lastIndexOf('}') + 1);
+
   group('happy path', () {
     test('answers tools/list with JSON and server info', () async {
       final (status, responseHeaders, text) = await post(
@@ -305,6 +326,26 @@ void main() {
       );
       expect(status, 200);
       expect(errorCode(text), isNull);
+    });
+
+    test('rejects a Content-Type dart:io cannot parse', () async {
+      // dart:io parses the header lazily and throws when it is first read,
+      // and that throw must land as a 400, not escape the handler and leave
+      // the request unanswered.
+      final requestBody = jsonEncode(body(listTools));
+      final response = await rawRequest(
+        'POST /mcp HTTP/1.1\r\n'
+        'Host: localhost\r\n'
+        'Content-Type: application/json; charset="utf-8\r\n'
+        'Accept: application/json, text/event-stream\r\n'
+        'Content-Length: ${requestBody.length}\r\n'
+        'Connection: close\r\n'
+        '\r\n'
+        '$requestBody',
+      );
+      expect(response, startsWith('HTTP/1.1 400'));
+      expect(errorCode(jsonBody(response)), McpErrorCodes.headerMismatch);
+      expect(servers, isEmpty);
     });
 
     test('acknowledges a notification which accepts nothing', () async {
@@ -564,6 +605,49 @@ void main() {
         expect(servers, isEmpty);
       });
     }
+  });
+
+  group('client disconnects', () {
+    /// Sends a POST whose body never finishes arriving, then hangs up.
+    Future<void> disconnectMidBody({required String contentType}) async {
+      final socket = await Socket.connect(httpServer.address, httpServer.port);
+      socket.write(
+        'POST /mcp HTTP/1.1\r\n'
+        'Host: localhost\r\n'
+        'Content-Type: $contentType\r\n'
+        'Accept: application/json, text/event-stream\r\n'
+        'Content-Length: 500\r\n'
+        '\r\n'
+        '{"jsonrpc":"2.0",',
+      );
+      await socket.flush();
+      socket.destroy();
+      // The handler sees the disconnect asynchronously; give the event loop
+      // a beat so a failure surfaces inside this test.
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+    }
+
+    test('survives a disconnect while reading the body', () async {
+      await disconnectMidBody(contentType: 'application/json');
+      // There is no response to assert on, so the proof that the handler
+      // survived is a request which round-trips after the disconnect.
+      final (status, _, text) = await post(
+        headers: headers(listTools),
+        json: body(listTools),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
+
+    test('survives a disconnect while draining a rejected body', () async {
+      await disconnectMidBody(contentType: 'text/plain');
+      final (status, _, text) = await post(
+        headers: headers(listTools),
+        json: body(listTools),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
   });
 
   group('malformed bodies', () {

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -572,8 +572,8 @@ void main() {
 
     test('ignores an Mcp-Param header which contradicts the body', () async {
       // Nothing here opts into `x-mcp-header`, so `Mcp-Param-*` is a header
-      // this handler does not recognize and RFC 9110 has it ignore it rather
-      // than guess which parameter it mirrors.
+      // this handler does not recognize, and it is ignored rather than
+      // guessed at.
       final (status, _, text) = await post(
         headers: {
           ...headers(callTool),

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -12,11 +12,25 @@ import 'dart:io';
 import 'package:dart_mcp/server.dart';
 import 'package:dart_mcp/src/utils/constants.dart';
 import 'package:dart_mcp/streamable_http.dart';
+import 'package:json_rpc_2/error_code.dart' as error_code;
 import 'package:json_rpc_2/json_rpc_2.dart';
 import 'package:test/test.dart';
 
 /// The protocol version this transport speaks.
 const version = '2026-07-28';
+
+/// Shorthands for the method names these tests post, so that a name reads as
+/// one token at the call site.
+///
+/// The two notifications keep their kind in the name because several tests
+/// turn on whether a body is a request or a notification.
+const listTools = ListToolsRequest.methodName;
+const callTool = CallToolRequest.methodName;
+const getPrompt = GetPromptRequest.methodName;
+const readResource = ReadResourceRequest.methodName;
+const initialize = InitializeRequest.methodName;
+const initializedNotification = InitializedNotification.methodName;
+const progressNotification = ProgressNotification.methodName;
 
 /// The headers every POST carries, whatever its body is.
 const transportHeaders = {
@@ -53,10 +67,10 @@ void main() {
     Object? bodyVersion,
     Object? capabilities = const <String, Object?>{},
   }) => {
-    'jsonrpc': '2.0',
-    if (id != null) 'id': id,
-    'method': method,
-    'params': {
+    Keys.jsonrpc: '2.0',
+    if (id != null) Keys.id: id,
+    Keys.method: method,
+    Keys.params: {
       ...?params,
       Keys.meta: {
         Keys.protocolVersionMeta: bodyVersion ?? version,
@@ -98,42 +112,41 @@ void main() {
       jsonDecode(text) as Map<String, Object?>;
 
   Object? errorCode(String text) =>
-      (decode(text)['error'] as Map<String, Object?>?)?['code'];
+      (decode(text)[Keys.error] as Map<String, Object?>?)?[Keys.code];
 
   group('happy path', () {
     test('answers tools/list with JSON and server info', () async {
       final (status, responseHeaders, text) = await post(
-        headers: headers('tools/list'),
-        json: body('tools/list'),
+        headers: headers(listTools),
+        json: body(listTools),
       );
       expect(status, 200);
       expect(responseHeaders.contentType?.mimeType, 'application/json');
       expect(responseHeaders.contentType?.charset, 'utf-8');
       expect(responseHeaders.value('Mcp-Session-Id'), isNull);
       final response = decode(text);
-      expect(response['id'], 1);
-      final result = response['result'] as Map<String, Object?>;
-      final tools = result['tools'] as List;
+      expect(response[Keys.id], 1);
+      final result = response[Keys.result] as Map<String, Object?>;
+      final tools = result[Keys.tools] as List;
       expect(
-        tools.map((tool) => (tool as Map<String, Object?>)['name']),
+        tools.map((tool) => (tool as Map<String, Object?>)[Keys.name]),
         contains('test/version'),
       );
       expect(
-        (result['_meta']
-            as Map<String, Object?>)['io.modelcontextprotocol/serverInfo'],
+        (result[Keys.meta] as Map<String, Object?>)[Keys.serverInfoMeta],
         isNotNull,
       );
     });
 
     test('answers tools/call with the tool result', () async {
       final (status, _, text) = await post(
-        headers: {...headers('tools/call'), 'Mcp-Name': 'test/version'},
-        json: body('tools/call', params: {'name': 'test/version'}),
+        headers: {...headers(callTool), 'Mcp-Name': 'test/version'},
+        json: body(callTool, params: {Keys.name: 'test/version'}),
       );
       expect(status, 200);
-      final result = decode(text)['result'] as Map<String, Object?>;
-      final content = result['content'] as List;
-      expect((content.single as Map<String, Object?>)['text'], '1.2.3');
+      final result = decode(text)[Keys.result] as Map<String, Object?>;
+      final content = result[Keys.content] as List;
+      expect((content.single as Map<String, Object?>)[Keys.text], '1.2.3');
     });
   });
 
@@ -141,7 +154,7 @@ void main() {
     test('acknowledges a notification without headers or dispatch', () async {
       final (status, _, text) = await post(
         headers: transportHeaders,
-        json: {'jsonrpc': '2.0', 'method': 'notifications/progress'},
+        json: {Keys.jsonrpc: '2.0', Keys.method: progressNotification},
       );
       expect(status, 202);
       expect(text, isEmpty);
@@ -151,7 +164,7 @@ void main() {
     test('acknowledges an unknown notification', () async {
       final (status, _, text) = await post(
         headers: headers('no/such/notification'),
-        json: {'jsonrpc': '2.0', 'method': 'no/such/notification'},
+        json: {Keys.jsonrpc: '2.0', Keys.method: 'no/such/notification'},
       );
       expect(status, 202);
       expect(text, isEmpty);
@@ -161,10 +174,14 @@ void main() {
     test('rejects a JSON-RPC response body', () async {
       final (status, _, text) = await post(
         headers: transportHeaders,
-        json: {'jsonrpc': '2.0', 'id': 1, 'result': <String, Object?>{}},
+        json: {
+          Keys.jsonrpc: '2.0',
+          Keys.id: 1,
+          Keys.result: <String, Object?>{},
+        },
       );
       expect(status, 400);
-      expect(errorCode(text), -32600);
+      expect(errorCode(text), error_code.INVALID_REQUEST);
       expect(servers, isEmpty);
     });
 
@@ -173,20 +190,20 @@ void main() {
       // but the missing method is caught first, so it is a 400 not a 202.
       final (status, _, text) = await post(
         headers: transportHeaders,
-        json: {'jsonrpc': '2.0'},
+        json: {Keys.jsonrpc: '2.0'},
       );
       expect(status, 400);
-      expect(errorCode(text), -32600);
+      expect(errorCode(text), error_code.INVALID_REQUEST);
       expect(servers, isEmpty);
     });
 
     test('rejects a non-string method', () async {
       final (status, _, text) = await post(
         headers: transportHeaders,
-        json: {'jsonrpc': '2.0', 'id': 1, 'method': 42},
+        json: {Keys.jsonrpc: '2.0', Keys.id: 1, Keys.method: 42},
       );
       expect(status, 400);
-      expect(errorCode(text), -32600);
+      expect(errorCode(text), error_code.INVALID_REQUEST);
     });
 
     test('rejects a scalar body', () async {
@@ -195,7 +212,7 @@ void main() {
         raw: '42',
       );
       expect(status, 400);
-      expect(errorCode(text), -32600);
+      expect(errorCode(text), error_code.INVALID_REQUEST);
     });
   });
 
@@ -205,32 +222,32 @@ void main() {
         headers: {
           'Accept': 'application/json, text/event-stream',
           'Mcp-Protocol-Version': version,
-          'Mcp-Method': 'tools/list',
+          'Mcp-Method': listTools,
         },
-        json: body('tools/list'),
+        json: body(listTools),
       );
       expect(status, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
       expect(servers, isEmpty);
     });
 
     test('rejects a text/plain Content-Type', () async {
       final (status, responseHeaders, text) = await post(
-        headers: {...headers('tools/list'), 'Content-Type': 'text/plain'},
-        json: body('tools/list'),
+        headers: {...headers(listTools), 'Content-Type': 'text/plain'},
+        json: body(listTools),
       );
       expect(status, 400);
       expect(responseHeaders.contentType?.mimeType, 'application/json');
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
     });
 
     test('tolerates a charset on the Content-Type', () async {
       final (status, _, text) = await post(
         headers: {
-          ...headers('tools/list'),
+          ...headers(listTools),
           'Content-Type': 'application/json; charset=utf-8',
         },
-        json: body('tools/list'),
+        json: body(listTools),
       );
       expect(status, 200);
       expect(errorCode(text), isNull);
@@ -241,38 +258,38 @@ void main() {
         headers: {
           'Content-Type': 'application/json',
           'Mcp-Protocol-Version': version,
-          'Mcp-Method': 'tools/list',
+          'Mcp-Method': listTools,
         },
-        json: body('tools/list'),
+        json: body(listTools),
       );
       expect(status, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
       expect(servers, isEmpty);
     });
 
     test('rejects an Accept header without text/event-stream', () async {
       final (status, responseHeaders, text) = await post(
-        headers: {...headers('tools/list'), 'Accept': 'application/json'},
-        json: body('tools/list'),
+        headers: {...headers(listTools), 'Accept': 'application/json'},
+        json: body(listTools),
       );
       expect(status, 400);
       expect(responseHeaders.contentType?.mimeType, 'application/json');
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
     });
 
     test('rejects an Accept header without application/json', () async {
       final (status, _, text) = await post(
-        headers: {...headers('tools/list'), 'Accept': 'text/event-stream'},
-        json: body('tools/list'),
+        headers: {...headers(listTools), 'Accept': 'text/event-stream'},
+        json: body(listTools),
       );
       expect(status, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
     });
 
     test('accepts the */* wildcard', () async {
       final (status, _, text) = await post(
-        headers: {...headers('tools/list'), 'Accept': '*/*'},
-        json: body('tools/list'),
+        headers: {...headers(listTools), 'Accept': '*/*'},
+        json: body(listTools),
       );
       expect(status, 200);
       expect(errorCode(text), isNull);
@@ -281,10 +298,10 @@ void main() {
     test('accepts type wildcards with quality values', () async {
       final (status, _, text) = await post(
         headers: {
-          ...headers('tools/list'),
+          ...headers(listTools),
           'Accept': 'application/*;q=0.9, text/*;q=0.8',
         },
-        json: body('tools/list'),
+        json: body(listTools),
       );
       expect(status, 200);
       expect(errorCode(text), isNull);
@@ -295,7 +312,7 @@ void main() {
       // that get a body back.
       final (status, _, text) = await post(
         headers: {'Content-Type': 'application/json'},
-        json: {'jsonrpc': '2.0', 'method': 'notifications/progress'},
+        json: {Keys.jsonrpc: '2.0', Keys.method: progressNotification},
       );
       expect(status, 202);
       expect(text, isEmpty);
@@ -305,38 +322,38 @@ void main() {
   group('required headers', () {
     test('rejects a missing protocol version header', () async {
       final (status, _, text) = await post(
-        headers: {...transportHeaders, 'Mcp-Method': 'tools/list'},
-        json: body('tools/list'),
+        headers: {...transportHeaders, 'Mcp-Method': listTools},
+        json: body(listTools),
       );
       expect(status, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
     });
 
     test('rejects a header and body version mismatch', () async {
       final (status, _, text) = await post(
-        headers: headers('tools/list'),
-        json: body('tools/list', bodyVersion: '2025-06-18'),
+        headers: headers(listTools),
+        json: body(listTools, bodyVersion: '2025-06-18'),
       );
       expect(status, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
     });
 
     test('rejects a missing Mcp-Method header', () async {
       final (status, _, text) = await post(
         headers: {...transportHeaders, 'Mcp-Protocol-Version': version},
-        json: body('tools/list'),
+        json: body(listTools),
       );
       expect(status, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
     });
 
     test('rejects an Mcp-Method header mismatch', () async {
       final (status, _, text) = await post(
-        headers: headers('tools/call'),
-        json: body('tools/list'),
+        headers: headers(callTool),
+        json: body(listTools),
       );
       expect(status, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
       expect(servers, isEmpty);
     });
 
@@ -344,28 +361,28 @@ void main() {
       // Header names are case insensitive, header values are not.
       final (status, _, text) = await post(
         headers: {
-          ...headers('tools/call', headerMethod: 'Tools/Call'),
+          ...headers(callTool, headerMethod: 'Tools/Call'),
           'Mcp-Name': 'test/version',
         },
-        json: body('tools/call', params: {'name': 'test/version'}),
+        json: body(callTool, params: {Keys.name: 'test/version'}),
       );
       expect(status, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
       expect(servers, isEmpty);
     });
 
     test('rejects a tools/call without an Mcp-Name header', () async {
       final (status, _, text) = await post(
-        headers: headers('tools/call'),
-        json: body('tools/call', params: {'name': 'test/version'}),
+        headers: headers(callTool),
+        json: body(callTool, params: {Keys.name: 'test/version'}),
       );
       expect(status, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
       // Messages name the headers in the casing the specification writes
       // them in, not the lower case dart:io looks them up by.
       expect(
-        decode(text)['error'],
-        containsPair('message', contains('Mcp-Name header is required')),
+        decode(text)[Keys.error],
+        containsPair(Keys.message, contains('Mcp-Name header is required')),
       );
     });
 
@@ -373,11 +390,11 @@ void main() {
       // The header is required for the method, not merely mirrored when the
       // body happens to carry a value, so this never reaches the dispatcher.
       final (status, _, text) = await post(
-        headers: headers('tools/call'),
-        json: body('tools/call'),
+        headers: headers(callTool),
+        json: body(callTool),
       );
       expect(status, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
       expect(servers, isEmpty);
     });
 
@@ -388,29 +405,29 @@ void main() {
       transportHeaders.forEach(request.headers.set);
       request.headers
         ..set('Mcp-Protocol-Version', version)
-        ..add('Mcp-Method', 'tools/list')
-        ..add('Mcp-Method', 'tools/list');
-      request.write(jsonEncode(body('tools/list')));
+        ..add('Mcp-Method', listTools)
+        ..add('Mcp-Method', listTools);
+      request.write(jsonEncode(body(listTools)));
       final response = await request.close();
       final text = await utf8.decodeStream(response);
       expect(response.statusCode, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
     });
 
     test('rejects a prompts/get without an Mcp-Name header', () async {
       final (status, _, text) = await post(
-        headers: headers('prompts/get'),
-        json: body('prompts/get', params: {'name': 'test/prompt'}),
+        headers: headers(getPrompt),
+        json: body(getPrompt, params: {Keys.name: 'test/prompt'}),
       );
       expect(status, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
       expect(servers, isEmpty);
     });
 
     test('matches a prompts/get Mcp-Name against the name', () async {
       final (status, _, _) = await post(
-        headers: {...headers('prompts/get'), 'Mcp-Name': 'test/prompt'},
-        json: body('prompts/get', params: {'name': 'test/prompt'}),
+        headers: {...headers(getPrompt), 'Mcp-Name': 'test/prompt'},
+        json: body(getPrompt, params: {Keys.name: 'test/prompt'}),
       );
       // The method reaches the dispatcher, which supports no prompts.
       expect(status, 404);
@@ -419,8 +436,8 @@ void main() {
     test('decodes a base64 sentinel Mcp-Name header', () async {
       final encoded = base64.encode(utf8.encode('test/version'));
       final (status, _, _) = await post(
-        headers: {...headers('tools/call'), 'Mcp-Name': '=?base64?$encoded?='},
-        json: body('tools/call', params: {'name': 'test/version'}),
+        headers: {...headers(callTool), 'Mcp-Name': '=?base64?$encoded?='},
+        json: body(callTool, params: {Keys.name: 'test/version'}),
       );
       expect(status, 200);
     });
@@ -428,11 +445,11 @@ void main() {
     test('rejects a base64 sentinel Mcp-Name for another tool', () async {
       final encoded = base64.encode(utf8.encode('test/throw'));
       final (status, _, text) = await post(
-        headers: {...headers('tools/call'), 'Mcp-Name': '=?base64?$encoded?='},
-        json: body('tools/call', params: {'name': 'test/version'}),
+        headers: {...headers(callTool), 'Mcp-Name': '=?base64?$encoded?='},
+        json: body(callTool, params: {Keys.name: 'test/version'}),
       );
       expect(status, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
       expect(servers, isEmpty);
     });
 
@@ -444,48 +461,48 @@ void main() {
       request.headers
         ..add('Mcp-Protocol-Version', version)
         ..add('Mcp-Protocol-Version', version)
-        ..set('Mcp-Method', 'tools/list');
-      request.write(jsonEncode(body('tools/list')));
+        ..set('Mcp-Method', listTools);
+      request.write(jsonEncode(body(listTools)));
       final response = await request.close();
       final text = await utf8.decodeStream(response);
       expect(response.statusCode, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
     });
 
     test('rejects an Mcp-Name sentinel that is not valid base64', () async {
       final (status, _, text) = await post(
-        headers: {...headers('tools/call'), 'Mcp-Name': '=?base64?%%%?='},
-        json: body('tools/call', params: {'name': 'test/version'}),
+        headers: {...headers(callTool), 'Mcp-Name': '=?base64?%%%?='},
+        json: body(callTool, params: {Keys.name: 'test/version'}),
       );
       expect(status, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
     });
 
     test('rejects an overlapping base64 sentinel without hanging', () async {
       // '=?base64?=' is 10 characters: the prefix and suffix share a '?', so
       // a naive slice throws a RangeError the handler would never answer.
       final (status, _, text) = await post(
-        headers: {...headers('tools/call'), 'Mcp-Name': '=?base64?='},
-        json: body('tools/call', params: {'name': 'test/version'}),
+        headers: {...headers(callTool), 'Mcp-Name': '=?base64?='},
+        json: body(callTool, params: {Keys.name: 'test/version'}),
       );
       expect(status, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
     });
 
     test('rejects a resources/read without an Mcp-Name header', () async {
       final (status, _, text) = await post(
-        headers: headers('resources/read'),
-        json: body('resources/read', params: {'uri': 'file:///doc.txt'}),
+        headers: headers(readResource),
+        json: body(readResource, params: {Keys.uri: 'file:///doc.txt'}),
       );
       expect(status, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
       expect(servers, isEmpty);
     });
 
     test('matches a resources/read Mcp-Name against the uri', () async {
       final (status, _, _) = await post(
-        headers: {...headers('resources/read'), 'Mcp-Name': 'file:///doc.txt'},
-        json: body('resources/read', params: {'uri': 'file:///doc.txt'}),
+        headers: {...headers(readResource), 'Mcp-Name': 'file:///doc.txt'},
+        json: body(readResource, params: {Keys.uri: 'file:///doc.txt'}),
       );
       // The method reaches the dispatcher, which has no such resource.
       expect(status, 404);
@@ -495,8 +512,8 @@ void main() {
   group('removed 2025-11-25 mechanisms', () {
     test('ignores an Mcp-Session-Id header and mints none', () async {
       final (status, responseHeaders, text) = await post(
-        headers: {...headers('tools/list'), 'Mcp-Session-Id': 'abc'},
-        json: body('tools/list'),
+        headers: {...headers(listTools), 'Mcp-Session-Id': 'abc'},
+        json: body(listTools),
       );
       expect(status, 200);
       expect(errorCode(text), isNull);
@@ -505,8 +522,8 @@ void main() {
 
     test('ignores a Last-Event-ID header', () async {
       final (status, _, text) = await post(
-        headers: {...headers('tools/list'), 'Last-Event-ID': '42'},
-        json: body('tools/list'),
+        headers: {...headers(listTools), 'Last-Event-ID': '42'},
+        json: body(listTools),
       );
       expect(status, 200);
       expect(errorCode(text), isNull);
@@ -518,15 +535,15 @@ void main() {
       // than guess which parameter it mirrors.
       final (status, _, text) = await post(
         headers: {
-          ...headers('tools/call'),
+          ...headers(callTool),
           'Mcp-Name': 'test/version',
           'Mcp-Param-Region': 'eu-west1',
         },
         json: body(
-          'tools/call',
+          callTool,
           params: {
-            'name': 'test/version',
-            'arguments': {'region': 'us-west1'},
+            Keys.name: 'test/version',
+            Keys.arguments: {'region': 'us-west1'},
           },
         ),
       );
@@ -556,32 +573,35 @@ void main() {
         raw: '{"jsonrpc": "2.0",',
       );
       expect(status, 400);
-      expect(errorCode(text), -32700);
+      expect(errorCode(text), error_code.PARSE_ERROR);
     });
 
     test('rejects a batch array', () async {
       final (status, _, text) = await post(
         headers: transportHeaders,
-        raw: jsonEncode([body('tools/list'), body('tools/list')]),
+        raw: jsonEncode([body(listTools), body(listTools)]),
       );
       expect(status, 400);
-      expect(errorCode(text), -32600);
-      expect(decode(text)['error'], containsPair('message', contains('Batch')));
+      expect(errorCode(text), error_code.INVALID_REQUEST);
+      expect(
+        decode(text)[Keys.error],
+        containsPair(Keys.message, contains('Batch')),
+      );
     });
 
     test('rejects an empty body', () async {
       final (status, _, text) = await post(headers: transportHeaders, raw: '');
       expect(status, 400);
-      expect(errorCode(text), -32700);
+      expect(errorCode(text), error_code.PARSE_ERROR);
     });
 
     test('rejects an explicit null request id', () async {
       final (status, _, text) = await post(
-        headers: headers('tools/list'),
-        json: {'jsonrpc': '2.0', 'id': null, 'method': 'tools/list'},
+        headers: headers(listTools),
+        json: {Keys.jsonrpc: '2.0', Keys.id: null, Keys.method: listTools},
       );
       expect(status, 400);
-      expect(errorCode(text), -32600);
+      expect(errorCode(text), error_code.INVALID_REQUEST);
     });
   });
 
@@ -592,16 +612,16 @@ void main() {
         json: body('no/such/method'),
       );
       expect(status, 404);
-      expect(errorCode(text), -32601);
+      expect(errorCode(text), error_code.METHOD_NOT_FOUND);
     });
 
     test('maps an initialize request from a modern client to 404', () async {
       final (status, _, text) = await post(
-        headers: headers('initialize'),
-        json: body('initialize'),
+        headers: headers(initialize),
+        json: body(initialize),
       );
       expect(status, 404);
-      expect(errorCode(text), -32601);
+      expect(errorCode(text), error_code.METHOD_NOT_FOUND);
       expect(servers, isEmpty);
     });
 
@@ -609,11 +629,11 @@ void main() {
       // Without an id this is a notification and gets a 202; with one it is a
       // request for a method the request-scoped lifecycle does not have.
       final (status, _, text) = await post(
-        headers: headers('notifications/initialized'),
-        json: body('notifications/initialized'),
+        headers: headers(initializedNotification),
+        json: body(initializedNotification),
       );
       expect(status, 404);
-      expect(errorCode(text), -32601);
+      expect(errorCode(text), error_code.METHOD_NOT_FOUND);
       expect(servers, isEmpty);
     });
 
@@ -622,12 +642,12 @@ void main() {
       // no `_meta` envelope, both of which this revision introduced.
       final (status, _, text) = await post(
         headers: {...transportHeaders, 'Mcp-Protocol-Version': '2025-11-25'},
-        json: {'jsonrpc': '2.0', 'id': 1, 'method': 'initialize'},
+        json: {Keys.jsonrpc: '2.0', Keys.id: 1, Keys.method: initialize},
       );
       expect(status, 400);
-      expect(errorCode(text), -32022);
+      expect(errorCode(text), McpErrorCodes.unsupportedProtocolVersion);
       final data =
-          (decode(text)['error'] as Map<String, Object?>)['data']
+          (decode(text)[Keys.error] as Map<String, Object?>)[Keys.data]
               as Map<String, Object?>;
       expect(data[Keys.supported], [version]);
       expect(servers, isEmpty);
@@ -635,12 +655,12 @@ void main() {
 
     test('keeps a tool error result as 200', () async {
       final (status, _, text) = await post(
-        headers: {...headers('tools/call'), 'Mcp-Name': 'no/such/tool'},
-        json: body('tools/call', params: {'name': 'no/such/tool'}),
+        headers: {...headers(callTool), 'Mcp-Name': 'no/such/tool'},
+        json: body(callTool, params: {Keys.name: 'no/such/tool'}),
       );
       expect(status, 200);
-      final result = decode(text)['result'] as Map<String, Object?>;
-      expect(result['isError'], isTrue);
+      final result = decode(text)[Keys.result] as Map<String, Object?>;
+      expect(result[Keys.isError], isTrue);
     });
 
     test('keeps unmapped dispatcher errors as 200', () async {
@@ -652,63 +672,63 @@ void main() {
         json: body('test/crash'),
       );
       expect(status, 200);
-      expect(errorCode(text), -32000);
+      expect(errorCode(text), error_code.SERVER_ERROR);
     });
 
     test('maps an RpcException from a tool to its HTTP status', () async {
       final (status, _, text) = await post(
-        headers: {...headers('tools/call'), 'Mcp-Name': 'test/throw'},
-        json: body('tools/call', params: {'name': 'test/throw'}),
+        headers: {...headers(callTool), 'Mcp-Name': 'test/throw'},
+        json: body(callTool, params: {Keys.name: 'test/throw'}),
       );
       expect(status, 400);
-      expect(errorCode(text), -32602);
+      expect(errorCode(text), error_code.INVALID_PARAMS);
     });
 
     test('maps a missing client capability error to 400', () async {
       final (status, _, text) = await post(
-        headers: {...headers('tools/call'), 'Mcp-Name': 'test/needsSampling'},
-        json: body('tools/call', params: {'name': 'test/needsSampling'}),
+        headers: {...headers(callTool), 'Mcp-Name': 'test/needsSampling'},
+        json: body(callTool, params: {Keys.name: 'test/needsSampling'}),
       );
       expect(status, 400);
-      expect(errorCode(text), -32021);
+      expect(errorCode(text), McpErrorCodes.missingRequiredClientCapability);
     });
 
     test('rejects an envelope without client capabilities', () async {
-      final request = body('tools/list');
-      final params = request['params'] as Map<String, Object?>;
+      final request = body(listTools);
+      final params = request[Keys.params] as Map<String, Object?>;
       final meta = params[Keys.meta] as Map<String, Object?>;
       meta.remove(Keys.clientCapabilitiesMeta);
       final (status, _, text) = await post(
-        headers: headers('tools/list'),
+        headers: headers(listTools),
         json: request,
       );
       expect(status, 400);
-      expect(errorCode(text), -32602);
+      expect(errorCode(text), error_code.INVALID_PARAMS);
       expect(servers, isEmpty);
     });
 
     test('rejects a request without an envelope', () async {
       final (status, _, text) = await post(
-        headers: headers('tools/list'),
-        json: {'jsonrpc': '2.0', 'id': 1, 'method': 'tools/list'},
+        headers: headers(listTools),
+        json: {Keys.jsonrpc: '2.0', Keys.id: 1, Keys.method: listTools},
       );
       expect(status, 400);
-      expect(errorCode(text), -32602);
+      expect(errorCode(text), error_code.INVALID_PARAMS);
       expect(servers, isEmpty);
     });
 
     test('rejects an unknown protocol version', () async {
       final (status, _, text) = await post(
-        headers: headers('tools/list', headerVersion: '2099-01-01'),
-        json: body('tools/list', bodyVersion: '2099-01-01'),
+        headers: headers(listTools, headerVersion: '2099-01-01'),
+        json: body(listTools, bodyVersion: '2099-01-01'),
       );
       expect(status, 400);
-      expect(errorCode(text), -32022);
+      expect(errorCode(text), McpErrorCodes.unsupportedProtocolVersion);
       final data =
-          (decode(text)['error'] as Map<String, Object?>)['data']
+          (decode(text)[Keys.error] as Map<String, Object?>)[Keys.data]
               as Map<String, Object?>;
-      expect(data['requested'], '2099-01-01');
-      expect(data['supported'], [version]);
+      expect(data[Keys.requested], '2099-01-01');
+      expect(data[Keys.supported], [version]);
       expect(servers, isEmpty);
     });
 
@@ -717,30 +737,30 @@ void main() {
       // earlier version cannot send one; the version answer has to come first
       // or that client never learns what to renegotiate to.
       final (status, _, text) = await post(
-        headers: headers('tools/list', headerVersion: '2025-11-25'),
-        json: {'jsonrpc': '2.0', 'id': 1, 'method': 'tools/list'},
+        headers: headers(listTools, headerVersion: '2025-11-25'),
+        json: {Keys.jsonrpc: '2.0', Keys.id: 1, Keys.method: listTools},
       );
       expect(status, 400);
-      expect(errorCode(text), -32022);
+      expect(errorCode(text), McpErrorCodes.unsupportedProtocolVersion);
       final data =
-          (decode(text)['error'] as Map<String, Object?>)['data']
+          (decode(text)[Keys.error] as Map<String, Object?>)[Keys.data]
               as Map<String, Object?>;
-      expect(data['requested'], '2025-11-25');
-      expect(data['supported'], [version]);
+      expect(data[Keys.requested], '2025-11-25');
+      expect(data[Keys.supported], [version]);
       expect(servers, isEmpty);
     });
 
     test('rejects a malformed client info', () async {
-      final request = body('tools/list');
-      final params = request['params'] as Map<String, Object?>;
+      final request = body(listTools);
+      final params = request[Keys.params] as Map<String, Object?>;
       final meta = params[Keys.meta] as Map<String, Object?>;
       meta[Keys.clientInfoMeta] = 'test client';
       final (status, _, text) = await post(
-        headers: headers('tools/list'),
+        headers: headers(listTools),
         json: request,
       );
       expect(status, 400);
-      expect(errorCode(text), -32602);
+      expect(errorCode(text), error_code.INVALID_PARAMS);
       expect(servers, isEmpty);
     });
 
@@ -759,40 +779,41 @@ void main() {
       final request = await client.postUrl(
         Uri.http('${failing.address.host}:${failing.port}', '/mcp'),
       );
-      headers('tools/list').forEach(request.headers.set);
-      request.write(jsonEncode(body('tools/list')));
+      headers(listTools).forEach(request.headers.set);
+      request.write(jsonEncode(body(listTools)));
       final response = await request.close();
       final text = await utf8.decodeStream(response);
       expect(response.statusCode, 500);
-      expect(errorCode(text), -32603);
+      expect(errorCode(text), error_code.INTERNAL_ERROR);
       expect(await failure.future, isStateError);
     });
   });
 
   group('request isolation', () {
     String probed(String text) =>
-        (((decode(text)['result'] as Map<String, Object?>)['content'] as List)
+        (((decode(text)[Keys.result] as Map<String, Object?>)[Keys.content]
+                        as List)
                     .single
-                as Map<String, Object?>)['text']
+                as Map<String, Object?>)[Keys.text]
             as String;
 
     test('gives every request a fresh server and context', () async {
       final probeHeaders = {
-        ...headers('tools/call'),
+        ...headers(callTool),
         'Mcp-Name': 'test/capabilities',
       };
-      final probeBody = {'name': 'test/capabilities'};
+      final probeBody = {Keys.name: 'test/capabilities'};
       final (_, _, first) = await post(
         headers: probeHeaders,
         json: body(
-          'tools/call',
+          callTool,
           params: probeBody,
-          capabilities: {'sampling': <String, Object?>{}},
+          capabilities: {Keys.sampling: <String, Object?>{}},
         ),
       );
       final (_, _, second) = await post(
         headers: probeHeaders,
-        json: body('tools/call', params: probeBody),
+        json: body(callTool, params: probeBody),
       );
       expect(probed(first), 'true');
       expect(probed(second), 'false');
@@ -802,21 +823,21 @@ void main() {
 
     test('gives concurrent requests independent contexts', () async {
       final probeHeaders = {
-        ...headers('tools/call'),
+        ...headers(callTool),
         'Mcp-Name': 'test/capabilities',
       };
-      final probeBody = {'name': 'test/capabilities'};
+      final probeBody = {Keys.name: 'test/capabilities'};
       final withSampling = post(
         headers: probeHeaders,
         json: body(
-          'tools/call',
+          callTool,
           params: probeBody,
-          capabilities: {'sampling': <String, Object?>{}},
+          capabilities: {Keys.sampling: <String, Object?>{}},
         ),
       );
       final without = post(
         headers: probeHeaders,
-        json: body('tools/call', params: probeBody),
+        json: body(callTool, params: probeBody),
       );
       final [(_, _, first), (_, _, second)] = await Future.wait([
         withSampling,
@@ -828,12 +849,15 @@ void main() {
     });
 
     test('accepts an optional client info', () async {
-      final request = body('tools/list');
-      final params = request['params'] as Map<String, Object?>;
+      final request = body(listTools);
+      final params = request[Keys.params] as Map<String, Object?>;
       final meta = params[Keys.meta] as Map<String, Object?>;
-      meta[Keys.clientInfoMeta] = {'name': 'test client', 'version': '1.0.0'};
+      meta[Keys.clientInfoMeta] = {
+        Keys.name: 'test client',
+        Keys.version: '1.0.0',
+      };
       final (status, _, text) = await post(
-        headers: headers('tools/list'),
+        headers: headers(listTools),
         json: request,
       );
       expect(status, 200);
@@ -842,14 +866,14 @@ void main() {
 
     test('passes server notifications to the handler', () async {
       final (status, _, text) = await post(
-        headers: {...headers('tools/call'), 'Mcp-Name': 'test/notify'},
-        json: body('tools/call', params: {'name': 'test/notify'}),
+        headers: {...headers(callTool), 'Mcp-Name': 'test/notify'},
+        json: body(callTool, params: {Keys.name: 'test/notify'}),
       );
       expect(status, 200);
       expect(errorCode(text), isNull);
       expect(notifications, hasLength(1));
       expect(
-        notifications.single['method'],
+        notifications.single[Keys.method],
         LoggingMessageNotification.methodName,
       );
     });

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -209,7 +209,7 @@ void main() {
         },
         json: body('tools/list'),
       );
-      expect(status, 415);
+      expect(status, 400);
       expect(errorCode(text), -32020);
       expect(servers, isEmpty);
     });
@@ -219,7 +219,7 @@ void main() {
         headers: {...headers('tools/list'), 'Content-Type': 'text/plain'},
         json: body('tools/list'),
       );
-      expect(status, 415);
+      expect(status, 400);
       expect(responseHeaders.contentType?.mimeType, 'application/json');
       expect(errorCode(text), -32020);
     });
@@ -245,7 +245,7 @@ void main() {
         },
         json: body('tools/list'),
       );
-      expect(status, 406);
+      expect(status, 400);
       expect(errorCode(text), -32020);
       expect(servers, isEmpty);
     });
@@ -255,7 +255,7 @@ void main() {
         headers: {...headers('tools/list'), 'Accept': 'application/json'},
         json: body('tools/list'),
       );
-      expect(status, 406);
+      expect(status, 400);
       expect(responseHeaders.contentType?.mimeType, 'application/json');
       expect(errorCode(text), -32020);
     });
@@ -265,7 +265,7 @@ void main() {
         headers: {...headers('tools/list'), 'Accept': 'text/event-stream'},
         json: body('tools/list'),
       );
-      expect(status, 406);
+      expect(status, 400);
       expect(errorCode(text), -32020);
     });
 

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -455,6 +455,39 @@ void main() {
       expect(errorCode(text), McpErrorCodes.headerMismatch);
     });
 
+    test('rejects an Mcp-Name sent as two separate field lines', () async {
+      // dart:io's client folds repeated headers into one comma separated
+      // line, which the mismatch check catches, so the two-line shape the
+      // spec's "single value" rule is really about has to go over a raw
+      // socket: dart:io's server keeps the lines separate.
+      final requestBody = jsonEncode(
+        body(callTool, params: {Keys.name: 'test/version'}),
+      );
+      final response = await rawRequest(
+        'POST /mcp HTTP/1.1\r\n'
+        'Host: localhost\r\n'
+        'Content-Type: application/json\r\n'
+        'Accept: application/json, text/event-stream\r\n'
+        'Mcp-Protocol-Version: $version\r\n'
+        'Mcp-Method: $callTool\r\n'
+        'Mcp-Name: test/version\r\n'
+        'Mcp-Name: test/version\r\n'
+        'Content-Length: ${requestBody.length}\r\n'
+        'Connection: close\r\n'
+        '\r\n'
+        '$requestBody',
+      );
+      expect(response, startsWith('HTTP/1.1 400'));
+      final error = decode(jsonBody(response))[Keys.error];
+      expect(errorCode(jsonBody(response)), McpErrorCodes.headerMismatch);
+      // Both values are identical, so only the line count can be what this
+      // rejection is about.
+      expect(
+        error,
+        containsPair(Keys.message, contains('Mcp-Name header is required')),
+      );
+    });
+
     test('rejects a prompts/get without an Mcp-Name header', () async {
       final (status, _, text) = await post(
         headers: headers(getPrompt),
@@ -596,12 +629,13 @@ void main() {
   group('http methods', () {
     for (final method in ['GET', 'DELETE', 'PUT']) {
       test('rejects $method with 405', () async {
-        final (status, responseHeaders, _) = await post(
+        final (status, responseHeaders, text) = await post(
           method: method,
           headers: method == 'DELETE' ? {'Mcp-Session-Id': 'abc'} : const {},
         );
         expect(status, 405);
         expect(responseHeaders.value(HttpHeaders.allowHeader), 'POST');
+        expect(text, isEmpty);
         expect(servers, isEmpty);
       });
     }
@@ -879,6 +913,16 @@ void main() {
               as Map<String, Object?>;
       expect(data[Keys.requested], '2025-11-25');
       expect(data[Keys.supported], [version]);
+      expect(servers, isEmpty);
+    });
+
+    test('rejects an envelope version which is not a String', () async {
+      final (status, _, text) = await post(
+        headers: headers(listTools),
+        json: body(listTools, bodyVersion: 42),
+      );
+      expect(status, 400);
+      expect(errorCode(text), error_code.INVALID_PARAMS);
       expect(servers, isEmpty);
     });
 

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -689,6 +689,54 @@ void main() {
     });
   });
 
+  group('rejection bodies', () {
+    Map<String, Object?> errorData(String text) =>
+        (decode(text)[Keys.error] as Map<String, Object?>)[Keys.data]
+            as Map<String, Object?>;
+
+    test('echo the message when the exception carries no data', () async {
+      // `RpcException.serialize` injects the request into `error.data` when
+      // the exception has no data of its own.
+      final request = body(listTools);
+      final (status, _, text) = await post(
+        headers: headers(callTool),
+        json: request,
+      );
+      expect(status, 400);
+      expect(errorData(text)[Keys.request], request);
+    });
+
+    test('echo the message alongside data the exception carries', () async {
+      // ...and injects it next to existing data when that is a map without
+      // a `request` key, so the version payload keeps its echo too.
+      final request = {Keys.jsonrpc: '2.0', Keys.id: 1, Keys.method: listTools};
+      final (status, _, text) = await post(
+        headers: {...transportHeaders, 'Mcp-Protocol-Version': '2025-11-25'},
+        json: request,
+      );
+      expect(status, 400);
+      final data = errorData(text);
+      expect(data[Keys.supported], [version]);
+      expect(data[Keys.request], request);
+    });
+
+    test('echo raw text for unparsed bodies, null for unread ones', () async {
+      final (_, _, unparsed) = await post(
+        headers: transportHeaders,
+        raw: '{"jsonrpc": "2.0",',
+      );
+      expect(errorData(unparsed)[Keys.request], '{"jsonrpc": "2.0",');
+
+      final (_, _, unread) = await post(
+        headers: {...headers(listTools), 'Content-Type': 'text/plain'},
+        json: body(listTools),
+      );
+      final data = errorData(unread);
+      expect(data.containsKey(Keys.request), true);
+      expect(data[Keys.request], isNull);
+    });
+  });
+
   group('dispatch mappings', () {
     test('maps an unknown method to 404', () async {
       final (status, _, text) = await post(


### PR DESCRIPTION
Next 2026-07-28 slice tracked in #162, the POST handler laid out in the [finalized-spec diff report](https://github.com/dart-lang/ai/issues/162#issuecomment-5108248966). Rebased onto main now that #571 has landed, so nothing here predates that.

Adds `package:dart_mcp/streamable_http.dart` with `handleStreamableHttpRequest`, the server side of the [Streamable HTTP transport](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http) from the finalized revision. Each POST carries one JSON-RPC request or notification which is validated against the required headers and `_meta` envelope, then dispatched to a fresh server instance via `handleRequestScopedMessage`. Responses are JSON only. Also adds `ProtocolVersion.v2026_07_28`; `ProtocolVersion.latestSupported` still points at 2025-11-25, the newest version the legacy `initialize` handshake negotiates, since a transport for the request-scoped protocol carries its own set of supported versions.

Two mapping decisions worth calling out:

- Accept and Content-Type failures are answered with 400 Bad Request rather than 406/415: the 2026-07-28 schema requires 400 on every `HeaderMismatch` body ("For HTTP, the response status code MUST be `400 Bad Request`"), and the revision names no other status for content negotiation.
- A notification POST is acknowledged with 202 before the header checks run; the spec's note on notification POSTs states "header requirements for notification POSTs are not defined by this revision".

`example/streamable_http_server.dart` serves one tool over the transport and prints a `curl` command for it.

Does not add SSE response streams, the legacy session routes, or an HTTP client; those land as separate slices in that order.

## Tests

- `dart test -p chrome,vm -c dart2wasm,dart2js,kernel,exe` passes: 1028 tests (293 in each VM configuration, 221 in each Chrome configuration; the new suite is `@TestOn('vm')` since it drives `dart:io` sockets).
- `dart analyze --fatal-infos`: no issues.
- `cd mcp_examples && dart pub get && dart analyze --fatal-infos`: no issues.

