### PR TITLE
send the result fields the 2026-07-28 revision requires

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -32,9 +32,12 @@
     initialize response or version negotiation.
 - Add `handleRequestScopedMessage` and `MCPServerFactory`, which serve each
   decoded JSON-RPC message on a fresh server instance for request-scoped
-  transports. Successful results record the server implementation under the
-  reserved `io.modelcontextprotocol/serverInfo` result metadata key. Does
-  **not** add any transport.
+  transports. On 2026-07-28, successful results record the server
+  implementation under the reserved `io.modelcontextprotocol/serverInfo`
+  result metadata key, carry a `resultType`, and on the list and read results
+  carry the `ttlMs` and `cacheScope` hints, which the handler may set itself.
+  A server answering an earlier revision gets none of them. Does **not** add
+  any transport.
 - `RootsTrackingSupport` no longer surfaces an unhandled error when the
   connection closes while a `listRoots` request is in flight.
 - The URL elicitation retry rethrows the original error when its data is not

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -192,7 +192,8 @@ extension type Result._(Map<String, Object?> _value) {
   /// any other string. Servers on protocol versions before 2026-07-28 omit
   /// the field; the schema requires treating that as "complete", so an absent
   /// value is reported here as "complete".
-  String get resultType => _value[Keys.resultType] as String? ?? 'complete';
+  String get resultType =>
+      _value[Keys.resultType] as String? ?? ResultTypes.complete;
 }
 
 /// A response that indicates success but carries no data.

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -33,12 +33,14 @@ typedef MCPServerFactory =
 /// `io.modelcontextprotocol/serverInfo` result metadata key, carries a
 /// `resultType`, and, for the requests the caching rules name, carries `ttlMs`
 /// and `cacheScope` unless it is an interim `resources/read` result, which is
-/// not cacheable. A field the handler set is kept when the schema allows it:
-/// a `resultType` left `null` becomes `complete`, a `ttlMs` which is `null`
-/// or below zero becomes `0`, and a `cacheScope` which is `null` or outside
-/// `public` and `private` becomes `private`. The dispatcher cannot know when
-/// an answer goes stale, and `public` is the one guess which could put a
-/// private answer in a cache shared across authorization contexts. None of
+/// not cacheable. A field the handler left out is filled in: a `resultType`
+/// left `null` becomes `complete`, a `ttlMs` which is `null` becomes `0`, and
+/// a `cacheScope` which is `null` becomes `private`. The dispatcher cannot
+/// know when an answer goes stale, and `public` is the one guess which could
+/// put a private answer in a cache shared across authorization contexts.
+/// A `ttlMs` below zero or a `cacheScope` outside `public` and `private` is a
+/// bug in the server: it asserts, and in a build with asserts disabled it is
+/// replaced the same way a field left `null` is. None of
 /// this reaches a result on an earlier revision, and every error response is
 /// returned unchanged. If the server closes before responding to a request,
 /// an internal-error response is returned instead. The server may still be

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -163,16 +163,11 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
               );
             }
         }
-      } catch (error, stackTrace) {
-        // The server sent a frame we could not process. Never let it wedge or
-        // escape the exchange: a request gets an internal error, anything
-        // else surfaces as an uncaught error. A failed assert is a bug in the
-        // server rather than a frame we could not read, so it surfaces even
-        // when a response still goes back; otherwise the message it carries
-        // would be lost behind the internal error.
-        if (error is AssertionError || !isRequest || response.isCompleted) {
-          Zone.current.handleUncaughtError(error, stackTrace);
-        }
+      } catch (_) {
+        // The server sent a frame we could not process. Answer the request
+        // before rethrowing so a caller waiting on it is not left hanging;
+        // the error itself still reaches the zone, which is where a bug in
+        // the server belongs.
         if (isRequest && !response.isCompleted) {
           response.complete(
             _errorResponse(
@@ -181,6 +176,7 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
             ),
           );
         }
+        rethrow;
       }
     },
     onDone: () {

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -164,7 +164,13 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
       } catch (error, stackTrace) {
         // The server sent a frame we could not process. Never let it wedge or
         // escape the exchange: a request gets an internal error, anything
-        // else surfaces as an uncaught error.
+        // else surfaces as an uncaught error. A failed assert is a bug in the
+        // server rather than a frame we could not read, so it surfaces even
+        // when a response still goes back; otherwise the message it carries
+        // would be lost behind the internal error.
+        if (error is AssertionError || !isRequest || response.isCompleted) {
+          Zone.current.handleUncaughtError(error, stackTrace);
+        }
         if (isRequest && !response.isCompleted) {
           response.complete(
             _errorResponse(
@@ -172,8 +178,6 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
               'The server sent an invalid response',
             ),
           );
-        } else {
-          Zone.current.handleUncaughtError(error, stackTrace);
         }
       }
     },
