### PR TITLE
let servers set the caching hints on cacheable results

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -57,7 +57,8 @@
   leaves a default to each SDK. `ListToolsResult`, `ListPromptsResult`,
   `ListResourcesResult`, `ListResourceTemplatesResult`, and
   `ReadResourceResult` now implement `CacheableResult`, so the hints are
-  readable on responses from servers that send them.
+  readable on responses from servers that send them, and their factories take
+  an optional `ttlMs` and `cacheScope`, which are left out when not passed.
 - Add `McpErrorCodes.headerMismatch` (`-32020`),
   `.missingRequiredClientCapability` (`-32021`), and
   `.unsupportedProtocolVersion` (`-32022`), the error codes the 2026-07-28

--- a/pkgs/dart_mcp/lib/src/api/prompts.dart
+++ b/pkgs/dart_mcp/lib/src/api/prompts.dart
@@ -23,12 +23,19 @@ extension type ListPromptsResult.fromMap(Map<String, Object?> _value)
   factory ListPromptsResult({
     required List<Prompt> prompts,
     Cursor? nextCursor,
+    int? ttlMs,
+    CacheScope? cacheScope,
     Meta? meta,
-  }) => ListPromptsResult.fromMap({
-    Keys.prompts: prompts,
-    if (nextCursor != null) Keys.nextCursor: nextCursor,
-    if (meta != null) Keys.meta: meta,
-  });
+  }) {
+    assert(ttlMs == null || ttlMs >= 0);
+    return ListPromptsResult.fromMap({
+      Keys.prompts: prompts,
+      if (nextCursor != null) Keys.nextCursor: nextCursor,
+      if (ttlMs != null) Keys.ttlMs: ttlMs,
+      if (cacheScope != null) Keys.cacheScope: cacheScope.name,
+      if (meta != null) Keys.meta: meta,
+    });
+  }
 
   List<Prompt> get prompts => (_value[Keys.prompts] as List).cast<Prompt>();
 }

--- a/pkgs/dart_mcp/lib/src/api/resources.dart
+++ b/pkgs/dart_mcp/lib/src/api/resources.dart
@@ -22,12 +22,19 @@ extension type ListResourcesResult.fromMap(Map<String, Object?> _value)
   factory ListResourcesResult({
     required List<Resource> resources,
     Cursor? nextCursor,
+    int? ttlMs,
+    CacheScope? cacheScope,
     Meta? meta,
-  }) => ListResourcesResult.fromMap({
-    Keys.resources: resources,
-    if (nextCursor != null) Keys.nextCursor: nextCursor,
-    if (meta != null) Keys.meta: meta,
-  });
+  }) {
+    assert(ttlMs == null || ttlMs >= 0);
+    return ListResourcesResult.fromMap({
+      Keys.resources: resources,
+      if (nextCursor != null) Keys.nextCursor: nextCursor,
+      if (ttlMs != null) Keys.ttlMs: ttlMs,
+      if (cacheScope != null) Keys.cacheScope: cacheScope.name,
+      if (meta != null) Keys.meta: meta,
+    });
+  }
 
   List<Resource> get resources =>
       (_value[Keys.resources] as List).cast<Resource>();
@@ -54,12 +61,19 @@ extension type ListResourceTemplatesResult.fromMap(Map<String, Object?> _value)
   factory ListResourceTemplatesResult({
     required List<ResourceTemplate> resourceTemplates,
     Cursor? nextCursor,
+    int? ttlMs,
+    CacheScope? cacheScope,
     Meta? meta,
-  }) => ListResourceTemplatesResult.fromMap({
-    Keys.resourceTemplates: resourceTemplates,
-    if (nextCursor != null) Keys.nextCursor: nextCursor,
-    if (meta != null) Keys.meta: meta,
-  });
+  }) {
+    assert(ttlMs == null || ttlMs >= 0);
+    return ListResourceTemplatesResult.fromMap({
+      Keys.resourceTemplates: resourceTemplates,
+      if (nextCursor != null) Keys.nextCursor: nextCursor,
+      if (ttlMs != null) Keys.ttlMs: ttlMs,
+      if (cacheScope != null) Keys.cacheScope: cacheScope.name,
+      if (meta != null) Keys.meta: meta,
+    });
+  }
 
   List<ResourceTemplate> get resourceTemplates =>
       (_value[Keys.resourceTemplates] as List).cast<ResourceTemplate>();
