### PR TITLE
report -32602 when a resource URI has no handler

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -30,6 +30,13 @@
     `MCPServer.clientInfo` is now nullable (`Implementation?`).
   - Override `MCPServer.initializeLegacy` only to customize the legacy
     initialize response or version negotiation.
+  - `ResourcesSupport.readResource` now answers a URI it has no resource or
+    template for with the `-32602` (invalid params) error the 2026-07-28
+    revision requires, carrying the URI as `data.uri`, instead of letting an
+    `ArgumentError` reach the client as a generic `-32000` server error with a
+    Dart stack trace attached. A server which overrides `readResource` and
+    catches the `ArgumentError` its dartdoc used to promise needs to catch
+    `RpcException` from `package:json_rpc_2` instead.
 - Add `handleRequestScopedMessage` and `MCPServerFactory`, which serve each
   decoded JSON-RPC message on a fresh server instance for request-scoped
   transports. On 2026-07-28, successful results record the server

--- a/pkgs/dart_mcp/lib/src/server/resources_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/resources_support.dart
@@ -205,8 +205,10 @@ base mixin ResourcesSupport on MCPServer {
 
   /// Reads the resource at `request.uri`.
   ///
-  /// Throws an [ArgumentError] if it does not exist (this gets translated into
-  /// a generic JSON RPC2 error response).
+  /// Throws an [RpcException] with the `-32602` code the 2026-07-28 revision
+  /// requires if no resource or template answers the URI, carrying that URI as
+  /// `data.uri`. Earlier revisions asked for `-32002` here, which this package
+  /// has never sent.
   @mustCallSuper
   FutureOr<ReadResourceResult> readResource(ReadResourceRequest request) async {
     final impl = _resourceImpls[request.uri];
@@ -220,7 +222,11 @@ base mixin ResourcesSupport on MCPServer {
 
     final response = await impl?.call(request);
     if (response == null) {
-      throw ArgumentError.value(request.uri, 'uri', 'Resource not found');
+      throw RpcException(
+        error_code.INVALID_PARAMS,
+        'Resource not found',
+        data: {Keys.uri: request.uri},
+      );
     }
     return response;
   }

--- a/pkgs/dart_mcp/test/server/resources_support_test.dart
+++ b/pkgs/dart_mcp/test/server/resources_support_test.dart
@@ -6,6 +6,8 @@ import 'dart:async';
 
 import 'package:async/async.dart';
 import 'package:dart_mcp/server.dart';
+import 'package:json_rpc_2/error_code.dart' as error_code;
+import 'package:json_rpc_2/json_rpc_2.dart';
 import 'package:test/test.dart';
 
 import '../test_utils.dart';
@@ -230,6 +232,33 @@ void main() {
       );
     },
   );
+
+  test('reading an unknown resource reports invalid params', () async {
+    final environment = TestEnvironment(
+      TestMCPClient(),
+      TestMCPServerWithResources.new,
+    );
+    await environment.initializeServer();
+
+    await expectLater(
+      environment.serverConnection.readResource(
+        ReadResourceRequest(uri: 'file:///NoSuchResource.txt'),
+      ),
+      throwsA(
+        isA<RpcException>()
+            .having((e) => e.code, 'code', error_code.INVALID_PARAMS)
+            .having((e) => e.message, 'message', 'Resource not found')
+            // The key is spelled out rather than read back through
+            // `Keys.uri`, so renaming the constant cannot keep this passing
+            // while the wire key changes.
+            .having(
+              (e) => (e.data as Map)['uri'],
+              'data.uri',
+              'file:///NoSuchResource.txt',
+            ),
+      ),
+    );
+  });
 }
 
 final class TestMCPServerWithResources extends TestMCPServer


### PR DESCRIPTION
`readResource` threw an `ArgumentError` when no resource or template answered a URI, which reached the client as `-32000` with a Dart stack trace. The [2026-07-28 revision](https://modelcontextprotocol.io/specification/2026-07-28/server/resources#error-handling) requires `-32602` carrying the URI as `data.uri`. It now throws `RpcException` with that code. A server that overrides `readResource` to catch the `ArgumentError` breaks.

`json_rpc_2` injects the request into the `data` of every `RpcException` this package throws, so this frame carries `{uri, request}`. On `-32602` the TypeScript SDK rebuilds its `ResourceNotFoundError` only from an exact `{uri}` (`packages/core-internal/src/types/errors.ts`), leaving a TS client with a generic protocol error.

Part of #162.