@@ -248,12 +252,26 @@ Map<String, Object?> _withServerFields(
       resultType != ResultTypes.complete;
   final cacheable = modern && !interim && _cacheableMethods.contains(method);
   // A hint the schema does not allow is not an answer, so it is replaced
-  // rather than sent on.
+  // rather than sent on. Answering with one is a bug in the server though, so
+  // assert on it as well: a test fails, while a server in production still
+  // gets an answer. A hint left out is not a bug, so it does not assert.
   final handlerTtlMs = result[Keys.ttlMs];
-  final addTtlMs = cacheable && !(handlerTtlMs is int && handlerTtlMs >= 0);
+  final ttlMsAllowed = handlerTtlMs is int && handlerTtlMs >= 0;
+  assert(
+    !cacheable || handlerTtlMs == null || ttlMsAllowed,
+    'A handler answered `${Keys.ttlMs}` with `$handlerTtlMs`, but the schema '
+    'only allows a non-negative integer.',
+  );
+  final addTtlMs = cacheable && !ttlMsAllowed;
   final handlerScope = result[Keys.cacheScope];
-  final addCacheScope =
-      cacheable && !CacheScope.values.any((s) => s.name == handlerScope);
+  final scopeAllowed = CacheScope.values.any((s) => s.name == handlerScope);
+  assert(
+    !cacheable || handlerScope == null || scopeAllowed,
+    'A handler answered `${Keys.cacheScope}` with `$handlerScope`, but the '
+    'schema only allows '
+    '${CacheScope.values.map((s) => '`${s.name}`').join(' and ')}.',
+  );
+  final addCacheScope = cacheable && !scopeAllowed;
 
   if (!addServerInfo && !addResultType && !addTtlMs && !addCacheScope) {
     return response;

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -30,10 +30,18 @@ typedef MCPServerFactory =
 /// otherwise. Returns the decoded JSON-RPC response for a request, and `null`
 /// for a notification, which per JSON-RPC gets no response. A successful
 /// result records the server's [MCPServer.implementation] under the reserved
-/// `io.modelcontextprotocol/serverInfo` result metadata key; a result which
-/// already carries a server info entry, and every error response, is returned
-/// unchanged. If the server closes before responding to a request, an
-/// internal-error response is returned instead. The server may still be
+/// `io.modelcontextprotocol/serverInfo` result metadata key, carries a
+/// `resultType`, and, for the requests the caching rules name, carries `ttlMs`
+/// and `cacheScope` unless it is an interim `resources/read` result, which is
+/// not cacheable. A field the handler set is kept when the schema allows it:
+/// a `resultType` left `null` becomes `complete`, a `ttlMs` which is `null`
+/// or below zero becomes `0`, and a `cacheScope` which is `null` or outside
+/// `public` and `private` becomes `private`. The dispatcher cannot know when
+/// an answer goes stale, and `public` is the one guess which could put a
+/// private answer in a cache shared across authorization contexts. None of
+/// this reaches a result on an earlier revision, and every error response is
+/// returned unchanged. If the server closes before responding to a request,
+/// an internal-error response is returned instead. The server may still be
 /// processing a notification when the returned future completes.
 ///
 /// The returned future completes once the server responds or the exchange
@@ -143,7 +151,14 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
             }
           case JsonRpc2Kind.response:
             if (!response.isCompleted) {
-              response.complete(_withServerInfo(data, server.implementation));
+              response.complete(
+                _withServerFields(
+                  data,
+                  server.implementation,
+                  method,
+                  initialization.protocolVersion,
+                ),
+              );
             }
         }
       } catch (error, stackTrace) {
@@ -194,23 +209,56 @@ Map<String, Object?> _errorResponse(Object? id, String message) => {
   Keys.error: {Keys.code: error_code.INTERNAL_ERROR, Keys.message: message},
 };
 
-/// Returns a copy of [response] with [implementation] recorded under the
-/// reserved `io.modelcontextprotocol/serverInfo` result metadata key.
+/// Returns a copy of [response] with the fields a server on this protocol
+/// revision must send and the handler for [method] did not, as
+/// [handleRequestScopedMessage] describes.
 ///
-/// Returns [response] unchanged when there is nothing to stamp: error
-/// responses have no result, and results which already carry a server info
-/// entry or whose metadata is not a string-keyed map are left alone.
-Map<String, Object?> _withServerInfo(
+/// Returns [response] unchanged when there is nothing to add: error responses
+/// have no result, and a result whose fields the handler set itself is already
+/// complete.
+Map<String, Object?> _withServerFields(
   Map<String, Object?> response,
   Implementation implementation,
+  String method,
+  ProtocolVersion protocolVersion,
 ) {
   final result = JsonRpc2Response.fromMap(response).result;
   if (result is! Map<String, Object?>) return response;
-  final existingMeta = result[Keys.meta];
-  if (existingMeta is! Map<String, Object?>?) return response;
-  if (existingMeta != null && existingMeta.containsKey(Keys.serverInfoMeta)) {
+
+  // These fields are 2026-07-28 vocabulary, so a server answering an earlier
+  // revision must not send any of them.
+  final modern = protocolVersion >= ProtocolVersion.v2026_07_28;
+
+  // Metadata which is not a string-keyed map is left alone rather than thrown
+  // on, so a server which sends one still gets an answer.
+  final meta = result[Keys.meta];
+  final existingMeta = meta is Map<String, Object?>? ? meta : null;
+  final addServerInfo =
+      modern &&
+      meta is Map<String, Object?>? &&
+      existingMeta?[Keys.serverInfoMeta] == null;
+  final resultType = result[Keys.resultType];
+  final addResultType = modern && resultType == null;
+  // Only a complete result is cacheable. `resources/read` is the one cacheable
+  // request the schema also answers with an interim result, so it is the only
+  // one whose result type can excuse the hints.
+  final interim =
+      method == ReadResourceRequest.methodName &&
+      resultType != null &&
+      resultType != ResultTypes.complete;
+  final cacheable = modern && !interim && _cacheableMethods.contains(method);
+  // A hint the schema does not allow is not an answer, so it is replaced
+  // rather than sent on.
+  final handlerTtlMs = result[Keys.ttlMs];
+  final addTtlMs = cacheable && !(handlerTtlMs is int && handlerTtlMs >= 0);
+  final handlerScope = result[Keys.cacheScope];
+  final addCacheScope =
+      cacheable && !CacheScope.values.any((s) => s.name == handlerScope);
+
+  if (!addServerInfo && !addResultType && !addTtlMs && !addCacheScope) {
     return response;
   }
+
   // With decoded channels there is no decode step between the server and this
   // dispatcher, so `result` can be the very map a handler returned. Handlers
   // may retain that map, and it may not even be modifiable (the built-in ping
@@ -220,12 +268,30 @@ Map<String, Object?> _withServerInfo(
     ...response,
     Keys.result: {
       ...result,
-      Keys.meta: {
-        ...?existingMeta,
-        Keys.serverInfoMeta: Map<String, Object?>.of(
-          implementation as Map<String, Object?>,
-        ),
-      },
+      if (addResultType) Keys.resultType: ResultTypes.complete,
+      if (addTtlMs) Keys.ttlMs: 0,
+      if (addCacheScope) Keys.cacheScope: CacheScope.private.name,
+      if (addServerInfo)
+        Keys.meta: {
+          ...?existingMeta,
+          Keys.serverInfoMeta: Map<String, Object?>.of(
+            implementation as Map<String, Object?>,
+          ),
+        },
     },
   };
 }
+
+/// The requests whose results a server must send caching hints on.
+///
+/// `server/discover` is on that list too, and joins this set when this package
+/// serves it.
+///
+/// https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching
+const _cacheableMethods = {
+  ListToolsRequest.methodName,
+  ListPromptsRequest.methodName,
+  ListResourcesRequest.methodName,
+  ListResourceTemplatesRequest.methodName,
+  ReadResourceRequest.methodName,
+};

--- a/pkgs/dart_mcp/lib/src/utils/constants.dart
+++ b/pkgs/dart_mcp/lib/src/utils/constants.dart
@@ -2,6 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+/// Constants for the values the specification names for [Keys.resultType].
+///
+/// A server may send any other string, so these are not an enum.
+extension ResultTypes on Never {
+  /// A result which is not waiting on anything, and the value the
+  /// specification tells a client to assume when the field is absent.
+  static const complete = 'complete';
+}
+
 /// Constants for all keys used in the MCP API.
 extension Keys on Never {
   static const accept = 'accept';

--- a/pkgs/dart_mcp/lib/src/utils/constants.dart
+++ b/pkgs/dart_mcp/lib/src/utils/constants.dart
@@ -5,10 +5,15 @@
 /// Constants for the values the specification names for [Keys.resultType].
 ///
 /// A server may send any other string, so these are not an enum.
+///
+/// See https://modelcontextprotocol.io/specification/latest/schema#resulttype.
 extension ResultTypes on Never {
   /// A result which is not waiting on anything, and the value the
   /// specification tells a client to assume when the field is absent.
   static const complete = 'complete';
+
+  /// A result which is waiting on input before the request can finish.
+  static const inputRequired = 'input_required';
 }
 
 /// Constants for all keys used in the MCP API.

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -188,39 +188,27 @@ void main() {
 
     test('rejects a ttl the schema does not allow', () async {
       final errors = <Object>[];
-      Map<String, Object?>? response;
       await runZonedGuarded(() async {
-        response = await _dispatchShapedList(
-          (result) => {...result, Keys.ttlMs: -1},
-        );
+        await _dispatchShapedList((result) => {...result, Keys.ttlMs: -1});
       }, (error, _) => errors.add(error));
 
-      if (_assertsEnabled) {
-        expect(errors.single, isA<AssertionError>());
-        expect(errors.single.toString(), contains(Keys.ttlMs));
-      } else {
-        expect(errors, isEmpty);
-        expect(_result(response), containsPair(Keys.ttlMs, 0));
-      }
-    });
+      expect(errors.single, isA<AssertionError>());
+      expect(errors.single.toString(), contains(Keys.ttlMs));
+      // A compiled executable has asserts stripped, so there is nothing to
+      // catch there.
+    }, testOn: '!exe');
 
     test('rejects a cache scope the schema does not allow', () async {
       final errors = <Object>[];
-      Map<String, Object?>? response;
       await runZonedGuarded(() async {
-        response = await _dispatchShapedList(
+        await _dispatchShapedList(
           (result) => {...result, Keys.cacheScope: 'shared'},
         );
       }, (error, _) => errors.add(error));
 
-      if (_assertsEnabled) {
-        expect(errors.single, isA<AssertionError>());
-        expect(errors.single.toString(), contains(Keys.cacheScope));
-      } else {
-        expect(errors, isEmpty);
-        expect(_result(response), containsPair(Keys.cacheScope, 'private'));
-      }
-    });
+      expect(errors.single, isA<AssertionError>());
+      expect(errors.single.toString(), contains(Keys.cacheScope));
+    }, testOn: '!exe');
 
     test('records caching hints despite a result type the schema does not '
         'give the request', () async {
@@ -814,16 +802,6 @@ MCPServerInitialization _initialization({
 
 Map<String, Object?> _result(Map<String, Object?>? response) =>
     response![Keys.result] as Map<String, Object?>;
-
-/// Whether this configuration runs with asserts enabled.
-///
-/// A compiled executable has them stripped, so a test which pins an assert has
-/// to pin the behavior a release build has instead.
-bool get _assertsEnabled {
-  var enabled = false;
-  assert(enabled = true);
-  return enabled;
-}
 
 /// Dispatches a `resources/read` to a server whose result is passed through
 /// [shape] first, so a test can say what the handler itself already set.

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -66,7 +66,10 @@ void main() {
         _initialization(),
       );
 
-      expect(_result(response), containsPair(Keys.resultType, 'complete'));
+      expect(
+        _result(response),
+        containsPair(Keys.resultType, ResultTypes.complete),
+      );
     });
 
     test('preserves the result type a handler chose', () async {
@@ -78,7 +81,7 @@ void main() {
 
       expect(
         _result(response),
-        containsPair(Keys.resultType, 'input_required'),
+        containsPair(Keys.resultType, ResultTypes.inputRequired),
       );
     });
 
@@ -199,7 +202,7 @@ void main() {
       // `tools/list` has no interim arm, so a non-complete type there does not
       // make the result one the caching rules exempt.
       final response = await _dispatchShapedList(
-        (result) => {...result, Keys.resultType: 'input_required'},
+        (result) => {...result, Keys.resultType: ResultTypes.inputRequired},
       );
 
       expect(_result(response), containsPair(Keys.ttlMs, 0));
@@ -210,7 +213,7 @@ void main() {
       // The schema gives `resources/read` an interim arm; `tools/list` has
       // none, so a list result is never the one waiting on input.
       final response = await _dispatchShapedRead(
-        (result) => {...result, Keys.resultType: 'input_required'},
+        (result) => {...result, Keys.resultType: ResultTypes.inputRequired},
       );
 
       expect(_result(response), isNot(contains(Keys.ttlMs)));
@@ -637,7 +640,7 @@ final class _DispatcherTestServer extends TestMCPServer
       Tool(name: 'interim', inputSchema: ObjectSchema()),
       (_) => CallToolResult.fromMap({
         Keys.content: [TextContent(text: 'waiting')],
-        Keys.resultType: 'input_required',
+        Keys.resultType: ResultTypes.inputRequired,
       }),
     );
     registerTool(

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -814,7 +814,6 @@ bool get _assertsEnabled {
 
 /// Dispatches a `resources/read` to a server whose result is passed through
 /// [shape] first, so a test can say what the handler itself already set.
-
 Future<Map<String, Object?>?> _dispatchShapedRead(
   Map<String, Object?> Function(Map<String, Object?> result) shape,
 ) => handleRequestScopedMessage(

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -173,28 +173,40 @@ void main() {
       expect(_result(withScope), containsPair(Keys.cacheScope, 'public'));
     });
 
-    test('asserts on a ttl the schema does not allow', () async {
-      // Answering with one is a bug in the server, so it is worth an assert
-      // even though a release build still replaces the hint and answers.
+    test('rejects a ttl the schema does not allow', () async {
       final errors = <Object>[];
+      Map<String, Object?>? response;
       await runZonedGuarded(() async {
-        await _dispatchShapedList((result) => {...result, Keys.ttlMs: -1});
+        response = await _dispatchShapedList(
+          (result) => {...result, Keys.ttlMs: -1},
+        );
       }, (error, _) => errors.add(error));
 
-      expect(errors.single, isA<AssertionError>());
-      expect(errors.single.toString(), contains(Keys.ttlMs));
+      if (_assertsEnabled) {
+        expect(errors.single, isA<AssertionError>());
+        expect(errors.single.toString(), contains(Keys.ttlMs));
+      } else {
+        expect(errors, isEmpty);
+        expect(_result(response), containsPair(Keys.ttlMs, 0));
+      }
     });
 
-    test('asserts on a cache scope the schema does not allow', () async {
+    test('rejects a cache scope the schema does not allow', () async {
       final errors = <Object>[];
+      Map<String, Object?>? response;
       await runZonedGuarded(() async {
-        await _dispatchShapedList(
+        response = await _dispatchShapedList(
           (result) => {...result, Keys.cacheScope: 'shared'},
         );
       }, (error, _) => errors.add(error));
 
-      expect(errors.single, isA<AssertionError>());
-      expect(errors.single.toString(), contains(Keys.cacheScope));
+      if (_assertsEnabled) {
+        expect(errors.single, isA<AssertionError>());
+        expect(errors.single.toString(), contains(Keys.cacheScope));
+      } else {
+        expect(errors, isEmpty);
+        expect(_result(response), containsPair(Keys.cacheScope, 'private'));
+      }
     });
 
     test('records caching hints despite a result type the schema does not '
@@ -790,8 +802,19 @@ MCPServerInitialization _initialization({
 Map<String, Object?> _result(Map<String, Object?>? response) =>
     response![Keys.result] as Map<String, Object?>;
 
+/// Whether this configuration runs with asserts enabled.
+///
+/// A compiled executable has them stripped, so a test which pins an assert has
+/// to pin the behavior a release build has instead.
+bool get _assertsEnabled {
+  var enabled = false;
+  assert(enabled = true);
+  return enabled;
+}
+
 /// Dispatches a `resources/read` to a server whose result is passed through
 /// [shape] first, so a test can say what the handler itself already set.
+
 Future<Map<String, Object?>?> _dispatchShapedRead(
   Map<String, Object?> Function(Map<String, Object?> result) shape,
 ) => handleRequestScopedMessage(

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -122,6 +122,19 @@ void main() {
 
       expect(_result(response), containsPair(Keys.ttlMs, 5000));
       expect(_result(response), containsPair(Keys.cacheScope, 'public'));
+
+      // Zero is the edge of what the schema allows, and a handler which sends
+      // it means it: the answer is stale as soon as it arrives.
+      final errors = <Object>[];
+      Map<String, Object?>? withZero;
+      await runZonedGuarded(() async {
+        withZero = await _dispatchShapedList(
+          (result) => {...result, Keys.ttlMs: 0},
+        );
+      }, (error, _) => errors.add(error));
+
+      expect(errors, isEmpty);
+      expect(_result(withZero), containsPair(Keys.ttlMs, 0));
     });
 
     test('sends none of these fields on an earlier revision', () async {

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -170,13 +170,28 @@ void main() {
       expect(_result(withScope), containsPair(Keys.cacheScope, 'public'));
     });
 
-    test('replaces a caching hint the schema does not allow', () async {
-      final response = await _dispatchShapedList(
-        (result) => {...result, Keys.ttlMs: -1, Keys.cacheScope: 'shared'},
-      );
+    test('asserts on a ttl the schema does not allow', () async {
+      // Answering with one is a bug in the server, so it is worth an assert
+      // even though a release build still replaces the hint and answers.
+      final errors = <Object>[];
+      await runZonedGuarded(() async {
+        await _dispatchShapedList((result) => {...result, Keys.ttlMs: -1});
+      }, (error, _) => errors.add(error));
 
-      expect(_result(response), containsPair(Keys.ttlMs, 0));
-      expect(_result(response), containsPair(Keys.cacheScope, 'private'));
+      expect(errors.single, isA<AssertionError>());
+      expect(errors.single.toString(), contains(Keys.ttlMs));
+    });
+
+    test('asserts on a cache scope the schema does not allow', () async {
+      final errors = <Object>[];
+      await runZonedGuarded(() async {
+        await _dispatchShapedList(
+          (result) => {...result, Keys.cacheScope: 'shared'},
+        );
+      }, (error, _) => errors.add(error));
+
+      expect(errors.single, isA<AssertionError>());
+      expect(errors.single.toString(), contains(Keys.cacheScope));
     });
 
     test('records caching hints despite a result type the schema does not '

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -59,6 +59,149 @@ void main() {
       expect(serverInfo.name, 'already there');
     });
 
+    test('records a result type on the response', () async {
+      final harness = _DispatcherHarness();
+      final response = await harness.dispatch(
+        _callTool('probe'),
+        _initialization(),
+      );
+
+      expect(_result(response), containsPair(Keys.resultType, 'complete'));
+    });
+
+    test('preserves the result type a handler chose', () async {
+      final harness = _DispatcherHarness();
+      final response = await harness.dispatch(
+        _callTool('interim'),
+        _initialization(),
+      );
+
+      expect(
+        _result(response),
+        containsPair(Keys.resultType, 'input_required'),
+      );
+    });
+
+    test('records caching hints on a result which takes them', () async {
+      final harness = _DispatcherHarness();
+      final response = await harness.dispatch(_listTools(), _initialization());
+
+      expect(_result(response), containsPair(Keys.ttlMs, 0));
+      expect(_result(response), containsPair(Keys.cacheScope, 'private'));
+    });
+
+    test('leaves caching hints off results which do not take them', () async {
+      final harness = _DispatcherHarness();
+      final response = await harness.dispatch(
+        _callTool('probe'),
+        _initialization(),
+      );
+
+      expect(_result(response), isNot(contains(Keys.ttlMs)));
+      expect(_result(response), isNot(contains(Keys.cacheScope)));
+    });
+
+    test('records caching hints on a read as well as a list', () async {
+      final harness = _DispatcherHarness();
+      final response = await harness.dispatch(
+        _readResource(),
+        _initialization(),
+      );
+
+      expect(_result(response), containsPair(Keys.ttlMs, 0));
+      expect(_result(response), containsPair(Keys.cacheScope, 'private'));
+    });
+
+    test('preserves the caching hints a handler chose', () async {
+      final response = await _dispatchShapedList(
+        (result) => {...result, Keys.ttlMs: 5000, Keys.cacheScope: 'public'},
+      );
+
+      expect(_result(response), containsPair(Keys.ttlMs, 5000));
+      expect(_result(response), containsPair(Keys.cacheScope, 'public'));
+    });
+
+    test('sends none of these fields on an earlier revision', () async {
+      // All of them are 2026-07-28 vocabulary, including the reserved
+      // metadata key.
+      final harness = _DispatcherHarness();
+      final response = await harness.dispatch(
+        _listTools(),
+        _initialization(protocolVersion: ProtocolVersion.v2025_11_25),
+      );
+
+      expect(_result(response), isNot(contains(Keys.resultType)));
+      expect(_result(response), isNot(contains(Keys.ttlMs)));
+      expect(_result(response), isNot(contains(Keys.cacheScope)));
+      expect(_result(response), isNot(contains(Keys.meta)));
+    });
+
+    test('fills in fields a handler left null', () async {
+      // A null is a field the handler did not answer, not an answer of null:
+      // sending one on the wire would be a value the schema does not allow.
+      final response = await _dispatchShapedList(
+        (result) => {
+          ...result,
+          Keys.resultType: null,
+          Keys.ttlMs: null,
+          Keys.cacheScope: null,
+        },
+      );
+
+      expect(
+        _result(response),
+        containsPair(Keys.resultType, ResultTypes.complete),
+      );
+      expect(_result(response), containsPair(Keys.ttlMs, 0));
+      expect(_result(response), containsPair(Keys.cacheScope, 'private'));
+    });
+
+    test('fills in the caching hint a handler left out', () async {
+      final withTtl = await _dispatchShapedList(
+        (result) => {...result, Keys.ttlMs: 5000},
+      );
+      expect(_result(withTtl), containsPair(Keys.ttlMs, 5000));
+      expect(_result(withTtl), containsPair(Keys.cacheScope, 'private'));
+
+      final withScope = await _dispatchShapedList(
+        (result) => {...result, Keys.cacheScope: 'public'},
+      );
+      expect(_result(withScope), containsPair(Keys.ttlMs, 0));
+      expect(_result(withScope), containsPair(Keys.cacheScope, 'public'));
+    });
+
+    test('replaces a caching hint the schema does not allow', () async {
+      final response = await _dispatchShapedList(
+        (result) => {...result, Keys.ttlMs: -1, Keys.cacheScope: 'shared'},
+      );
+
+      expect(_result(response), containsPair(Keys.ttlMs, 0));
+      expect(_result(response), containsPair(Keys.cacheScope, 'private'));
+    });
+
+    test('records caching hints despite a result type the schema does not '
+        'give the request', () async {
+      // `tools/list` has no interim arm, so a non-complete type there does not
+      // make the result one the caching rules exempt.
+      final response = await _dispatchShapedList(
+        (result) => {...result, Keys.resultType: 'input_required'},
+      );
+
+      expect(_result(response), containsPair(Keys.ttlMs, 0));
+      expect(_result(response), containsPair(Keys.cacheScope, 'private'));
+    });
+
+    test('leaves caching hints off an interim result', () async {
+      // The schema gives `resources/read` an interim arm; `tools/list` has
+      // none, so a list result is never the one waiting on input.
+      final response = await _dispatchShapedRead(
+        (result) => {...result, Keys.resultType: 'input_required'},
+      );
+
+      expect(_result(response), isNot(contains(Keys.ttlMs)));
+      expect(_result(response), isNot(contains(Keys.cacheScope)));
+    });
+
     test('answers even when a result has malformed metadata', () async {
       final harness = _DispatcherHarness();
       final response = await harness.dispatch(
@@ -434,7 +577,7 @@ final class _DispatcherHarness {
 
 /// A server with tools which observe the request-scoped lifecycle.
 final class _DispatcherTestServer extends TestMCPServer
-    with LoggingSupport, ToolsSupport {
+    with LoggingSupport, ResourcesSupport, ToolsSupport {
   static const testNotification = 'notifications/test';
 
   _DispatcherTestServer(super.channel);
@@ -467,6 +610,19 @@ final class _DispatcherTestServer extends TestMCPServer
             version: '1.0.0',
           ),
         },
+      }),
+    );
+    addResource(
+      Resource(uri: 'file:///probe', name: 'probe'),
+      (_) async => ReadResourceResult(
+        contents: [TextResourceContents(uri: 'file:///probe', text: 'probe')],
+      ),
+    );
+    registerTool(
+      Tool(name: 'interim', inputSchema: ObjectSchema()),
+      (_) => CallToolResult.fromMap({
+        Keys.content: [TextContent(text: 'waiting')],
+        Keys.resultType: 'input_required',
       }),
     );
     registerTool(
@@ -537,6 +693,43 @@ final class _FailingInitServer extends TestMCPServer {
   ) => throw StateError('initialization failed');
 }
 
+/// A server whose `resources/read` answers with whatever [shape] returns.
+final class _ShapedReadServer extends TestMCPServer with ResourcesSupport {
+  _ShapedReadServer(super.channel, this.shape);
+
+  final Map<String, Object?> Function(Map<String, Object?> result) shape;
+
+  @override
+  FutureOr<ServerCapabilities> initialize(
+    MCPServerInitialization initialization,
+  ) {
+    addResource(
+      Resource(uri: 'file:///probe', name: 'probe'),
+      (_) async => ReadResourceResult(contents: []),
+    );
+    return super.initialize(initialization);
+  }
+
+  @override
+  Future<ReadResourceResult> readResource(ReadResourceRequest request) async =>
+      ReadResourceResult.fromMap(
+        shape(await super.readResource(request) as Map<String, Object?>),
+      );
+}
+
+/// A server whose `tools/list` answers with whatever [shape] returns.
+final class _ShapedListServer extends TestMCPServer with ToolsSupport {
+  _ShapedListServer(super.channel, this.shape);
+
+  final Map<String, Object?> Function(Map<String, Object?> result) shape;
+
+  @override
+  Future<ListToolsResult> listTools([ListToolsRequest? request]) async =>
+      ListToolsResult.fromMap(
+        shape(await super.listTools(request) as Map<String, Object?>),
+      );
+}
+
 Map<String, Object?> _callTool(
   String name, {
   Map<String, Object?> arguments = const {},
@@ -545,6 +738,13 @@ Map<String, Object?> _callTool(
   Keys.id: 1,
   Keys.method: CallToolRequest.methodName,
   Keys.params: {Keys.name: name, Keys.arguments: arguments},
+};
+
+Map<String, Object?> _readResource() => {
+  Keys.jsonrpc: '2.0',
+  Keys.id: 1,
+  Keys.method: ReadResourceRequest.methodName,
+  Keys.params: {Keys.uri: 'file:///probe'},
 };
 
 Map<String, Object?> _listTools() => {
@@ -559,11 +759,35 @@ Map<String, Object?> _ping() => {
   Keys.method: PingRequest.methodName,
 };
 
-MCPServerInitialization _initialization({ClientCapabilities? capabilities}) =>
-    MCPServerInitialization(
-      protocolVersion: ProtocolVersion.latestSupported,
-      clientCapabilities: capabilities ?? ClientCapabilities(),
-    );
+/// The request-scoped lifecycle arrived with 2026-07-28, so that is the
+/// revision these dispatch, unless a test says otherwise.
+MCPServerInitialization _initialization({
+  ClientCapabilities? capabilities,
+  ProtocolVersion protocolVersion = ProtocolVersion.v2026_07_28,
+}) => MCPServerInitialization(
+  protocolVersion: protocolVersion,
+  clientCapabilities: capabilities ?? ClientCapabilities(),
+);
 
 Map<String, Object?> _result(Map<String, Object?>? response) =>
     response![Keys.result] as Map<String, Object?>;
+
+/// Dispatches a `resources/read` to a server whose result is passed through
+/// [shape] first, so a test can say what the handler itself already set.
+Future<Map<String, Object?>?> _dispatchShapedRead(
+  Map<String, Object?> Function(Map<String, Object?> result) shape,
+) => handleRequestScopedMessage(
+  _readResource(),
+  _initialization(),
+  (channel) => _ShapedReadServer(channel, shape),
+);
+
+/// Dispatches a `tools/list` to a server whose result is passed through
+/// [shape] first, so a test can say what the handler itself already set.
+Future<Map<String, Object?>?> _dispatchShapedList(
+  Map<String, Object?> Function(Map<String, Object?> result) shape,
+) => handleRequestScopedMessage(
+  _listTools(),
+  _initialization(),
+  (channel) => _ShapedListServer(channel, shape),
+);


### PR DESCRIPTION
Next 2026-07-28 core-protocol slice tracked in #162, following #565 and #570: the request-scoped dispatcher now sends `resultType`, `ttlMs`, and `cacheScope`. #579 is the other half, how a handler supplies the two hints itself.

Both landed read-only, and both closed with a note that server-side emission was a later slice.

- Every result on 2026-07-28 carries a `resultType`. The schema types the field as required for a server on this revision (https://modelcontextprotocol.io/specification/2026-07-28/schema#result-resulttype), and the dispatcher was leaving it off, so every result the Streamable HTTP handler returned was missing it.
- The list and read results also carry the caching hints those rules require (https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching). `resources/read` is the one of them the schema also answers with an interim result (https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr), so it is the only one whose result type excuses the hints.
- All of it is gated on the negotiated revision, including the reserved `_meta` key from #528: it is 2026-07-28 vocabulary too. `handleRequestScopedMessage` takes the version in its `MCPServerInitialization` and is exported for transports this package does not own, so it cannot assume the revision the way `handleStreamableHttpRequest` can.
- A field the handler set is kept when the schema allows it; an assert catches one it does not, and the dartdoc on `handleRequestScopedMessage` lists what replaces it in a build with asserts disabled.

This sits in the server info stamping from #528 rather than in the result factories, because the fields belong to a protocol revision and the same server also serves 2025-11-25 over stdio.

`'complete'` moved to `ResultTypes` in `constants.dart`, so the value the reader folds to and the value the dispatcher writes are one definition.

## Tests

- A result type is recorded, and one the handler chose is kept. The hints are recorded on `tools/list` and on `resources/read`, and not on `tools/call`. Hints the handler chose are kept, one hint given and one left out is completed, and fields left `null` are replaced. An interim `resources/read` gets no hints while an interim-typed `tools/list` still gets them. An earlier revision gets none of it. All asserted on the result map, since no existing test pins the set of keys on a result. A value the schema rejects fails an assert instead.
- The dispatch tests now negotiate 2026-07-28, since the request-scoped lifecycle arrived with it; the earlier revision has its own test.
- `dart test -p chrome,vm -c dart2wasm,dart2js,kernel,exe` passes (1094 tests across the four configurations).
- `dart analyze --fatal-infos` is clean here and in `mcp_examples` resolved against this branch.

Part of #162.


