### PR TITLE
add the subscriptions/listen types from protocol 2026-07-28

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -76,13 +76,13 @@
   `SubscriptionsListenResult`, and `SubscriptionsAcknowledgedNotification`,
   modeling the `subscriptions/listen` request the 2026-07-28 revision adds, see
   https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/subscriptions.
-  It opens one long-lived stream for the notifications which do not belong to
-  a request, replacing the HTTP GET endpoint along with `resources/subscribe`
-  and `resources/unsubscribe`; `SubscriptionFilter.resourceSubscriptions`
-  carries the resource URIs those two used to. `SubscribeRequest` and
-  `UnsubscribeRequest` stay for the revisions which have them. Serving the
-  request, and delivering notifications on the stream it opens, land as
-  separate changes.
+  `subscriptions/listen` opens one long-lived stream for the notifications
+  which do not belong to a specific request, and it replaces three things: the
+  HTTP GET endpoint, `resources/subscribe`, and `resources/unsubscribe`.
+  `SubscriptionFilter.resourceSubscriptions` carries the resource URIs the last
+  two took. `SubscribeRequest` and `UnsubscribeRequest` stay for the revisions
+  which have them. Serving the request, and delivering notifications on the
+  stream it opens, land as separate changes.
 - Fix `RequestId` so it can hold a JSON-RPC id. Its representation type was
   `json_rpc_2`'s `Parameter` rather than `Object`, which its sibling
   `ProgressToken` uses, so `CancelledNotification.requestId` threw for every

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -72,6 +72,17 @@
   and `.unsupportedProtocolVersion`. The same registry reserves `-32042`, so
   `urlElicitationRequired` now documents that only the 2025-11-25 revision
   emits it.
+- Add `SubscriptionFilter`, `SubscriptionsListenRequest`,
+  `SubscriptionsListenResult`, and `SubscriptionsAcknowledgedNotification`,
+  modeling the `subscriptions/listen` request the 2026-07-28 revision adds, see
+  https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/subscriptions.
+  It opens one long-lived stream for the notifications which do not belong to
+  a request, replacing the HTTP GET endpoint along with `resources/subscribe`
+  and `resources/unsubscribe`; `SubscriptionFilter.resourceSubscriptions`
+  carries the resource URIs those two used to. `SubscribeRequest` and
+  `UnsubscribeRequest` stay for the revisions which have them. Serving the
+  request, and delivering notifications on the stream it opens, land as
+  separate changes.
 - Fix `RequestId` so it can hold a JSON-RPC id. Its representation type was
   `json_rpc_2`'s `Parameter` rather than `Object`, which its sibling
   `ProgressToken` uses, so `CancelledNotification.requestId` threw for every

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -22,6 +22,7 @@ part 'prompts.dart';
 part 'resources.dart';
 part 'roots.dart';
 part 'sampling.dart';
+part 'subscriptions.dart';
 part 'tools.dart';
 
 /// Enum of the known protocol versions.

--- a/pkgs/dart_mcp/lib/src/api/subscriptions.dart
+++ b/pkgs/dart_mcp/lib/src/api/subscriptions.dart
@@ -27,16 +27,16 @@ extension type SubscriptionFilter.fromMap(Map<String, Object?> _value) {
       Keys.resourceSubscriptions: resourceSubscriptions,
   });
 
-  /// If true, the server sends [ToolListChangedNotification]s.
+  /// If true, receive [ToolListChangedNotification]s.
   bool? get toolsListChanged => _value[Keys.toolsListChanged] as bool?;
 
-  /// If true, the server sends [PromptListChangedNotification]s.
+  /// If true, receive [PromptListChangedNotification]s.
   bool? get promptsListChanged => _value[Keys.promptsListChanged] as bool?;
 
-  /// If true, the server sends [ResourceListChangedNotification]s.
+  /// If true, receive [ResourceListChangedNotification]s.
   bool? get resourcesListChanged => _value[Keys.resourcesListChanged] as bool?;
 
-  /// The resource URIs the server sends [ResourceUpdatedNotification]s for.
+  /// The resource URIs to receive [ResourceUpdatedNotification]s for.
   ///
   /// In the 2026-07-28 revision this field replaces the `resources/subscribe`
   /// and `resources/unsubscribe` requests, which [SubscribeRequest] and

