### PR TITLE
add the capability extensions maps from protocol 2026-07-28

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -130,6 +130,15 @@
   streams, the legacy session routes, or an HTTP client; those land as
   separate changes.
 - Add instructions to read the schema when tool arguments fail validation.
+- Add `ClientCapabilities.extensions` and `ServerCapabilities.extensions`, the
+  extension-support maps the 2026-07-28 revision adds to both capability
+  objects alongside the `experimental` maps, see
+  https://modelcontextprotocol.io/extensions/overview for the identifier
+  format. The client map is carried by the legacy `initialize` request and by
+  the `io.modelcontextprotocol/clientCapabilities` envelope key the
+  Streamable HTTP handler already requires; the server map travels with
+  `ServerCapabilities`, which is held by the legacy `initialize` result and
+  by `DiscoverResult`.
 
 ## 0.5.2
 

--- a/pkgs/dart_mcp/lib/src/api/initialization.dart
+++ b/pkgs/dart_mcp/lib/src/api/initialization.dart
@@ -192,11 +192,13 @@ extension type ClientCapabilities.fromMap(Map<String, Object?> _value) {
     RootsCapabilities? roots,
     Map<String, Object?>? sampling,
     ElicitationCapability? elicitation,
+    Map<String, Object?>? extensions,
   }) => ClientCapabilities.fromMap({
     if (experimental != null) Keys.experimental: experimental,
     if (roots != null) Keys.roots: roots,
     if (sampling != null) Keys.sampling: sampling,
     if (elicitation != null) Keys.elicitation: elicitation,
+    if (extensions != null) Keys.extensions: extensions,
   });
 
   /// Experimental, non-standard capabilities that the client supports.
@@ -236,6 +238,21 @@ extension type ClientCapabilities.fromMap(Map<String, Object?> _value) {
   set elicitation(ElicitationCapability? value) {
     assert(elicitation == null);
     _value[Keys.elicitation] = value;
+  }
+
+  /// Optional MCP extensions that the client supports.
+  ///
+  /// Keys are extension identifiers in the `{vendor-prefix}/{extension-name}`
+  /// format, such as `io.modelcontextprotocol/oauth-client-credentials`, and
+  /// values are per-extension settings objects. An empty object indicates
+  /// support with no settings.
+  Map<String, Object?>? get extensions =>
+      (_value[Keys.extensions] as Map?)?.cast<String, Object?>();
+
+  /// Sets [extensions], asserting it is null first.
+  set extensions(Map<String, Object?>? value) {
+    assert(extensions == null);
+    _value[Keys.extensions] = value;
   }
 }
 
@@ -298,6 +315,7 @@ extension type ServerCapabilities.fromMap(Map<String, Object?> _value) {
     Tools? tools,
     @Deprecated('Do not use, only clients have this capability')
     Elicitation? elicitation,
+    Map<String, Object?>? extensions,
   }) => ServerCapabilities.fromMap({
     if (experimental != null) Keys.experimental: experimental,
     if (logging != null) Keys.logging: logging,
@@ -305,6 +323,7 @@ extension type ServerCapabilities.fromMap(Map<String, Object?> _value) {
     if (resources != null) Keys.resources: resources,
     if (tools != null) Keys.tools: tools,
     if (elicitation != null) Keys.elicitation: elicitation,
+    if (extensions != null) Keys.extensions: extensions,
   });
 
   /// Experimental, non-standard capabilities that the server supports.
@@ -372,6 +391,21 @@ extension type ServerCapabilities.fromMap(Map<String, Object?> _value) {
   set elicitation(Elicitation? value) {
     assert(elicitation == null);
     _value[Keys.elicitation] = value;
+  }
+
+  /// Optional MCP extensions that the server supports.
+  ///
+  /// Keys are extension identifiers in the `{vendor-prefix}/{extension-name}`
+  /// format, such as `io.modelcontextprotocol/tasks`, and values are
+  /// per-extension settings objects. An empty object indicates support with
+  /// no settings.
+  Map<String, Object?>? get extensions =>
+      (_value[Keys.extensions] as Map?)?.cast<String, Object?>();
+
+  /// Sets [extensions] if it is null, otherwise throws.
+  set extensions(Map<String, Object?>? value) {
+    assert(extensions == null);
+    _value[Keys.extensions] = value;
   }
 }
 

--- a/pkgs/dart_mcp/lib/src/utils/constants.dart
+++ b/pkgs/dart_mcp/lib/src/utils/constants.dart
@@ -58,6 +58,7 @@ extension Keys on Never {
   static const exclusiveMaximum = 'exclusiveMaximum';
   static const exclusiveMinimum = 'exclusiveMinimum';
   static const experimental = 'experimental';
+  static const extensions = 'extensions';
   static const form = 'form';
   static const format = 'format';
   static const hasMore = 'hasMore';

--- a/pkgs/dart_mcp/test/api/initialization_test.dart
+++ b/pkgs/dart_mcp/test/api/initialization_test.dart
@@ -124,4 +124,50 @@ void main() {
       expect(result.supportedVersions, ['2026-07-28', '2027-11-05']);
     });
   });
