### PR TITLE
send notifications/message only when a 2026-07-28 request asks

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -54,6 +54,16 @@
   carry the `ttlMs` and `cacheScope` hints, which the handler may set itself.
   A server answering an earlier revision gets none of them. Does **not** add
   any transport.
+- Send `notifications/message` only when the request named a log level on
+  2026-07-28, see
+  https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/logging.
+  The name goes in the `io.modelcontextprotocol/logLevel` metadata key, which
+  `MCPServerInitialization` now carries and the Streamable HTTP handler reads
+  off the envelope, rejecting a value which is not a logging level with
+  invalid params. `LoggingSupport.log` sends at or above the level the key
+  named, and sends nothing when the key was absent, which that revision
+  requires of it. The revisions the legacy handshake negotiates have no
+  per-request level, so `logging/setLevel` still decides there.
 - `RootsTrackingSupport` no longer surfaces an unhandled error when the
   connection closes while a `listRoots` request is in flight.
 - The URL elicitation retry rethrows the original error when its data is not

--- a/pkgs/dart_mcp/lib/src/server/logging_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/logging_support.dart
@@ -34,6 +34,9 @@ base mixin LoggingSupport on MCPServer {
   /// Sends a [LoggingMessageNotification] to the client, if the [loggingLevel]
   /// is <= [level].
   ///
+  /// Sends nothing on 2026-07-28 unless the exchange was given a
+  /// [MCPServerInitialization.logLevel].
+  ///
   /// The [data] must either be some json serializable object, or a function
   /// which takes no arguments and returns some json serializable object.
   ///

--- a/pkgs/dart_mcp/lib/src/server/logging_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/logging_support.dart
@@ -11,11 +11,22 @@ base mixin LoggingSupport on MCPServer {
   /// The current logging level, defaults to [LoggingLevel.warning].
   LoggingLevel loggingLevel = LoggingLevel.warning;
 
+  /// Whether this exchange asked for log messages, see
+  /// [MCPServerInitialization.logLevel].
+  bool _logsRequested = true;
+
   @override
   FutureOr<ServerCapabilities> initialize(
     MCPServerInitialization initialization,
   ) async {
     registerRequestHandler(SetLevelRequest.methodName, handleSetLevel);
+
+    final requested = initialization.logLevel;
+    if (requested != null) {
+      loggingLevel = requested;
+    } else if (initialization.protocolVersion >= ProtocolVersion.v2026_07_28) {
+      _logsRequested = false;
+    }
 
     return (await super.initialize(initialization))..logging ??= Logging();
   }
@@ -33,7 +44,7 @@ base mixin LoggingSupport on MCPServer {
   /// If [data] is any other type of function, an [ArgumentError] will be
   /// thrown.
   void log(LoggingLevel level, Object data, {String? logger, Meta? meta}) {
-    if (loggingLevel > level) return;
+    if (!_logsRequested || loggingLevel > level) return;
 
     if (data is Function) {
       if (data is Object Function()) {

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -33,6 +33,7 @@ final class MCPServerInitialization {
     required this.protocolVersion,
     required this.clientCapabilities,
     this.clientInfo,
+    this.logLevel,
   });
 
   /// The protocol version used for this connection or request.
@@ -46,6 +47,17 @@ final class MCPServerInitialization {
   /// The legacy handshake always provides this. Request-scoped transports may
   /// omit it, since clients are not required to send it on every request.
   final Implementation? clientInfo;
+
+  /// The log level the client asked for on this request, if any.
+  ///
+  /// Request-scoped transports read this from the reserved
+  /// `io.modelcontextprotocol/logLevel` request metadata key, see
+  /// https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/logging.
+  /// On 2026-07-28 an exchange which was given no level emits no
+  /// `notifications/message`, which that revision requires of the server. The
+  /// legacy handshake has no per-request level and leaves this null, so
+  /// `logging/setLevel` still decides there.
+  final LoggingLevel? logLevel;
 }
 
 /// Base class to extend when implementing an MCP server.

--- a/pkgs/dart_mcp/lib/src/utils/constants.dart
+++ b/pkgs/dart_mcp/lib/src/utils/constants.dart
@@ -77,6 +77,7 @@ extension Keys on Never {
   static const listChanged = 'listChanged';
   static const logger = 'logger';
   static const logging = 'logging';
+  static const logLevelMeta = 'io.modelcontextprotocol/logLevel';
   static const maxItems = 'maxItems';
   static const maxLength = 'maxLength';
   static const maxProperties = 'maxProperties';

--- a/pkgs/dart_mcp/lib/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/streamable_http.dart
@@ -15,6 +15,7 @@ library;
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:json_rpc_2/error_code.dart' as error_code;
 import 'package:json_rpc_2/json_rpc_2.dart';
 
@@ -326,6 +327,23 @@ Future<void> handleStreamableHttpRequest(
       decoded,
     );
   }
+  final rawLogLevel = meta[Keys.logLevelMeta];
+  LoggingLevel? logLevel;
+  if (rawLogLevel != null) {
+    logLevel = LoggingLevel.values.firstWhereOrNull(
+      (level) => level.name == rawLogLevel,
+    );
+    if (logLevel == null) {
+      return _reject(
+        response,
+        HttpStatus.badRequest,
+        RpcException.invalidParams(
+          'The envelope ${Keys.logLevelMeta} must be a logging level',
+        ),
+        decoded,
+      );
+    }
+  }
 
   if (headerVersion != bodyVersion) {
     return _reject(
@@ -417,6 +435,7 @@ Future<void> handleStreamableHttpRequest(
         clientCapabilities: ClientCapabilities.fromMap(capabilities),
         clientInfo:
             clientInfo == null ? null : Implementation.fromMap(clientInfo),
+        logLevel: logLevel,
       ),
       serverFactory,
       onNotification: onNotification,

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -311,7 +311,7 @@ void main() {
       final notifications = <Map<String, Object?>>[];
       await harness.dispatch(
         _callTool('notify'),
-        _initialization(),
+        _initialization(logLevel: LoggingLevel.error),
         onNotification: notifications.add,
       );
 
@@ -325,18 +325,63 @@ void main() {
       final notifications = <Map<String, Object?>>[];
       // Without the roots capability, roots tracking logs a warning as it
       // initializes, before the dispatched message is handled.
-      await handleRequestScopedMessage(_listTools(), _initialization(), (
-        channel,
-      ) {
-        final server = _RootsTrackingDispatcherServer(channel);
-        servers.add(server);
-        return server;
-      }, onNotification: notifications.add);
+      await handleRequestScopedMessage(
+        _listTools(),
+        _initialization(logLevel: LoggingLevel.warning),
+        (channel) {
+          final server = _RootsTrackingDispatcherServer(channel);
+          servers.add(server);
+          return server;
+        },
+        onNotification: notifications.add,
+      );
 
       expect(
         notifications.map((n) => n[Keys.method]),
         contains(LoggingMessageNotification.methodName),
       );
+    });
+
+    test('sends no log messages to a request which asked for none', () async {
+      final harness = _DispatcherHarness();
+      final notifications = <Map<String, Object?>>[];
+      await harness.dispatch(
+        _callTool('notify'),
+        _initialization(),
+        onNotification: notifications.add,
+      );
+
+      final methods = [for (final n in notifications) n[Keys.method]];
+      expect(methods, contains(ProgressNotification.methodName));
+      expect(methods, isNot(contains(LoggingMessageNotification.methodName)));
+    });
+
+    test('applies the level a request asked for', () async {
+      final harness = _DispatcherHarness();
+      final notifications = <Map<String, Object?>>[];
+      // The `notify` tool logs at error, which is below emergency.
+      await harness.dispatch(
+        _callTool('notify'),
+        _initialization(logLevel: LoggingLevel.emergency),
+        onNotification: notifications.add,
+      );
+
+      final methods = [for (final n in notifications) n[Keys.method]];
+      expect(methods, contains(ProgressNotification.methodName));
+      expect(methods, isNot(contains(LoggingMessageNotification.methodName)));
+    });
+
+    test('keeps logging on a revision with no per-request level', () async {
+      final harness = _DispatcherHarness();
+      final notifications = <Map<String, Object?>>[];
+      await harness.dispatch(
+        _callTool('notify'),
+        _initialization(protocolVersion: ProtocolVersion.v2025_11_25),
+        onNotification: notifications.add,
+      );
+
+      final methods = [for (final n in notifications) n[Keys.method]];
+      expect(methods, contains(LoggingMessageNotification.methodName));
     });
 
     test('fails server to client requests instead of hanging', () async {
@@ -795,9 +840,11 @@ Map<String, Object?> _ping() => {
 MCPServerInitialization _initialization({
   ClientCapabilities? capabilities,
   ProtocolVersion protocolVersion = ProtocolVersion.v2026_07_28,
+  LoggingLevel? logLevel,
 }) => MCPServerInitialization(
   protocolVersion: protocolVersion,
   clientCapabilities: capabilities ?? ClientCapabilities(),
+  logLevel: logLevel,
 );
 
 Map<String, Object?> _result(Map<String, Object?>? response) =>

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -626,6 +626,76 @@ void main() {
     });
   });
 
+  group('per-request log level', () {
+    /// A `tools/call` body for the tool which logs, carrying [logLevel] in its
+    /// envelope when one is given.
+    Map<String, Object?> logBody({Object? logLevel}) {
+      final request = body(callTool, params: {Keys.name: 'test/log'});
+      final params = request[Keys.params] as Map<String, Object?>;
+      final meta = params[Keys.meta] as Map<String, Object?>;
+      if (logLevel != null) meta[Keys.logLevelMeta] = logLevel;
+      return request;
+    }
+
+    Map<String, String> logHeaders() => {
+      ...headers(callTool),
+      'Mcp-Name': 'test/log',
+    };
+
+    test('sends no log messages when the envelope asks for none', () async {
+      final (status, _, text) = await post(
+        headers: logHeaders(),
+        json: logBody(),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+      expect(notifications, isEmpty);
+    });
+
+    test('sends log messages at the level the envelope asked for', () async {
+      final (status, _, text) = await post(
+        headers: logHeaders(),
+        json: logBody(logLevel: LoggingLevel.error.name),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+      expect(
+        notifications.single[Keys.method],
+        LoggingMessageNotification.methodName,
+      );
+    });
+
+    test('drops log messages below the level the envelope asked for', () async {
+      final (status, _, text) = await post(
+        headers: logHeaders(),
+        json: logBody(logLevel: LoggingLevel.emergency.name),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+      expect(notifications, isEmpty);
+    });
+
+    test('rejects a log level no revision defines', () async {
+      final (status, _, text) = await post(
+        headers: logHeaders(),
+        json: logBody(logLevel: 'chatty'),
+      );
+      expect(status, 400);
+      expect(errorCode(text), error_code.INVALID_PARAMS);
+      expect(servers, isEmpty);
+    });
+
+    test('rejects a log level which is not a String', () async {
+      final (status, _, text) = await post(
+        headers: logHeaders(),
+        json: logBody(logLevel: 3),
+      );
+      expect(status, 400);
+      expect(errorCode(text), error_code.INVALID_PARAMS);
+      expect(servers, isEmpty);
+    });
+  });
+
   group('http methods', () {
     for (final method in ['GET', 'DELETE', 'PUT']) {
       test('rejects $method with 405', () async {
@@ -1074,7 +1144,7 @@ void main() {
   });
 }
 
-base class _HttpTestServer extends MCPServer with ToolsSupport {
+base class _HttpTestServer extends MCPServer with LoggingSupport, ToolsSupport {
   bool get _declaredSampling => clientCapabilities.sampling != null;
 
   _HttpTestServer(super.channel)
@@ -1135,6 +1205,10 @@ base class _HttpTestServer extends MCPServer with ToolsSupport {
         ),
       );
       return CallToolResult(content: [TextContent(text: 'notified')]);
+    });
+    registerTool(Tool(name: 'test/log', inputSchema: ObjectSchema()), (_) {
+      log(LoggingLevel.error, 'from tool');
+      return CallToolResult(content: [TextContent(text: 'logged')]);
     });
   }
 }


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

On 2026-07-28 the log level travels in each request's `_meta`, as [`io.modelcontextprotocol/logLevel`](https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/logging). A server must send no `notifications/message` for a request that omits the key, and `LoggingSupport` was still sending them at its warning default.

I put the level on `MCPServerInitialization`, filled by the streamable HTTP handler from the envelope key beside the reserved ones it already reads. An unrecognized value comes back as `-32602`. That leaves the warning default just for 2025-11-25 and older, where `logging/setLevel` still sets it.