### PR TITLE
emit -32021 when a client asks to elicit without the capability

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -30,6 +30,15 @@
     `MCPServer.clientInfo` is now nullable (`Implementation?`).
   - Override `MCPServer.initializeLegacy` only to customize the legacy
     initialize response or version negotiation.
+  - `ElicitationRequestSupport.elicit` now throws an `RpcException` with
+    `McpErrorCodes.missingRequiredClientCapability` instead of a `StateError`
+    when the client did not declare the `elicitation` capability, naming the
+    missing capability under `data.requiredCapabilities`, which the 2026-07-28
+    revision requires of that error. `ToolsSupport.callTool` rethrows an
+    `RpcException`, so a tool which elicits reaches the client as that error
+    rather than as a `CallToolResult` whose text is a Dart stack trace. A
+    server catching the `StateError` needs to catch `RpcException` instead,
+    which comes from `package:json_rpc_2`.
 - Add `handleRequestScopedMessage` and `MCPServerFactory`, which serve each
   decoded JSON-RPC message on a fresh server instance for request-scoped
   transports. On 2026-07-28, successful results record the server

--- a/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
@@ -29,9 +29,26 @@ base mixin ElicitationRequestSupport on LoggingSupport {
   ///
   /// This method will only succeed if the client has advertised the
   /// `elicitation` capability.
+  ///
+  /// Throws an [RpcException] with
+  /// [McpErrorCodes.missingRequiredClientCapability] when it has not, naming
+  /// the capability the client is missing under `data.requiredCapabilities`,
+  /// which the 2026-07-28 revision requires of that error.
+  ///
+  /// [ToolsSupport.callTool] rethrows an [RpcException] instead of folding it
+  /// into a [CallToolResult], so a tool which elicits reaches the client as
+  /// that error rather than as a result whose text is a Dart stack trace.
   Future<ElicitResult> elicit(ElicitRequest request) async {
     if (!supportsElicitation) {
-      throw StateError('Client does not support elicitation');
+      throw RpcException(
+        McpErrorCodes.missingRequiredClientCapability,
+        'The client did not declare the elicitation capability',
+        data: {
+          Keys.requiredCapabilities: ClientCapabilities(
+            elicitation: ElicitationCapability(),
+          ),
+        },
+      );
     }
     return sendRequest(ElicitRequest.methodName, request);
   }

--- a/pkgs/dart_mcp/lib/src/utils/constants.dart
+++ b/pkgs/dart_mcp/lib/src/utils/constants.dart
@@ -123,6 +123,7 @@ extension Keys on Never {
   static const requested = 'requested';
   static const requestedSchema = 'requestedSchema';
   static const required = 'required';
+  static const requiredCapabilities = 'requiredCapabilities';
   static const resource = 'resource';
   static const resourceTemplates = 'resourceTemplates';
   static const resources = 'resources';

--- a/pkgs/dart_mcp/test/server/elicitation_request_support_test.dart
+++ b/pkgs/dart_mcp/test/server/elicitation_request_support_test.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dart_mcp/server.dart';
+import 'package:dart_mcp/src/utils/constants.dart';
+import 'package:test/test.dart';
+
+final class _ElicitingServer extends MCPServer
+    with LoggingSupport, ToolsSupport, ElicitationRequestSupport {
+  _ElicitingServer(super.channel)
+    : super.fromStreamChannel(
+        implementation: Implementation(name: 'test', version: '0.1.0'),
+      ) {
+    registerTool(Tool(name: 'test/ask', inputSchema: ObjectSchema()), (
+      _,
+    ) async {
+      await elicit(
+        ElicitRequest(message: 'need input', requestedSchema: ObjectSchema()),
+      );
+      return CallToolResult(content: [TextContent(text: 'asked')]);
+    });
+  }
+}
+
+void main() {
+  test('a tool which elicits fails with the missing capability code', () async {
+    final result = await handleRequestScopedMessage(
+      {
+        Keys.jsonrpc: '2.0',
+        Keys.id: 1,
+        Keys.method: CallToolRequest.methodName,
+        Keys.params: {Keys.name: 'test/ask'},
+      },
+      MCPServerInitialization(
+        protocolVersion: ProtocolVersion.v2026_07_28,
+        clientCapabilities: ClientCapabilities(),
+      ),
+      _ElicitingServer.new,
+    );
+
+    final error = result![Keys.error] as Map<String, Object?>;
+    expect(error[Keys.code], McpErrorCodes.missingRequiredClientCapability);
+    // In memory the data skips the JSON round trip, so it is an untyped map.
+    final data = error[Keys.data] as Map;
+    expect(data[Keys.requiredCapabilities], {
+      Keys.elicitation: <String, Object?>{},
+    });
+    expect(result[Keys.result], isNull);
+  });
+}


### PR DESCRIPTION
Next 2026-07-28 core-protocol slice tracked in #162, following #571 and #572: `ElicitationRequestSupport.elicit` now produces `-32021` when the client did not declare the elicitation capability.

#571 added `missingRequiredClientCapability` and #572 mapped it to `400`, but nothing in the library produces it. The one throw site is `test/needsSampling`, a tool registered to exercise that mapping.

`callTool` already sorts these apart: an `RpcException` is rethrown and reaches the client as an RPC error, while anything else becomes a `CallToolResult` with `isError: true` whose text is the exception and stack trace. `elicit` was throwing a `StateError`, on the wrong side of that split. A tool which elicits against such a client came back indistinguishable from one which crashed, carrying nothing machine-readable about what was missing.

It now throws an `RpcException` carrying `data.requiredCapabilities`, both of which the schema marks required on this error. The payload names the top-level `elicitation` capability, matching the gate that failed: `supportsElicitation` is a null check on `clientCapabilities.elicitation` and does not separate the `form` and `url` modes the way the TypeScript SDK does. Narrowing it belongs with that gate.

Breaking for a server catching the `StateError`, though nothing here does: `grep_packages` checks the capability itself and returns early, and neither call site in the example catches by type. `RpcException` comes from `package:json_rpc_2`, already a direct dependency that `example/elicitations_server.dart` imports and throws today.

## Tests

- That case now comes back as `-32021`, with the capability under `data.requiredCapabilities`. The mapping from that code to `400` is already covered.
- `dart test -p chrome,vm -c dart2wasm,dart2js,kernel,exe` passes (1122 tests across the four configurations, the new one in all of them).
- `dart analyze --fatal-infos` is clean here and in `mcp_examples` resolved against this branch.

Part of #162.