+
+  group('capability extensions', () {
+    test('client capabilities round trip an extensions map', () {
+      final capabilities = ClientCapabilities(
+        extensions: {'io.modelcontextprotocol/oauth-client-credentials': {}},
+      );
+
+      final map = capabilities as Map<String, Object?>;
+      expect(map['extensions'], {
+        'io.modelcontextprotocol/oauth-client-credentials': <String, Object?>{},
+      });
+      expect(capabilities.extensions, {
+        'io.modelcontextprotocol/oauth-client-credentials': <String, Object?>{},
+      });
+    });
+
+    test('client capabilities omit extensions when unset', () {
+      final capabilities = ClientCapabilities();
+
+      final map = capabilities as Map<String, Object?>;
+      expect(map.containsKey('extensions'), isFalse);
+      expect(capabilities.extensions, isNull);
+    });
+
+    test('server capabilities round trip an extensions map', () {
+      final capabilities = ServerCapabilities(
+        extensions: {'io.modelcontextprotocol/tasks': {}},
+      );
+
+      final map = capabilities as Map<String, Object?>;
+      expect(map['extensions'], {
+        'io.modelcontextprotocol/tasks': <String, Object?>{},
+      });
+      expect(capabilities.extensions, {
+        'io.modelcontextprotocol/tasks': <String, Object?>{},
+      });
+    });
+
+    test('server capabilities omit extensions when unset', () {
+      final capabilities = ServerCapabilities();
+
+      final map = capabilities as Map<String, Object?>;
+      expect(map.containsKey('extensions'), isFalse);
+      expect(capabilities.extensions, isNull);
+    });
+  });
 }

--- a/pkgs/dart_mcp/test/api/initialization_test.dart
+++ b/pkgs/dart_mcp/test/api/initialization_test.dart
@@ -169,5 +169,35 @@ void main() {
       expect(map.containsKey('extensions'), isFalse);
       expect(capabilities.extensions, isNull);
     });
+
+    test('client capabilities set extensions once', () {
+      final capabilities = ClientCapabilities();
+      capabilities.extensions = {
+        'io.modelcontextprotocol/oauth-client-credentials': {},
+      };
+
+      expect(capabilities.extensions, {
+        'io.modelcontextprotocol/oauth-client-credentials': <String, Object?>{},
+      });
+      expect(
+        () => capabilities.extensions = {'io.modelcontextprotocol/tasks': {}},
+        throwsA(isA<AssertionError>()),
+      );
+      // A compiled executable has asserts stripped, so there is nothing to
+      // catch there.
+    }, testOn: '!exe');
+
+    test('server capabilities set extensions once', () {
+      final capabilities = ServerCapabilities();
+      capabilities.extensions = {'io.modelcontextprotocol/tasks': {}};
+
+      expect(capabilities.extensions, {
+        'io.modelcontextprotocol/tasks': <String, Object?>{},
+      });
+      expect(
+        () => capabilities.extensions = {'io.modelcontextprotocol/other': {}},
+        throwsA(isA<AssertionError>()),
+      );
+    }, testOn: '!exe');
   });
 }


### PR DESCRIPTION
Adds the `extensions` map the [2026-07-28 revision](https://modelcontextprotocol.io/specification/2026-07-28/changelog) puts on both capability objects.

The same revision moves the whole `tasks` surface out of the core schema and into `io.modelcontextprotocol/tasks`, which the schema uses as its example key for the server map. Each extension defines its own settings object, so values stay an opaque `Map<String, Object?>` like `experimental`.

Part of #162.
