### PR TITLE
stop two optional resource fields from throwing

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -58,6 +58,11 @@
     server to client request at all. A server which expects either of those
     codes for an undeclared capability should read
     `MCPServer.supportsRoots` or `MCPServer.supportsSampling` first.
+  - `ResourceLink.icons` is now `List<Icon>?` instead of `List<String>?`, and
+    its factory takes the icons, the way the other five types carrying `icons`
+    already do. The schema has typed the field as `Icon[]` since it was added,
+    so reading it off a resource link a server sent threw a type error on the
+    first element.
   - `LoggingSupport.loggingLevel` is now nullable (`LoggingLevel?`), `null`
     meaning `log` sends nothing. On 2026-07-28 `initialize` assigns the level
     the request named, over whatever the server set before it ran. Earlier
@@ -77,6 +82,8 @@
   The level goes in the `io.modelcontextprotocol/logLevel` metadata key, which
   `MCPServerInitialization` now carries and the Streamable HTTP handler reads
   off the envelope, answering invalid params when it is not a logging level.
+- `Resource.size` reads `null` for an absent size instead of throwing a type
+  error. The field is optional, and the getter cast it to a non-nullable `int`.
 - `RootsTrackingSupport` no longer surfaces an unhandled error when the
   connection closes while a `listRoots` request is in flight.
 - The URL elicitation retry rethrows the original error when its data is not

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -60,7 +60,9 @@
     `MCPServer.supportsRoots` or `MCPServer.supportsSampling` first.
   - `ResourceLink.icons` is now `List<Icon>?` instead of `List<String>?`, and
     its factory takes the icons, the way the other five types carrying `icons`
-    already do. The schema has typed the field as `Icon[]` since it was added,
+    already do. The schema has typed the field as `Icon[]` since 2025-11-25
+    added it, see
+    https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-11-25/schema.ts,
     so reading it off a resource link a server sent threw a type error on the
     first element.
   - `LoggingSupport.loggingLevel` is now nullable (`LoggingLevel?`), `null`

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -62,8 +62,8 @@
     its factory takes the icons, the way the other five types carrying `icons`
     already do. The field has been an array of icons since 2025-11-25 added it,
     see
-    https://modelcontextprotocol.io/specification/2025-11-25/server/resources,
-    so reading it off a resource link a server sent threw a type error on the
+    https://modelcontextprotocol.io/specification/2025-11-25/schema#resourcelink-icons.
+    Reading it off a resource link a server sent threw a type error on the
     first element.
   - `LoggingSupport.loggingLevel` is now nullable (`LoggingLevel?`), `null`
     meaning `log` sends nothing. On 2026-07-28 `initialize` assigns the level

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -60,9 +60,9 @@
     `MCPServer.supportsRoots` or `MCPServer.supportsSampling` first.
   - `ResourceLink.icons` is now `List<Icon>?` instead of `List<String>?`, and
     its factory takes the icons, the way the other five types carrying `icons`
-    already do. The schema has typed the field as `Icon[]` since 2025-11-25
-    added it, see
-    https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-11-25/schema.ts,
+    already do. The field has been an array of icons since 2025-11-25 added it,
+    see
+    https://modelcontextprotocol.io/specification/2025-11-25/server/resources,
     so reading it off a resource link a server sent threw a type error on the
     first element.
   - `LoggingSupport.loggingLevel` is now nullable (`LoggingLevel?`), `null`

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -644,6 +644,7 @@ extension type ResourceLink.fromMap(Map<String, Object?> _value)
     String? description,
     required String uri,
     String? mimeType,
+    List<Icon>? icons,
     Annotations? annotations,
     Meta? meta,
   }) => ResourceLink.fromMap({
@@ -652,6 +653,7 @@ extension type ResourceLink.fromMap(Map<String, Object?> _value)
     if (description != null) Keys.description: description,
     Keys.uri: uri,
     if (mimeType != null) Keys.mimeType: mimeType,
+    if (icons != null) Keys.icons: icons,
     Keys.type: expectedType,
     if (annotations != null) Keys.annotations: annotations,
     if (meta != null) Keys.meta: meta,
@@ -681,8 +683,9 @@ extension type ResourceLink.fromMap(Map<String, Object?> _value)
   /// The size of the resource in bytes.
   int? get size => _value[Keys.size] as int?;
 
-  /// List of icons for display in user interfaces
-  List<String>? get icons => (_value[Keys.icons] as List?)?.cast<String>();
+  /// Optional set of sized icons that the client can display in a user
+  /// interface.
+  List<Icon>? get icons => (_value[Keys.icons] as List?)?.cast<Icon>();
 }
 
 /// Base type for objects that include optional annotations for the client.

--- a/pkgs/dart_mcp/lib/src/api/resources.dart
+++ b/pkgs/dart_mcp/lib/src/api/resources.dart
@@ -254,7 +254,7 @@ extension type Resource.fromMap(Map<String, Object?> _value)
   ///
   /// This can be used by Hosts to display file sizes and estimate context
   /// window usage.
-  int? get size => _value[Keys.size] as int;
+  int? get size => _value[Keys.size] as int?;
 
   /// Optional set of sized icons that the client can display in a user
   /// interface.

--- a/pkgs/dart_mcp/test/api/api_test.dart
+++ b/pkgs/dart_mcp/test/api/api_test.dart
@@ -315,4 +315,41 @@ void main() {
       }
     });
   });
