### PR TITLE
add the server/discover types from protocol 2026-07-28

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -87,8 +87,11 @@
   `DiscoverResult` implements `CacheableResult`, and reads
   `supportedVersions` as a `List<String>` rather than a
   `List<ProtocolVersion>`, because a server may list a version this package
-  has no name for and the client is the one choosing between them. This adds
-  the types only; the server does not answer `server/discover` yet.
+  has no name for and the client is the one choosing between them. Its factory
+  takes `ttlMs` and `cacheScope` on the same terms as the other five cacheable
+  results, so the sixth operation the caching rules name is no longer the one
+  which cannot carry the hints. This adds the types only; the server does not
+  answer `server/discover` yet.
 - Add `package:dart_mcp/streamable_http.dart` with
   `handleStreamableHttpRequest`, the server side of the Streamable HTTP
   transport from the 2026-07-28 revision, see

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -81,6 +81,14 @@
   points at 2025-11-25, the newest version the legacy `initialize` handshake
   negotiates; transports for the request-scoped protocol carry their own set
   of supported versions.
+- Add `DiscoverRequest` and `DiscoverResult`, modeling the `server/discover`
+  request that the 2026-07-28 revision requires servers to implement, see
+  https://modelcontextprotocol.io/specification/2026-07-28/server/discover.
+  `DiscoverResult` implements `CacheableResult`, and reads
+  `supportedVersions` as a `List<String>` rather than a
+  `List<ProtocolVersion>`, because a server may list a version this package
+  has no name for and the client is the one choosing between them. This adds
+  the types only; the server does not answer `server/discover` yet.
 - Add `package:dart_mcp/streamable_http.dart` with
   `handleStreamableHttpRequest`, the server side of the Streamable HTTP
   transport from the 2026-07-28 revision, see

--- a/pkgs/dart_mcp/lib/src/api/initialization.dart
+++ b/pkgs/dart_mcp/lib/src/api/initialization.dart
@@ -104,6 +104,65 @@ extension type InitializedNotification.fromMap(Map<String, Object?> _value)
       InitializedNotification.fromMap({if (meta != null) Keys.meta: meta});
 }
 
+/// A request from the client asking the server to advertise its supported
+/// protocol versions, capabilities, and other metadata.
+///
+/// Servers on protocol version 2026-07-28 MUST implement this method. Clients
+/// MAY call it but are not required to: a client can also send any request
+/// inline and handle the error if the server does not support the version it
+/// asked for.
+///
+/// It has no parameters of its own beyond the `_meta` envelope that every
+/// request on this revision sends.
+extension type DiscoverRequest.fromMap(Map<String, Object?> _value)
+    implements Request {
+  static const methodName = 'server/discover';
+
+  factory DiscoverRequest({MetaWithProgressToken? meta}) =>
+      DiscoverRequest.fromMap({if (meta != null) Keys.meta: meta});
+}
+
+/// The server's response to a [DiscoverRequest] from the client.
+extension type DiscoverResult.fromMap(Map<String, Object?> _value)
+    implements CacheableResult {
+  factory DiscoverResult({
+    required List<String> supportedVersions,
+    required ServerCapabilities capabilities,
+    String? instructions,
+    Meta? meta,
+  }) => DiscoverResult.fromMap({
+    Keys.supportedVersions: supportedVersions,
+    Keys.capabilities: capabilities,
+    if (instructions != null) Keys.instructions: instructions,
+    if (meta != null) Keys.meta: meta,
+  });
+
+  /// The protocol versions this server supports.
+  ///
+  /// The client should choose one of these to use for its subsequent
+  /// requests.
+  ///
+  /// These are the version strings as they appear on the wire rather than
+  /// [ProtocolVersion] values. That enum is a closed set, so a version this
+  /// package does not know would be dropped from the list the client is
+  /// choosing between.
+  List<String> get supportedVersions =>
+      (_value[Keys.supportedVersions] as List).cast<String>();
+
+  /// The capabilities of the server.
+  ServerCapabilities get capabilities =>
+      _value[Keys.capabilities] as ServerCapabilities;
+
+  /// Natural-language guidance describing the server and its features.
+  ///
+  /// This can be used by clients to improve an LLM's understanding of
+  /// available tools, for instance by including it in a system prompt. It
+  /// should focus on information that helps the model use the server
+  /// effectively, and should not duplicate information already in tool
+  /// descriptions.
+  String? get instructions => _value[Keys.instructions] as String?;
+}
+
 /// Capabilities a client may support.
 ///
 /// Known capabilities are defined here, in this schema, but this is not a

