### PR TITLE
Report the install directory in skills get output

### DIFF
--- a/pkgs/skills/CHANGELOG.md
+++ b/pkgs/skills/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.0.0-wip
 
+- Display the actual install directory for each agent in the `get` command's
+  summary message.
 - Emphasize (bold) actual skill names in interactive dialog options.
 - Fix bug where failing to clone a git repository in `skills add` still saved
   it to configuration/manifest files.

--- a/pkgs/skills/lib/src/commands/get_skills.dart
+++ b/pkgs/skills/lib/src/commands/get_skills.dart
@@ -257,7 +257,8 @@ Future<bool> getSkills({
       logger.info('  [${info.agentName}] Installed ${info.skillName}');
     }
     logger.info(
-      'Installed ${result.installed.length} skill(s) for ${agent.cliName}.',
+      'Installed ${result.installed.length} skill(s) for ${agent.cliName} '
+      'at ${agent.skillsRelativePath}.',
     );
   }
 

--- a/pkgs/skills/test/commands/get_command_select_packages_test.dart
+++ b/pkgs/skills/test/commands/get_command_select_packages_test.dart
@@ -302,5 +302,42 @@ void main() {
         ]).validate();
       },
     );
+
+    test('when running `skills get --all` for multiple agents then the summary '
+        'for each agent reports its own install directory', () async {
+      final logMessages = <String>[];
+      final subscription = Logger('skills get').onRecord.listen((r) {
+        logMessages.add(r.message);
+      });
+
+      final getCommand = GetCommand(
+        dialogSupport: null,
+        gitRunner: GitRunner(isAvailableOverride: () async => false),
+      );
+      final runner = SkillsCommandRunner('skills', 'Test')
+        ..addCommand(getCommand);
+
+      await runner.run([
+        'get',
+        '--directory',
+        projectPath,
+        '--agent',
+        Agent.generic.cliName,
+        '--agent',
+        Agent.claude.cliName,
+        '--all',
+      ]);
+
+      await subscription.cancel();
+
+      expect(
+        logMessages,
+        contains('Installed 2 skill(s) for generic at .agents/skills.'),
+      );
+      expect(
+        logMessages,
+        contains('Installed 2 skill(s) for claude at .claude/skills.'),
+      );
+    });
   });
 }

--- a/pkgs/skills/test/commands/get_command_select_packages_test.dart
+++ b/pkgs/skills/test/commands/get_command_select_packages_test.dart
@@ -309,6 +309,7 @@ void main() {
       final subscription = Logger('skills get').onRecord.listen((r) {
         logMessages.add(r.message);
       });
+      addTearDown(subscription.cancel);
 
       final getCommand = GetCommand(
         dialogSupport: null,
@@ -327,8 +328,6 @@ void main() {
         Agent.claude.cliName,
         '--all',
       ]);
-
-      await subscription.cancel();
 
       expect(
         logMessages,


### PR DESCRIPTION
Fixes #552.

After installing, the per-agent summary named the agent but not where the
skills actually went. It now names the directory:

Before:

    Installed 2 skill(s) for generic.
    Installed 2 skill(s) for claude.

After:

    Installed 2 skill(s) for generic at .agents/skills.
    Installed 2 skill(s) for claude at .claude/skills.

This follows the display you added to `skills list` in #554 (d1405de), whose
header is `claude (installed at .claude/skills):` — same project-relative
directory, same `at` preposition. The value here is `agent.skillsRelativePath`
rather than `p.split(p.relative(adapter.skillsDirectory, from: rootPath)).join('/')`;
I checked all six adapters on multiple roots and the two produce identical
strings, so this avoids pulling `package:path` into `get_skills.dart` while
staying consistent with what `list` prints.

Not included: a location on each per-skill line. The directory is constant per
agent, so repeating it on every skill is noise, and `InstalledSkillInfo`
carries no path — threading one through `_installSkills` →
`_PackageInstallResult` → `SkillInstallResult` would multiply the diff for that
noise. Happy to do it if you disagree.

This touches `get_skills.dart` and the `## 1.0.0-wip` CHANGELOG, the same two
files as your open #568. I merged the two locally and they apply cleanly, so
there's nothing to coordinate.

Test covers two agents with different directories in a single `get` run.
