### PR TITLE
publish dart_mcp_server version 1.1.1

### DIFF
--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.1-wip
+## 1.1.1
 
 - Improve server instructions and error messages to encourage agents to
   proactively connect to running applications and hot reload after changes.

--- a/pkgs/dart_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_mcp_server/lib/src/server.dart
@@ -113,7 +113,7 @@ package.
   /// The version of the MCP server.
   ///
   /// Should match the version in `pubspec.yaml` and `CHANGELOG.md`.
-  static final version = '1.1.1-wip';
+  static final version = '1.1.1';
 
   /// Runs the MCP server given command line arguments and an optional
   /// [Analytics] instance.

--- a/pkgs/dart_mcp_server/pubspec.yaml
+++ b/pkgs/dart_mcp_server/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/dart-lang/ai/tree/main/pkgs/dart_mcp_server
 issue_tracker: https://github.com/dart-lang/ai/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Adart_mcp_server
 
 # NOTE: Must also update version in pkgs/dart_mcp_server/lib/src/server.dart
-version: 1.1.1-wip
+version: 1.1.1
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
This includes some additional instructions and better errors for hot reload related tasks.