+
+  group('ResourceLink', () {
+    test('reads the icons a server sent', () {
+      final link = ResourceLink.fromMap({
+        'type': 'resource_link',
+        'uri': 'file:///a',
+        'name': 'a',
+        'icons': <Object?>[
+          {
+            'src': 'https://example.com/a.png',
+            'sizes': <Object?>['48x48'],
+          },
+        ],
+      });
+      final icon = link.icons!.single;
+      expect(icon.src, 'https://example.com/a.png');
+      expect(icon.sizes, ['48x48']);
+    });
+
+    test('writes the icons it is given', () {
+      final link = ResourceLink(
+        uri: 'file:///a',
+        name: 'a',
+        icons: [Icon(src: 'https://example.com/a.png')],
+      );
+      expect((link as Map<String, Object?>)['icons'], [
+        {'src': 'https://example.com/a.png'},
+      ]);
+      expect(link.icons!.single.src, 'https://example.com/a.png');
+    });
+
+    test('reads null icons when the server left them out', () {
+      final link = ResourceLink(uri: 'file:///a', name: 'a');
+      expect(link.icons, null);
+      expect((link as Map<String, Object?>).containsKey('icons'), isFalse);
+    });
+  });
 }

--- a/pkgs/dart_mcp/test/api/resources_test.dart
+++ b/pkgs/dart_mcp/test/api/resources_test.dart
@@ -21,41 +21,4 @@ void main() {
       expect(resource.size, null);
     });
   });
-
-  group('ResourceLink', () {
-    test('reads the icons a server sent', () {
-      final link = ResourceLink.fromMap({
-        'type': 'resource_link',
-        'uri': 'file:///a',
-        'name': 'a',
-        'icons': <Object?>[
-          {
-            'src': 'https://example.com/a.png',
-            'sizes': <Object?>['48x48'],
-          },
-        ],
-      });
-      final icon = link.icons!.single;
-      expect(icon.src, 'https://example.com/a.png');
-      expect(icon.sizes, ['48x48']);
-    });
-
-    test('writes the icons it is given', () {
-      final link = ResourceLink(
-        uri: 'file:///a',
-        name: 'a',
-        icons: [Icon(src: 'https://example.com/a.png')],
-      );
-      expect((link as Map<String, Object?>)['icons'], [
-        {'src': 'https://example.com/a.png'},
-      ]);
-      expect(link.icons!.single.src, 'https://example.com/a.png');
-    });
-
-    test('reads null icons when the server left them out', () {
-      final link = ResourceLink(uri: 'file:///a', name: 'a');
-      expect(link.icons, null);
-      expect((link as Map<String, Object?>).containsKey('icons'), isFalse);
-    });
-  });
 }

--- a/pkgs/dart_mcp/test/api/resources_test.dart
+++ b/pkgs/dart_mcp/test/api/resources_test.dart
@@ -55,6 +55,7 @@ void main() {
     test('reads null icons when the server left them out', () {
       final link = ResourceLink(uri: 'file:///a', name: 'a');
       expect(link.icons, null);
+      expect((link as Map<String, Object?>).containsKey('icons'), isFalse);
     });
   });
 }

--- a/pkgs/dart_mcp/test/api/resources_test.dart
+++ b/pkgs/dart_mcp/test/api/resources_test.dart
@@ -1,0 +1,60 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dart_mcp/client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Resource', () {
+    test('reads a size off a decoded map', () {
+      final resource = Resource.fromMap({
+        'uri': 'file:///a',
+        'name': 'a',
+        'size': 12,
+      });
+      expect(resource.size, 12);
+    });
+
+    test('reads a null size when the server left it out', () {
+      final resource = Resource.fromMap({'uri': 'file:///a', 'name': 'a'});
+      expect(resource.size, null);
+    });
+  });
+
+  group('ResourceLink', () {
+    test('reads the icons a server sent', () {
+      final link = ResourceLink.fromMap({
+        'type': 'resource_link',
+        'uri': 'file:///a',
+        'name': 'a',
+        'icons': <Object?>[
+          {
+            'src': 'https://example.com/a.png',
+            'sizes': <Object?>['48x48'],
+          },
+        ],
+      });
+      final icon = link.icons!.single;
+      expect(icon.src, 'https://example.com/a.png');
+      expect(icon.sizes, ['48x48']);
+    });
+
+    test('writes the icons it is given', () {
+      final link = ResourceLink(
+        uri: 'file:///a',
+        name: 'a',
+        icons: [Icon(src: 'https://example.com/a.png')],
+      );
+      expect((link as Map<String, Object?>)['icons'], [
+        {'src': 'https://example.com/a.png'},
+      ]);
+      expect(link.icons!.single.src, 'https://example.com/a.png');
+    });
+
+    test('reads null icons when the server left them out', () {
+      final link = ResourceLink(uri: 'file:///a', name: 'a');
+      expect(link.icons, null);
+    });
+  });
+}


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

The size getter on `Resource` is declared `int?` but cast to a non-nullable `int`. Any resource that just left the field out threw. Its twin on `ResourceLink` already reads that same optional field nullably.

Icons on a resource link were typed as a list of strings while the schema has typed them as icons since the field was added. Reading them off a link a server sent threw on the first element. The getter type changing is what breaks. I matched the five other types which carry icons, factory included.