--- a/pkgs/dart_mcp/lib/src/api/subscriptions.dart
+++ b/pkgs/dart_mcp/lib/src/api/subscriptions.dart
@@ -1,0 +1,149 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+part of 'api.dart';
+
+/// The notification types a client opts in to on a
+/// [SubscriptionsListenRequest], and the ones a server agrees to on a
+/// [SubscriptionsAcknowledgedNotification].
+///
+/// Each type is opt-in, so a server sends only the ones it was asked for. An
+/// acknowledgement carries the types the server agreed to, so a type it does
+/// not support is left out of that set rather than sent back as `false`.
+///
+/// From the 2026-07-28 revision.
+extension type SubscriptionFilter.fromMap(Map<String, Object?> _value) {
+  factory SubscriptionFilter({
+    bool? toolsListChanged,
+    bool? promptsListChanged,
+    bool? resourcesListChanged,
+    List<String>? resourceSubscriptions,
+  }) => SubscriptionFilter.fromMap({
+    if (toolsListChanged != null) Keys.toolsListChanged: toolsListChanged,
+    if (promptsListChanged != null) Keys.promptsListChanged: promptsListChanged,
+    if (resourcesListChanged != null)
+      Keys.resourcesListChanged: resourcesListChanged,
+    if (resourceSubscriptions != null)
+      Keys.resourceSubscriptions: resourceSubscriptions,
+  });
+
+  /// If true, receive [ToolListChangedNotification]s.
+  bool? get toolsListChanged => _value[Keys.toolsListChanged] as bool?;
+
+  /// If true, receive [PromptListChangedNotification]s.
+  bool? get promptsListChanged => _value[Keys.promptsListChanged] as bool?;
+
+  /// If true, receive [ResourceListChangedNotification]s.
+  bool? get resourcesListChanged => _value[Keys.resourcesListChanged] as bool?;
+
+  /// The resource URIs to receive [ResourceUpdatedNotification]s for.
+  ///
+  /// The 2026-07-28 revision replaces the `resources/subscribe` and
+  /// `resources/unsubscribe` requests, which [SubscribeRequest] and
+  /// [UnsubscribeRequest] model, with this field.
+  List<String>? get resourceSubscriptions =>
+      (_value[Keys.resourceSubscriptions] as List?)?.cast<String>();
+}
+
+/// Sent from the client to open a long-lived stream for the notifications
+/// which do not belong to a specific request.
+///
+/// This replaces the HTTP GET endpoint earlier revisions used, so a stdio
+/// connection and a Streamable HTTP one deliver those notifications the same
+/// way.
+///
+/// From the 2026-07-28 revision.
+extension type SubscriptionsListenRequest.fromMap(Map<String, Object?> _value)
+    implements Request {
+  static const methodName = 'subscriptions/listen';
+
+  factory SubscriptionsListenRequest({
+    required SubscriptionFilter notifications,
+    MetaWithProgressToken? meta,
+  }) => SubscriptionsListenRequest.fromMap({
+    Keys.notifications: notifications,
+    if (meta != null) Keys.meta: meta,
+  });
+
+  /// The notification types this request opts in to.
+  SubscriptionFilter get notifications {
+    final notifications = _value[Keys.notifications] as SubscriptionFilter?;
+    if (notifications == null) {
+      throw ArgumentError(
+        'Missing ${Keys.notifications} field in $SubscriptionsListenRequest.',
+      );
+    }
+    return notifications;
+  }
+}
+
+/// The response to a [SubscriptionsListenRequest], which the server sends when
+/// it ends the subscription gracefully, for example while shutting down.
+///
+/// The stream is long-lived, so there is no response while it is open, and an
+/// abrupt transport close carries none at all. The body is empty apart from
+/// the [subscriptionId] in its metadata.
+///
+/// From the 2026-07-28 revision.
+extension type SubscriptionsListenResult.fromMap(Map<String, Object?> _value)
+    implements Result {
+  factory SubscriptionsListenResult({
+    required RequestId subscriptionId,
+    Meta? meta,
+  }) => SubscriptionsListenResult.fromMap({
+    Keys.meta: {...?meta?._value, Keys.subscriptionIdMeta: subscriptionId},
+  });
+
+  /// The stream this response closes.
+  ///
+  /// This is the JSON-RPC id of the [SubscriptionsListenRequest] which opened
+  /// the stream. The notifications delivered on the stream carry it under the
+  /// same `io.modelcontextprotocol/subscriptionId` metadata key, which is how
+  /// a client tells its streams apart.
+  RequestId get subscriptionId {
+    final subscriptionId = meta?[Keys.subscriptionIdMeta];
+    if (subscriptionId == null) {
+      throw ArgumentError(
+        'Missing ${Keys.subscriptionIdMeta} metadata in '
+        '$SubscriptionsListenResult.',
+      );
+    }
+    return RequestId(subscriptionId);
+  }
+}
+
+/// Sent by the server to acknowledge a [SubscriptionsListenRequest] and report
+/// the notification types it agreed to send.
+///
+/// This is the first message the server sends carrying the subscription's id.
+/// Over stdio every subscription shares one channel, so that ordering holds
+/// per subscription rather than per channel: messages belonging to other
+/// subscriptions may arrive before it.
+///
+/// From the 2026-07-28 revision.
+extension type SubscriptionsAcknowledgedNotification.fromMap(
+  Map<String, Object?> _value
+) implements Notification {
+  static const methodName = 'notifications/subscriptions/acknowledged';
+
+  factory SubscriptionsAcknowledgedNotification({
+    required SubscriptionFilter notifications,
+    Meta? meta,
+  }) => SubscriptionsAcknowledgedNotification.fromMap({
+    Keys.notifications: notifications,
+    if (meta != null) Keys.meta: meta,
+  });
+
+  /// The notification types the server agreed to send on this stream.
+  SubscriptionFilter get notifications {
+    final notifications = _value[Keys.notifications] as SubscriptionFilter?;
+    if (notifications == null) {
+      throw ArgumentError(
+        'Missing ${Keys.notifications} field in '
+        '$SubscriptionsAcknowledgedNotification.',
+      );
+    }
+    return notifications;
+  }
+}