--- a/pkgs/dart_mcp/lib/src/api/initialization.dart
+++ b/pkgs/dart_mcp/lib/src/api/initialization.dart
@@ -153,12 +153,24 @@ extension type DiscoverResult.fromMap(Map<String, Object?> _value)
   /// [ProtocolVersion] values. That enum is a closed set, so a version this
   /// package does not know would be dropped from the list the client is
   /// choosing between.
-  List<String> get supportedVersions =>
-      (_value[Keys.supportedVersions] as List).cast<String>();
+  List<String> get supportedVersions {
+    final supportedVersions = _value[Keys.supportedVersions] as List?;
+    if (supportedVersions == null) {
+      throw ArgumentError(
+        'Missing supportedVersions field in $DiscoverResult.',
+      );
+    }
+    return supportedVersions.cast<String>();
+  }
 
   /// The capabilities of the server.
-  ServerCapabilities get capabilities =>
-      _value[Keys.capabilities] as ServerCapabilities;
+  ServerCapabilities get capabilities {
+    final capabilities = _value[Keys.capabilities] as ServerCapabilities?;
+    if (capabilities == null) {
+      throw ArgumentError('Missing capabilities field in $DiscoverResult.');
+    }
+    return capabilities;
+  }
 
   /// Natural-language guidance describing the server and its features.
   ///

--- a/pkgs/dart_mcp/lib/src/api/initialization.dart
+++ b/pkgs/dart_mcp/lib/src/api/initialization.dart
@@ -129,13 +129,20 @@ extension type DiscoverResult.fromMap(Map<String, Object?> _value)
     required List<String> supportedVersions,
     required ServerCapabilities capabilities,
     String? instructions,
+    int? ttlMs,
+    CacheScope? cacheScope,
     Meta? meta,
-  }) => DiscoverResult.fromMap({
-    Keys.supportedVersions: supportedVersions,
-    Keys.capabilities: capabilities,
-    if (instructions != null) Keys.instructions: instructions,
-    if (meta != null) Keys.meta: meta,
-  });
+  }) {
+    assert(ttlMs == null || ttlMs >= 0);
+    return DiscoverResult.fromMap({
+      Keys.supportedVersions: supportedVersions,
+      Keys.capabilities: capabilities,
+      if (instructions != null) Keys.instructions: instructions,
+      if (ttlMs != null) Keys.ttlMs: ttlMs,
+      if (cacheScope != null) Keys.cacheScope: cacheScope.name,
+      if (meta != null) Keys.meta: meta,
+    });
+  }
 
   /// The protocol versions this server supports.
   ///

