### PR TITLE
Include install location in skill install summary message (#552)

### DIFF
--- a/pkgs/skills/CHANGELOG.md
+++ b/pkgs/skills/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.0-wip
 
+- Include install location in log messages when installing skills.
 - Emphasize (bold) actual skill names in interactive dialog options.
 - Fix bug where failing to clone a git repository in `skills add` still saved
   it to configuration/manifest files.

--- a/pkgs/skills/lib/src/commands/get_skills.dart
+++ b/pkgs/skills/lib/src/commands/get_skills.dart
@@ -238,7 +238,8 @@ Future<bool> getSkills({
   }
 
   final installer = SkillInstaller(dialogSupport);
-  for (final agent in agents) {
+  for (final adapter in agentAdapters) {
+    final agent = adapter.agent;
     final result = await installer.installSkillsForIde(
       agent: agent,
       rootPath: rootPath,
@@ -254,10 +255,7 @@ Future<bool> getSkills({
     }
     manifest = result.manifest;
     globalConfig = result.globalConfig;
-    final installDir = p.relative(
-      createAgentAdapter(agent, rootPath, null).skillsDirectory,
-      from: rootPath,
-    );
+    final installDir = p.relative(adapter.skillsDirectory, from: rootPath);
     for (final info in result.installed) {
       logger.info('  [${info.agentName}] Installed ${info.skillName}');
     }

--- a/pkgs/skills/lib/src/commands/get_skills.dart
+++ b/pkgs/skills/lib/src/commands/get_skills.dart
@@ -5,6 +5,7 @@
 import 'dart:io' as io;
 
 import 'package:io/ansi.dart' as ansi;
+import 'package:path/path.dart' as p;
 
 import 'package:args/command_runner.dart';
 import 'package:logging/logging.dart';
@@ -253,11 +254,15 @@ Future<bool> getSkills({
     }
     manifest = result.manifest;
     globalConfig = result.globalConfig;
+    final installDir = p.relative(
+      createAgentAdapter(agent, rootPath, null).skillsDirectory,
+      from: rootPath,
+    );
     for (final info in result.installed) {
       logger.info('  [${info.agentName}] Installed ${info.skillName}');
     }
     logger.info(
-      'Installed ${result.installed.length} skill(s) for ${agent.cliName}.',
+      'Installed ${result.installed.length} skill(s) for ${agent.cliName} ($installDir).',
     );
   }
 

--- a/pkgs/skills/test/commands/get_command_suggested_skills_test.dart
+++ b/pkgs/skills/test/commands/get_command_suggested_skills_test.dart
@@ -282,5 +282,5 @@ void main() {
         );
       },
     );
-  });
+  }, timeout: const Timeout(Duration(minutes: 3)));
 }

--- a/pkgs/skills/test/commands/get_command_test.dart
+++ b/pkgs/skills/test/commands/get_command_test.dart
@@ -320,5 +320,60 @@ New skill body.
         reason: 'Content should not be overwritten',
       );
     });
+
+    test('logs install messages with install location', () async {
+      final logMessages = <String>[];
+      final subscription = Logger.root.onRecord.listen((r) {
+        logMessages.add(r.message);
+      });
+
+      try {
+        final getCommand = GetCommand(
+          dialogSupport: null,
+          gitRunner: GitRunner(isAvailableOverride: () async => false),
+        );
+        final runner = SkillsCommandRunner('skills', 'Test')
+          ..addCommand(getCommand);
+
+        await d.dir('dep_log_test', [
+          pubspec('dep_log_test'),
+          d.dir('skills', [
+            d.dir('dep_log_test-skill', [
+              d.file(
+                'SKILL.md',
+                '---\nname: dep_log_test-skill\ndescription: Test\n---\n\nContent',
+              ),
+            ]),
+          ]),
+        ]).create();
+
+        await d.dir('project_log_test', [
+          pubspec('project_log_test', dependencies: [.new('dep_log_test')]),
+        ]).create();
+
+        final projectPath = d.path('project_log_test');
+
+        await runner.run([
+          'get',
+          '--directory',
+          projectPath,
+          '--agent',
+          Agent.generic.cliName,
+          '--all',
+        ]);
+
+        expect(
+          logMessages,
+          contains('  [generic] Installed dep_log_test-skill'),
+        );
+        final expectedInstallDir = p.join('.agents', 'skills');
+        expect(
+          logMessages,
+          contains('Installed 1 skill(s) for generic ($expectedInstallDir).'),
+        );
+      } finally {
+        await subscription.cancel();
+      }
+    });
   });
 }


### PR DESCRIPTION
- Add relative install directory path in parentheses to the agent installation summary log message in `skills get` / `skills add`.
- Add unit test verifying install location in log messages.
- Update CHANGELOG.md.

Fixes #552