--- a/pkgs/dart_mcp/lib/src/api/subscriptions.dart
+++ b/pkgs/dart_mcp/lib/src/api/subscriptions.dart
@@ -4,13 +4,12 @@
 
 part of 'api.dart';
 
-/// The notification types a client opts in to on a
-/// [SubscriptionsListenRequest], and the ones a server agrees to on a
-/// [SubscriptionsAcknowledgedNotification].
+/// A filter over the notifications a subscription carries.
 ///
-/// Each type is opt-in, so a server sends only the ones it was asked for. An
-/// acknowledgement carries the types the server agreed to, so a type it does
-/// not support is left out of that set rather than sent back as `false`.
+/// A client sends one on a [SubscriptionsListenRequest] to opt in, and the
+/// server sends one back on a [SubscriptionsAcknowledgedNotification] with the
+/// types it agreed to. A type the server does not support is left out rather
+/// than sent back as `false`.
 ///
 /// From the 2026-07-28 revision.
 extension type SubscriptionFilter.fromMap(Map<String, Object?> _value) {
@@ -28,20 +27,20 @@ extension type SubscriptionFilter.fromMap(Map<String, Object?> _value) {
       Keys.resourceSubscriptions: resourceSubscriptions,
   });
 
-  /// If true, receive [ToolListChangedNotification]s.
+  /// If true, the server sends [ToolListChangedNotification]s.
   bool? get toolsListChanged => _value[Keys.toolsListChanged] as bool?;
 
-  /// If true, receive [PromptListChangedNotification]s.
+  /// If true, the server sends [PromptListChangedNotification]s.
   bool? get promptsListChanged => _value[Keys.promptsListChanged] as bool?;
 
-  /// If true, receive [ResourceListChangedNotification]s.
+  /// If true, the server sends [ResourceListChangedNotification]s.
   bool? get resourcesListChanged => _value[Keys.resourcesListChanged] as bool?;
 
