### PR TITLE
fix RequestId so it can hold a JSON-RPC id

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -68,6 +68,11 @@
   and `.unsupportedProtocolVersion`. The same registry reserves `-32042`, so
   `urlElicitationRequired` now documents that only the 2025-11-25 revision
   emits it.
+- Fix `RequestId` so it can hold a JSON-RPC id. Its representation type was
+  `json_rpc_2`'s `Parameter` rather than `Object`, which its sibling
+  `ProgressToken` uses, so `CancelledNotification.requestId` threw for every
+  id a peer can send and no id could be constructed to pass to the
+  `CancelledNotification` factory.
 - Add `ProtocolVersion.v2026_07_28`. `ProtocolVersion.latestSupported` still
   points at 2025-11-25, the newest version the legacy `initialize` handshake
   negotiates; transports for the request-scoped protocol carry their own set

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -9,7 +9,6 @@ library;
 import 'dart:collection';
 
 import 'package:collection/collection.dart';
-import 'package:json_rpc_2/json_rpc_2.dart';
 
 import '../utils/constants.dart';
 
@@ -240,7 +239,7 @@ extension type CancelledNotification.fromMap(Map<String, Object?> _value)
 }
 
 /// An opaque request ID.
-extension type RequestId(/*String|int*/ Parameter _) {}
+extension type RequestId(/*String|int*/ Object _) {}
 
 /// A ping, issued by either the server or the client, to check that the other
 /// party is still alive.

--- a/pkgs/dart_mcp/test/api/api_test.dart
+++ b/pkgs/dart_mcp/test/api/api_test.dart
@@ -176,5 +176,15 @@ void main() {
       expect(listTools.ttlMs, 5000);
       expect(listTools.cacheScope, CacheScope.public);
     });
+    test('request ids round trip both JSON-RPC id types', () {
+      for (var id in <Object>[7, 'abc']) {
+        final cancelled = CancelledNotification(requestId: RequestId(id));
+        expect(
+          cancelled as Map<String, Object?>,
+          containsPair('requestId', id),
+        );
+        expect(cancelled.requestId, id);
+      }
+    });
   });
 }


### PR DESCRIPTION
`RequestId` is an extension type over `json_rpc_2`'s `Parameter`, while its
sibling `ProgressToken` uses `Object` for the same `String|int` union. Reading
`CancelledNotification.requestId` therefore throws for every id a peer can
send, and no id can be constructed to pass to the factory:

```
type 'int' is not a subtype of type 'Parameter?' in type cast
package:dart_mcp/src/api/api.dart 235:54  CancelledNotification.requestId
```

Nothing reads or builds `CancelledNotification` in this package, which is why
this went unnoticed. Changing the representation to `Object` drops the last
`json_rpc_2` import from `api.dart`.

## Tests

- A `CancelledNotification` round-trips an `int` id and a `String` id.
- `dart test` passes (294 tests).