--- a/pkgs/dart_mcp/lib/src/utils/constants.dart
+++ b/pkgs/dart_mcp/lib/src/utils/constants.dart
@@ -142,6 +142,7 @@ extension Keys on Never {
   static const structuredContent = 'structuredContent';
   static const subscribe = 'subscribe';
   static const supported = 'supported';
+  static const supportedVersions = 'supportedVersions';
   static const systemPrompt = 'systemPrompt';
   static const temperature = 'temperature';
   static const text = 'text';

--- a/pkgs/dart_mcp/test/api/api_test.dart
+++ b/pkgs/dart_mcp/test/api/api_test.dart
@@ -91,6 +91,11 @@ void main() {
         () => (empty as InitializeRequest).clientInfo,
         throwsArgumentError,
       );
+      expect(
+        () => (empty as DiscoverResult).supportedVersions,
+        throwsArgumentError,
+      );
+      expect(() => (empty as DiscoverResult).capabilities, throwsArgumentError);
 
       // Tools
       expect(() => (empty as CallToolRequest).name, throwsArgumentError);

--- a/pkgs/dart_mcp/test/api/api_test.dart
+++ b/pkgs/dart_mcp/test/api/api_test.dart
@@ -190,8 +190,7 @@ void main() {
 
   group('cacheable result factory', () {
     // Returns an instance of every cacheable result type with the given
-    // settings, except `server/discover`, which this package does not serve
-    // yet. The tests assert on the map rather than the getters: an absent
+    // settings. The tests assert on the map rather than the getters: an absent
     // `ttlMs` and a written `ttlMs: 0` both read as `0`.
     List<Map<String, Object?>> cacheable({
       int? ttlMs,
@@ -212,6 +211,12 @@ void main() {
           ),
           ReadResourceResult(
             contents: [],
+            ttlMs: ttlMs,
+            cacheScope: cacheScope,
+          ),
+          DiscoverResult(
+            supportedVersions: [],
+            capabilities: ServerCapabilities(),
             ttlMs: ttlMs,
             cacheScope: cacheScope,
           ),

--- a/pkgs/dart_mcp/test/api/initialization_test.dart
+++ b/pkgs/dart_mcp/test/api/initialization_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:dart_mcp/server.dart';
 import 'package:test/test.dart';
 
@@ -92,12 +94,18 @@ void main() {
     });
 
     test('the result reads its fields back off a decoded map', () {
-      final result = DiscoverResult.fromMap({
-        'supportedVersions': ['2026-07-28'],
-        'capabilities': ServerCapabilities(tools: Tools()),
-        'instructions': 'Prefer `get_weather` for forecast lookups.',
-      });
+      final result = DiscoverResult.fromMap(
+        jsonDecode('''
+{
+  "supportedVersions": ["2026-07-28"],
+  "capabilities": {"tools": {}},
+  "instructions": "Prefer `get_weather` for forecast lookups."
+}
+''')
+            as Map<String, Object?>,
+      );
 
+      expect(result.supportedVersions, ['2026-07-28']);
       expect(result.capabilities.tools, isNotNull);
       expect(result.instructions, 'Prefer `get_weather` for forecast lookups.');
     });

--- a/pkgs/dart_mcp/test/api/initialization_test.dart
+++ b/pkgs/dart_mcp/test/api/initialization_test.dart
@@ -91,6 +91,21 @@ void main() {
       expect(result, isNot(contains('_meta')));
     });
 
+    test('the method name is the one the schema gives', () {
+      expect(DiscoverRequest.methodName, 'server/discover');
+    });
+
+    test('the result reads its fields back off a decoded map', () {
+      final result = DiscoverResult.fromMap({
+        'supportedVersions': ['2026-07-28'],
+        'capabilities': ServerCapabilities(tools: Tools()),
+        'instructions': 'Prefer `get_weather` for forecast lookups.',
+      });
+
+      expect(result.capabilities.tools, isNotNull);
+      expect(result.instructions, 'Prefer `get_weather` for forecast lookups.');
+    });
+
     test('the result reports a version this package does not know', () {
       // The point of reading these as strings: dropping the versions
       // `ProtocolVersion` has no name for would hide them from the client

--- a/pkgs/dart_mcp/test/api/initialization_test.dart
+++ b/pkgs/dart_mcp/test/api/initialization_test.dart
@@ -91,10 +91,6 @@ void main() {
       expect(result, isNot(contains('_meta')));
     });
 
-    test('the method name is the one the schema gives', () {
-      expect(DiscoverRequest.methodName, 'server/discover');
-    });
-
     test('the result reads its fields back off a decoded map', () {
       final result = DiscoverResult.fromMap({
         'supportedVersions': ['2026-07-28'],

--- a/pkgs/dart_mcp/test/api/initialization_test.dart
+++ b/pkgs/dart_mcp/test/api/initialization_test.dart
@@ -28,4 +28,81 @@ void main() {
     final map = result as Map<String, Object?>;
     expect(map['instructions'], equals('foo'));
   });
+
+  // The factory tests assert on the map rather than on the getters, so that a
+  // field the factory never wrote cannot be mistaken for one it wrote.
+  group('server/discover', () {
+    test('the request carries no parameters of its own', () {
+      expect(DiscoverRequest() as Map<String, Object?>, isEmpty);
+    });
+
+    test('the request writes the metadata it is given', () {
+      final request =
+          DiscoverRequest(
+                meta: MetaWithProgressToken(progressToken: ProgressToken(1)),
+              )
+              as Map<String, Object?>;
+
+      expect(request['_meta'], containsPair('progressToken', ProgressToken(1)));
+    });
+
+    test('the result writes the fields it is given', () {
+      final result =
+          DiscoverResult(
+                supportedVersions: ['2026-07-28'],
+                capabilities: ServerCapabilities(tools: Tools()),
+                instructions: 'Prefer `get_weather` for forecast lookups.',
+                meta: Meta.fromMap({
+                  'io.modelcontextprotocol/serverInfo': Implementation(
+                    name: 'name',
+                    version: 'version',
+                  ),
+                }),
+              )
+              as Map<String, Object?>;
+
+      expect(result, containsPair('supportedVersions', ['2026-07-28']));
+      expect(result['capabilities'], containsPair('tools', isEmpty));
+      expect(
+        result,
+        containsPair(
+          'instructions',
+          'Prefer `get_weather` for forecast lookups.',
+        ),
+      );
+      expect(
+        result['_meta'],
+        containsPair(
+          'io.modelcontextprotocol/serverInfo',
+          containsPair('name', 'name'),
+        ),
+      );
+    });
+
+    test('the result leaves out the fields it is not given', () {
+      final result =
+          DiscoverResult(
+                supportedVersions: ['2026-07-28'],
+                capabilities: ServerCapabilities(),
+              )
+              as Map<String, Object?>;
+
+      expect(result, isNot(contains('instructions')));
+      expect(result, isNot(contains('_meta')));
+    });
+
+    test('the result reports a version this package does not know', () {
+      // The point of reading these as strings: dropping the versions
+      // `ProtocolVersion` has no name for would hide them from the client
+      // that has to choose one.
+      expect(ProtocolVersion.tryParse('2027-11-05'), isNull);
+
+      final result = DiscoverResult.fromMap({
+        'supportedVersions': ['2026-07-28', '2027-11-05'],
+        'capabilities': ServerCapabilities(),
+      });
+
+      expect(result.supportedVersions, ['2026-07-28', '2027-11-05']);
+    });
+  });
 }


### PR DESCRIPTION
Next 2026-07-28 core-protocol slice tracked in #162, following #570 and #579: the types for `server/discover`, the unlanded core support named in the [finalized-spec diff report](https://github.com/dart-lang/ai/issues/162#issuecomment-5108248966).

Servers on this revision must implement the method, and the package already points at it: `example/README.md` says a client that calls it gets `-32601` back, and the dartdoc on `handleRequestScopedMessage` tells readers that clients in this lifecycle "discover capabilities with `server/discover` rather than per message". Both stay true, since this adds the types without wiring the method into the dispatcher.

- `DiscoverRequest` carries nothing of its own: the schema gives it only the `_meta` envelope, and `handleStreamableHttpRequest` rejects a request that arrives without one.
- Until now the factory tests skipped `server/discover`, "which this package does not serve yet" and which had no type to construct in any case. `DiscoverResult` implements `CacheableResult` and its factory takes `ttlMs` and `cacheScope` on the same terms as the five factories from #579, so that carve-out comes off and the group iterates all six.
- `supportedVersions` is a `List<String>`, not a `List<ProtocolVersion>`, because that enum is a closed set and `tryParse` answers null for anything it cannot name.
- `serverInfo` is not a field on the result. The finalized revision moved it into the reserved `io.modelcontextprotocol/serverInfo` metadata key. `handleRequestScopedMessage` fills that key in when a handler leaves it out.

## Tests

- The request's map is empty until it is given metadata, and the result writes the fields it is given and leaves out the ones it is not; those are asserted on the map, as in #579. A decoded map reads back through the getters, and the closed-enum case is pinned directly: `2027-11-05` fails `ProtocolVersion.tryParse` and still comes through `supportedVersions`.
- `dart test -p chrome,vm -c dart2wasm,dart2js,kernel,exe` passes (1118 tests across the four configurations, the six new ones in all of them).
- `dart analyze --fatal-infos` is clean here and in `mcp_examples` resolved against this branch.

Part of #162.