@@ -94,11 +108,18 @@ extension type ReadResourceResult.fromMap(Map<String, Object?> _value)
     implements CacheableResult {
   factory ReadResourceResult({
     required List<ResourceContents> contents,
+    int? ttlMs,
+    CacheScope? cacheScope,
     Meta? meta,
-  }) => ReadResourceResult.fromMap({
-    Keys.contents: contents,
-    if (meta != null) Keys.meta: meta,
-  });
+  }) {
+    assert(ttlMs == null || ttlMs >= 0);
+    return ReadResourceResult.fromMap({
+      Keys.contents: contents,
+      if (ttlMs != null) Keys.ttlMs: ttlMs,
+      if (cacheScope != null) Keys.cacheScope: cacheScope.name,
+      if (meta != null) Keys.meta: meta,
+    });
+  }
 
   List<ResourceContents> get contents =>
       (_value[Keys.contents] as List).cast<ResourceContents>();

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -22,12 +22,19 @@ extension type ListToolsResult.fromMap(Map<String, Object?> _value)
   factory ListToolsResult({
     required List<Tool> tools,
     Cursor? nextCursor,
+    int? ttlMs,
+    CacheScope? cacheScope,
     Meta? meta,
-  }) => ListToolsResult.fromMap({
-    Keys.tools: tools,
-    if (nextCursor != null) Keys.nextCursor: nextCursor,
-    if (meta != null) Keys.meta: meta,
-  });
+  }) {
+    assert(ttlMs == null || ttlMs >= 0);
+    return ListToolsResult.fromMap({
+      Keys.tools: tools,
+      if (nextCursor != null) Keys.nextCursor: nextCursor,
+      if (ttlMs != null) Keys.ttlMs: ttlMs,
+      if (cacheScope != null) Keys.cacheScope: cacheScope.name,
+      if (meta != null) Keys.meta: meta,
+    });
+  }
 
   List<Tool> get tools {
     final tools = (_value[Keys.tools] as List?)?.cast<Tool>();

--- a/pkgs/dart_mcp/test/api/api_test.dart
+++ b/pkgs/dart_mcp/test/api/api_test.dart
@@ -179,9 +179,10 @@ void main() {
   });
 
   group('cacheable result factory', () {
-    // The results the caching rules name, minus `server/discover`, which this
-    // package does not serve yet. These assert on the map rather than the
-    // getters: an absent `ttlMs` and a written `ttlMs: 0` both read as `0`.
+    // Returns an instance of every cacheable result type with the given
+    // settings, except `server/discover`, which this package does not serve
+    // yet. The tests assert on the map rather than the getters: an absent
+    // `ttlMs` and a written `ttlMs: 0` both read as `0`.
     List<Map<String, Object?>> cacheable({
       int? ttlMs,
       CacheScope? cacheScope,

--- a/pkgs/dart_mcp/test/api/api_test.dart
+++ b/pkgs/dart_mcp/test/api/api_test.dart
@@ -177,4 +177,65 @@ void main() {
       expect(listTools.cacheScope, CacheScope.public);
     });
   });
+
+  group('cacheable result factory', () {
+    // The results the caching rules name, minus `server/discover`, which this
+    // package does not serve yet. These assert on the map rather than the
+    // getters: an absent `ttlMs` and a written `ttlMs: 0` both read as `0`.
+    List<Map<String, Object?>> cacheable({
+      int? ttlMs,
+      CacheScope? cacheScope,
+    }) =>
+        [
+          ListToolsResult(tools: [], ttlMs: ttlMs, cacheScope: cacheScope),
+          ListPromptsResult(prompts: [], ttlMs: ttlMs, cacheScope: cacheScope),
+          ListResourcesResult(
+            resources: [],
+            ttlMs: ttlMs,
+            cacheScope: cacheScope,
+          ),
+          ListResourceTemplatesResult(
+            resourceTemplates: [],
+            ttlMs: ttlMs,
+            cacheScope: cacheScope,
+          ),
+          ReadResourceResult(
+            contents: [],
+            ttlMs: ttlMs,
+            cacheScope: cacheScope,
+          ),
+        ].cast<Map<String, Object?>>();
+
+    test('writes the hints it is given', () {
+      for (var result in cacheable(
+        ttlMs: 5000,
+        cacheScope: CacheScope.public,
+      )) {
+        expect(result, containsPair('ttlMs', 5000));
+        expect(result, containsPair('cacheScope', 'public'));
+      }
+      for (var result in cacheable(ttlMs: 0, cacheScope: CacheScope.private)) {
+        expect(result, containsPair('ttlMs', 0));
+        expect(result, containsPair('cacheScope', 'private'));
+      }
+    });
+
+    test('writes only the hint it is given', () {
+      for (var result in cacheable(ttlMs: 5000)) {
+        expect(result, containsPair('ttlMs', 5000));
+        expect(result, isNot(contains('cacheScope')));
+      }
+      for (var result in cacheable(cacheScope: CacheScope.public)) {
+        expect(result, containsPair('cacheScope', 'public'));
+        expect(result, isNot(contains('ttlMs')));
+      }
+    });
+
+    test('leaves out the hints it is not given', () {
+      for (var result in cacheable()) {
+        expect(result, isNot(contains('ttlMs')));
+        expect(result, isNot(contains('cacheScope')));
+      }
+    });
+  });
 }