-  /// The resource URIs to receive [ResourceUpdatedNotification]s for.
+  /// The resource URIs the server sends [ResourceUpdatedNotification]s for.
   ///
-  /// The 2026-07-28 revision replaces the `resources/subscribe` and
-  /// `resources/unsubscribe` requests, which [SubscribeRequest] and
-  /// [UnsubscribeRequest] model, with this field.
+  /// In the 2026-07-28 revision this field replaces the `resources/subscribe`
+  /// and `resources/unsubscribe` requests, which [SubscribeRequest] and
+  /// [UnsubscribeRequest] model.
   List<String>? get resourceSubscriptions =>
       (_value[Keys.resourceSubscriptions] as List?)?.cast<String>();
 }
@@ -49,9 +48,8 @@ extension type SubscriptionFilter.fromMap(Map<String, Object?> _value) {
 /// Sent from the client to open a long-lived stream for the notifications
 /// which do not belong to a specific request.
 ///
-/// This replaces the HTTP GET endpoint earlier revisions used, so a stdio
-/// connection and a Streamable HTTP one deliver those notifications the same
-/// way.
+/// This replaces the HTTP GET endpoint earlier revisions used, so stdio and
+/// Streamable HTTP deliver those notifications the same way.
 ///
 /// From the 2026-07-28 revision.
 extension type SubscriptionsListenRequest.fromMap(Map<String, Object?> _value)
@@ -78,12 +76,12 @@ extension type SubscriptionsListenRequest.fromMap(Map<String, Object?> _value)
   }
 }
 
-/// The response to a [SubscriptionsListenRequest], which the server sends when
-/// it ends the subscription gracefully, for example while shutting down.
+/// The response to a [SubscriptionsListenRequest], sent when the server ends
+/// the subscription gracefully, for example while shutting down.
 ///
 /// The stream is long-lived, so there is no response while it is open, and an
-/// abrupt transport close carries none at all. The body is empty apart from
-/// the [subscriptionId] in its metadata.
+/// abrupt transport close carries none at all. The result has no fields of its
+/// own: the [subscriptionId] travels in its metadata.
 ///
 /// From the 2026-07-28 revision.
 extension type SubscriptionsListenResult.fromMap(Map<String, Object?> _value)
@@ -95,12 +93,12 @@ extension type SubscriptionsListenResult.fromMap(Map<String, Object?> _value)
     Keys.meta: {...?meta?._value, Keys.subscriptionIdMeta: subscriptionId},
   });
 
-  /// The stream this response closes.
+  /// The JSON-RPC id of the [SubscriptionsListenRequest] which opened the
+  /// stream this response closes.
   ///
