### PR TITLE
increase test timeout for flaky tests

### DIFF
--- a/pkgs/skills/test/commands/get_command_suggested_skills_test.dart
+++ b/pkgs/skills/test/commands/get_command_suggested_skills_test.dart
@@ -282,5 +282,5 @@ void main() {
         );
       },
     );
-  });
+  }, timeout: const Timeout(Duration(minutes: 3)));
 }


### PR DESCRIPTION
This test has been flaking a bunch on the latest flutter beta, it appears that `flutter pub get` is slower than it used to be.