### PR DESCRIPTION
Next 2026-07-28 core-protocol slice tracked in #162, following #570: the five cacheable result factories now take the `ttlMs` and `cacheScope` caching hints. #580 is the other half, what the dispatcher fills in when a handler did not.

#570 added `CacheableResult` to read the two off a result and closed with "server-side emission of the hints (factory parameters) are follow-up slices". This is that slice, for the results the caching rules name (https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching).

- Both are optional and are left out of the result when they are not passed. Writing a default `ttlMs` here would be indistinguishable from a real answer, since an absent one and a written `0` both read as `0`. Writing a default `cacheScope` would be worse: synthesizing `public` for a server that never declared a scope is the one guess that can leak a private response into a shared cache, which is why #570 has the getter read `null` instead.
- A negative `ttlMs` is an assertion failure. The spec requires `ttlMs >= 0`, and the reader already folds a negative value to `0`, so a server sending one would be telling clients something other than what it meant. Same shape as `Annotations`' assert on `priority`.
- `ReadResourceResult` takes the two without `nextCursor`, matching the schema: it is cacheable but not paginated.
- They are two parameters rather than one hints object because the factory is where these fields are defined, so a third hint would land here anyway, and because every other factory in the package takes its fields this way.

That page also names `server/discover`, which this package does not serve yet, so five factories change here.

## Tests

- Each factory writes both hints when given them, writes just the one it is given, and leaves both keys out when given neither. The assertions read the result map rather than the getters, since an absent `ttlMs` and a written `ttlMs: 0` both read as `0`. That `0` is covered explicitly: it is a meaningful value in the spec, not a sentinel.
- `dart test -p chrome,vm -c dart2wasm,dart2js,kernel,exe` passes (1040 tests across the four configurations).
- `dart analyze --fatal-infos` is clean here and in `mcp_examples` resolved against this branch.

One note on what is not tested: the `ttlMs` assert has no test. Asserts are compiled out under `-c exe`, so a test which expects one to throw fails there, and the package tests none of its 37 other asserts either.

Part of #162.
