### PR TITLE
refuse listRoots and createMessage without the client capability

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -46,6 +46,18 @@
     Dart stack trace attached. A server which overrides `readResource` and
     catches the `ArgumentError` its dartdoc used to promise needs to catch
     `RpcException` from `package:json_rpc_2` instead.
+  - `MCPServer.listRoots` and `MCPServer.createMessage` now throw an
+    `RpcException` with `McpErrorCodes.missingRequiredClientCapability` when
+    the client did not declare `roots` or `sampling`, naming the missing
+    capability under `data.requiredCapabilities`, the same way
+    `ElicitationRequestSupport.elicit` already did. The 2026-07-28 revision
+    requires a server not to send a request which relies on a capability the
+    client left out. Both used to send the request anyway, so what came back
+    depended on the peer: a client with no handler answered `-32601`, and a
+    request-scoped transport answered `-32603` because it cannot carry a
+    server to client request at all. A server which expects either of those
+    codes for an undeclared capability should read
+    `MCPServer.supportsRoots` or `MCPServer.supportsSampling` first.
 - Add `handleRequestScopedMessage` and `MCPServerFactory`, which serve each
   decoded JSON-RPC message on a fresh server instance for request-scoped
   transports. On 2026-07-28, successful results record the server

--- a/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
@@ -40,14 +40,9 @@ base mixin ElicitationRequestSupport on LoggingSupport {
   /// that error rather than as a result whose text is a Dart stack trace.
   Future<ElicitResult> elicit(ElicitRequest request) async {
     if (!supportsElicitation) {
-      throw RpcException(
-        McpErrorCodes.missingRequiredClientCapability,
-        'The client did not declare the elicitation capability',
-        data: {
-          Keys.requiredCapabilities: ClientCapabilities(
-            elicitation: ElicitationCapability(),
-          ),
-        },
+      throw _missingClientCapability(
+        'elicitation',
+        ClientCapabilities(elicitation: ElicitationCapability()),
       );
     }
     return sendRequest(ElicitRequest.methodName, request);

--- a/pkgs/dart_mcp/lib/src/server/roots_tracking_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/roots_tracking_support.dart
@@ -29,12 +29,6 @@ base mixin RootsTrackingSupport on LoggingSupport {
   /// [_RootsState.pending], otherwise `null`.
   Completer<List<Root>>? _rootsCompleter = Completer();
 
-  /// Whether or not the connected client supports [listRoots].
-  ///
-  /// Only safe to call after calling [initialize] on `super` since this
-  /// is based on the client capabilities.
-  bool get supportsRoots => clientCapabilities.roots != null;
-
   /// Whether or not the connected client supports reporting changes to the
   /// list of roots.
   ///

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -191,13 +191,69 @@ abstract base class MCPServer extends MCPBase {
     _initialized.complete(notification);
   }
 
+  /// Whether or not the connected client supports [listRoots].
+  ///
+  /// Only safe to call after calling [initialize] on `super` since this
+  /// is based on the client capabilities.
+  bool get supportsRoots => clientCapabilities.roots != null;
+
+  /// Whether or not the connected client supports [createMessage].
+  ///
+  /// Only safe to call after calling [initialize] on `super` since this
+  /// is based on the client capabilities.
+  bool get supportsSampling => clientCapabilities.sampling != null;
+
   /// Lists all the root URIs from the client.
-  Future<ListRootsResult> listRoots([ListRootsRequest? request]) =>
-      sendRequest(ListRootsRequest.methodName, request);
+  ///
+  /// This method will only succeed if the client has advertised the `roots`
+  /// capability.
+  ///
+  /// Throws an [RpcException] with
+  /// [McpErrorCodes.missingRequiredClientCapability] when it has not, naming
+  /// the capability the client is missing under `data.requiredCapabilities`,
+  /// which the 2026-07-28 revision requires of that error.
+  Future<ListRootsResult> listRoots([ListRootsRequest? request]) async {
+    if (!supportsRoots) {
+      throw _missingClientCapability(
+        'roots',
+        ClientCapabilities(roots: RootsCapabilities()),
+      );
+    }
+    return sendRequest(ListRootsRequest.methodName, request);
+  }
 
   /// A request to prompt the LLM owned by the client with a message.
   ///
   /// See https://spec.modelcontextprotocol.io/specification/2025-11-05/client/sampling/.
-  Future<CreateMessageResult> createMessage(CreateMessageRequest request) =>
-      sendRequest(CreateMessageRequest.methodName, request);
+  ///
+  /// This method will only succeed if the client has advertised the `sampling`
+  /// capability.
+  ///
+  /// Throws an [RpcException] with
+  /// [McpErrorCodes.missingRequiredClientCapability] when it has not, naming
+  /// the capability the client is missing under `data.requiredCapabilities`,
+  /// which the 2026-07-28 revision requires of that error.
+  Future<CreateMessageResult> createMessage(
+    CreateMessageRequest request,
+  ) async {
+    if (!supportsSampling) {
+      throw _missingClientCapability(
+        'sampling',
+        ClientCapabilities(sampling: {}),
+      );
+    }
+    return sendRequest(CreateMessageRequest.methodName, request);
+  }
 }
+
+/// The error a server must return when handling a request needs [capability],
+/// which the client did not declare, carrying [required] under
+/// `data.requiredCapabilities`.
+RpcException _missingClientCapability(
+  String capability,
+  ClientCapabilities required,
+) => RpcException(
+  McpErrorCodes.missingRequiredClientCapability,
+  'The client did not declare the $capability capability',
+  data: {Keys.requiredCapabilities: required},
+);

--- a/pkgs/dart_mcp/test/client_and_server_test.dart
+++ b/pkgs/dart_mcp/test/client_and_server_test.dart
@@ -43,7 +43,11 @@ void main() {
         CreateMessageRequest(messages: [], maxTokens: 1),
       ),
       throwsA(
-        isA<RpcException>().having((e) => e.code, 'code', METHOD_NOT_FOUND),
+        isA<RpcException>().having(
+          (e) => e.code,
+          'code',
+          McpErrorCodes.missingRequiredClientCapability,
+        ),
       ),
       reason: 'The server calling unsupported methods should throw',
     );

--- a/pkgs/dart_mcp/test/server/client_capability_guard_test.dart
+++ b/pkgs/dart_mcp/test/server/client_capability_guard_test.dart
@@ -1,0 +1,92 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dart_mcp/server.dart';
+import 'package:dart_mcp/src/utils/constants.dart';
+import 'package:test/test.dart';
+
+final class _RequestingServer extends MCPServer
+    with LoggingSupport, ToolsSupport {
+  _RequestingServer(super.channel)
+    : super.fromStreamChannel(
+        implementation: Implementation(name: 'test', version: '0.1.0'),
+      ) {
+    registerTool(Tool(name: 'test/sample', inputSchema: ObjectSchema()), (
+      _,
+    ) async {
+      await createMessage(CreateMessageRequest(messages: [], maxTokens: 1));
+      return CallToolResult(content: [TextContent(text: 'sampled')]);
+    });
+    registerTool(Tool(name: 'test/roots', inputSchema: ObjectSchema()), (
+      _,
+    ) async {
+      await listRoots(ListRootsRequest());
+      return CallToolResult(content: [TextContent(text: 'listed')]);
+    });
+  }
+}
+
+Future<Map<String, Object?>?> _callTool(
+  String name,
+  ClientCapabilities capabilities,
+) => handleRequestScopedMessage(
+  {
+    Keys.jsonrpc: '2.0',
+    Keys.id: 1,
+    Keys.method: CallToolRequest.methodName,
+    Keys.params: {Keys.name: name},
+  },
+  MCPServerInitialization(
+    protocolVersion: ProtocolVersion.v2026_07_28,
+    clientCapabilities: capabilities,
+  ),
+  _RequestingServer.new,
+);
+
+void main() {
+  test('a tool which samples fails with the missing capability code', () async {
+    final result = await _callTool('test/sample', ClientCapabilities());
+
+    final error = result![Keys.error] as Map<String, Object?>;
+    expect(error[Keys.code], McpErrorCodes.missingRequiredClientCapability);
+    // In memory the data skips the JSON round trip, so it is an untyped map.
+    final data = error[Keys.data] as Map;
+    expect(data[Keys.requiredCapabilities], {
+      Keys.sampling: <String, Object?>{},
+    });
+    expect(result[Keys.result], isNull);
+  });
+
+  test(
+    'a tool which lists roots fails with the missing capability code',
+    () async {
+      final result = await _callTool('test/roots', ClientCapabilities());
+
+      final error = result![Keys.error] as Map<String, Object?>;
+      expect(error[Keys.code], McpErrorCodes.missingRequiredClientCapability);
+      final data = error[Keys.data] as Map;
+      expect(data[Keys.requiredCapabilities], {
+        Keys.roots: <String, Object?>{},
+      });
+      expect(result[Keys.result], isNull);
+    },
+  );
+
+  test('a declared capability reaches the transport instead', () async {
+    // The request-scoped transport cannot carry a server to client request, so
+    // it answers with its own error. Reaching that error is what shows the
+    // guard let the request through.
+    final result = await _callTool(
+      'test/sample',
+      ClientCapabilities(sampling: {}),
+    );
+
+    final error = result![Keys.error] as Map<String, Object?>;
+    expect(
+      error[Keys.code],
+      isNot(McpErrorCodes.missingRequiredClientCapability),
+    );
+    expect(error[Keys.message], contains('request-scoped transport'));
+  });
+}

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -341,9 +341,13 @@ void main() {
 
     test('fails server to client requests instead of hanging', () async {
       final harness = _DispatcherHarness();
+      // The client declares roots, so `listRoots` reaches the transport rather
+      // than being refused for the missing capability.
       final response = await harness.dispatch(
         _callTool('roots'),
-        _initialization(),
+        _initialization(
+          capabilities: ClientCapabilities(roots: RootsCapabilities()),
+        ),
       );
 
       final error = response![Keys.error] as Map<String, Object?>;


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

Both `listRoots` and `createMessage` sent their request no matter what the client
declared, so an undeclared capability just surfaced as whatever the peer happened
to answer, and on a request-scoped transport that is a generic internal error.
The 2026-07-28 revision requires -32021 naming the capability under
`data.requiredCapabilities`, the same error `elicit` already returns.

I hoisted `supportsRoots` onto the base class where those two methods live and
added `supportsSampling` beside it, since dart_mcp_server already computes both
by hand for its analytics. This is breaking for a server which expects the codes
the peer used to produce.