-  /// This is the JSON-RPC id of the [SubscriptionsListenRequest] which opened
-  /// the stream. The notifications delivered on the stream carry it under the
-  /// same `io.modelcontextprotocol/subscriptionId` metadata key, which is how
-  /// a client tells its streams apart.
+  /// The notifications delivered on the stream carry it under the
+  /// `io.modelcontextprotocol/subscriptionId` metadata key, which is how a
+  /// client tells its streams apart.
   RequestId get subscriptionId {
     final subscriptionId = meta?[Keys.subscriptionIdMeta];
     if (subscriptionId == null) {
@@ -116,10 +114,9 @@ extension type SubscriptionsListenResult.fromMap(Map<String, Object?> _value)
 /// Sent by the server to acknowledge a [SubscriptionsListenRequest] and report
 /// the notification types it agreed to send.
 ///
-/// This is the first message the server sends carrying the subscription's id.
-/// Over stdio every subscription shares one channel, so that ordering holds
-/// per subscription rather than per channel: messages belonging to other
-/// subscriptions may arrive before it.
+/// This is the first message carrying the subscription's id. Over stdio every
+/// subscription shares one channel, so messages from other subscriptions may
+/// arrive before this acknowledgement.
 ///
 /// From the 2026-07-28 revision.
 extension type SubscriptionsAcknowledgedNotification.fromMap(

--- a/pkgs/dart_mcp/lib/src/utils/constants.dart
+++ b/pkgs/dart_mcp/lib/src/utils/constants.dart
@@ -99,6 +99,7 @@ extension Keys on Never {
   static const name = 'name';
   static const nextCursor = 'nextCursor';
   static const not = 'not';
+  static const notifications = 'notifications';
   static const oneOf = 'oneOf';
   static const openWorldHint = 'openWorldHint';
   static const outputSchema = 'outputSchema';
@@ -111,6 +112,7 @@ extension Keys on Never {
   static const progress = 'progress';
   static const progressToken = 'progressToken';
   static const prompts = 'prompts';
+  static const promptsListChanged = 'promptsListChanged';
   static const properties = 'properties';
   static const propertyNames = 'propertyNames';
   static const protocolVersion = 'protocolVersion';
@@ -124,8 +126,10 @@ extension Keys on Never {
   static const requestedSchema = 'requestedSchema';
   static const required = 'required';
   static const resource = 'resource';
+  static const resourceSubscriptions = 'resourceSubscriptions';
   static const resourceTemplates = 'resourceTemplates';
   static const resources = 'resources';
+  static const resourcesListChanged = 'resourcesListChanged';
   static const result = 'result';
   static const resultType = 'resultType';
   static const role = 'role';
@@ -141,6 +145,7 @@ extension Keys on Never {
   static const stopSequences = 'stopSequences';
   static const structuredContent = 'structuredContent';
   static const subscribe = 'subscribe';
+  static const subscriptionIdMeta = 'io.modelcontextprotocol/subscriptionId';
   static const supported = 'supported';
   static const supportedVersions = 'supportedVersions';
   static const systemPrompt = 'systemPrompt';
@@ -150,6 +155,7 @@ extension Keys on Never {
   static const title = 'title';
   static const toolChoice = 'toolChoice';
   static const tools = 'tools';
+  static const toolsListChanged = 'toolsListChanged';
   static const total = 'total';
   static const ttlMs = 'ttlMs';
   static const type = 'type';

--- a/pkgs/dart_mcp/test/api/subscriptions_test.dart
+++ b/pkgs/dart_mcp/test/api/subscriptions_test.dart
@@ -1,0 +1,153 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dart_mcp/client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // These assert on the map rather than the getters, since an absent field and
+  // one written as `false` both matter here: an acknowledgement reports the
+  // types a server honors by leaving the rest out.
+  test('the method names are the ones the schema gives', () {
+    expect(SubscriptionsListenRequest.methodName, 'subscriptions/listen');
+    expect(
+      SubscriptionsAcknowledgedNotification.methodName,
+      'notifications/subscriptions/acknowledged',
+    );
+  });
+
+  group('SubscriptionFilter', () {
+    test('writes only the fields it is given', () {
+      expect(SubscriptionFilter() as Map<String, Object?>, isEmpty);
+      expect(
+        SubscriptionFilter(toolsListChanged: true) as Map<String, Object?>,
+        {'toolsListChanged': true},
+      );
+      expect(
+        SubscriptionFilter(
+              promptsListChanged: true,
+              resourcesListChanged: true,
+              resourceSubscriptions: ['file:///a'],
+            )
+            as Map<String, Object?>,
+        {
+          'promptsListChanged': true,
+          'resourcesListChanged': true,
+          'resourceSubscriptions': ['file:///a'],
+        },
+      );
+      expect(
+        SubscriptionFilter(resourceSubscriptions: []) as Map<String, Object?>,
+        {'resourceSubscriptions': <String>[]},
+      );
+    });
+
+    test('keeps an explicit false apart from an absent field', () {
+      expect(
+        SubscriptionFilter(toolsListChanged: false) as Map<String, Object?>,
+        {'toolsListChanged': false},
+      );
+      expect(
+        SubscriptionFilter(toolsListChanged: false).toolsListChanged,
+        false,
+      );
+      expect(SubscriptionFilter().toolsListChanged, null);
+    });
+
+    test('reads the fields off a decoded map', () {
+      final filter = SubscriptionFilter.fromMap({
+        'toolsListChanged': true,
+        'promptsListChanged': false,
+        'resourcesListChanged': true,
+        'resourceSubscriptions': <Object?>['file:///a', 'file:///b'],
+      });
+      expect(filter.toolsListChanged, true);
+      expect(filter.promptsListChanged, false);
+      expect(filter.resourcesListChanged, true);
+      expect(filter.resourceSubscriptions, ['file:///a', 'file:///b']);
+
+      final absent = SubscriptionFilter.fromMap({});
+      expect(absent.toolsListChanged, null);
+      expect(absent.promptsListChanged, null);
+      expect(absent.resourcesListChanged, null);
+      expect(absent.resourceSubscriptions, null);
+    });
+  });
+
+  group('SubscriptionsListenRequest', () {
+    test('writes the filter it is given', () {
+      final request = SubscriptionsListenRequest(
+        notifications: SubscriptionFilter(toolsListChanged: true),
+      );
+      expect(request as Map<String, Object?>, {
+        'notifications': {'toolsListChanged': true},
+      });
+      expect(request.notifications.toolsListChanged, true);
+    });
+
+    test('throws when the filter is missing', () {
+      expect(
+        () => SubscriptionsListenRequest.fromMap({}).notifications,
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('SubscriptionsListenResult', () {
+    test('writes the subscription id into the result metadata', () {
+      final result = SubscriptionsListenResult(subscriptionId: RequestId(7));
+      expect(result as Map<String, Object?>, {
+        '_meta': {'io.modelcontextprotocol/subscriptionId': 7},
+      });
+      expect(result.subscriptionId, 7);
+    });
+
+    test('keeps the metadata it is given alongside the id', () {
+      final result = SubscriptionsListenResult(
+        subscriptionId: RequestId('stream-1'),
+        meta: Meta.fromMap({'com.example/trace': 'abc'}),
+      );
+      expect(result as Map<String, Object?>, {
+        '_meta': {
+          'com.example/trace': 'abc',
+          'io.modelcontextprotocol/subscriptionId': 'stream-1',
+        },
+      });
+      expect(result.subscriptionId, 'stream-1');
+    });
+
+    test('throws when the subscription id is missing', () {
+      expect(
+        () => SubscriptionsListenResult.fromMap({}).subscriptionId,
+        throwsArgumentError,
+      );
+      expect(
+        () =>
+            SubscriptionsListenResult.fromMap({
+              '_meta': <String, Object?>{},
+            }).subscriptionId,
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('SubscriptionsAcknowledgedNotification', () {
+    test('writes the filter it is given', () {
+      final acknowledged = SubscriptionsAcknowledgedNotification(
+        notifications: SubscriptionFilter(toolsListChanged: true),
+      );
+      expect(acknowledged as Map<String, Object?>, {
+        'notifications': {'toolsListChanged': true},
+      });
+      expect(acknowledged.notifications.toolsListChanged, true);
+    });
+
+    test('throws when the filter is missing', () {
+      expect(
+        () => SubscriptionsAcknowledgedNotification.fromMap({}).notifications,
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/pkgs/dart_mcp/test/api/subscriptions_test.dart
+++ b/pkgs/dart_mcp/test/api/subscriptions_test.dart
@@ -6,10 +6,7 @@ import 'package:dart_mcp/client.dart';
 import 'package:test/test.dart';
 
 void main() {
-  // These assert on the map rather than the getters, since an absent field and
-  // one written as `false` both matter here: an acknowledgement reports the
-  // types a server honors by leaving the rest out.
-  test('the method names are the ones the schema gives', () {
+  test('the method names match the schema', () {
     expect(SubscriptionsListenRequest.methodName, 'subscriptions/listen');
     expect(
       SubscriptionsAcknowledgedNotification.methodName,


### PR DESCRIPTION
Adds `SubscriptionFilter`, `SubscriptionsListenRequest`, `SubscriptionsListenResult`, and `SubscriptionsAcknowledgedNotification` for the [`subscriptions/listen`](https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/subscriptions) request the 2026-07-28 revision adds. That one stream replaces the HTTP GET endpoint, `resources/subscribe`, and `resources/unsubscribe`. `SubscriptionFilter.resourceSubscriptions` carries the URIs the last two took. `SubscribeRequest` and `UnsubscribeRequest` stay for the revisions that have them.

Types only. Nothing dispatches the method yet. Its response is an SSE stream, which `streamable_http.dart` does not implement.

Part of #162.
