### PR TITLE
omit optional fields instead of writing them as null

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -122,6 +122,9 @@
   two took. `SubscribeRequest` and `UnsubscribeRequest` stay for the revisions
   which have them. Serving the request, and delivering notifications on the
   stream it opens, land as separate changes.
+- Stop `BaseMetadata`, `MetaWithProgressToken`, `CompletionContext`,
+  `PromptReference` and `ElicitResult` from writing an explicit `null` for an
+  optional field that was not given. The schema types all five as non-nullable.
 - Fix `RequestId` so it can hold a JSON-RPC id. Its representation type was
   `json_rpc_2`'s `Parameter` rather than `Object`, which its sibling
   `ProgressToken` uses, so `CancelledNotification.requestId` threw for every

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -191,7 +191,10 @@ extension type Meta.fromMap(Map<String, Object?> _value) {
 /// different purpose.
 extension type BaseMetadata.fromMap(Map<String, Object?> _value) {
   factory BaseMetadata({required String name, String? title}) =>
-      BaseMetadata.fromMap({Keys.name: name, Keys.title: title});
+      BaseMetadata.fromMap({
+        Keys.name: name,
+        if (title != null) Keys.title: title,
+      });
 
   /// Intended for programmatic or logical use, but used as a display name in
   /// past specs for fallback (if title isn't present).
@@ -230,7 +233,9 @@ extension type WithProgressToken.fromMap(Map<String, Object?> _value) {
 extension type MetaWithProgressToken.fromMap(Map<String, Object?> _value)
     implements Meta, WithProgressToken {
   factory MetaWithProgressToken({ProgressToken? progressToken}) =>
-      MetaWithProgressToken.fromMap({Keys.progressToken: progressToken});
+      MetaWithProgressToken.fromMap({
+        if (progressToken != null) Keys.progressToken: progressToken,
+      });
 }
 
 /// Base interface for all types that can have arbitrary metadata attached.

--- a/pkgs/dart_mcp/lib/src/api/completions.dart
+++ b/pkgs/dart_mcp/lib/src/api/completions.dart
@@ -113,7 +113,9 @@ extension type CompletionArgument.fromMap(Map<String, Object?> _value) {
 /// A context passed to a [CompleteRequest].
 extension type CompletionContext.fromMap(Map<String, Object?> _value) {
   factory CompletionContext({Map<String, String>? arguments}) =>
-      CompletionContext.fromMap({Keys.arguments: arguments});
+      CompletionContext.fromMap({
+        if (arguments != null) Keys.arguments: arguments,
+      });
 
   /// Previously-resolved variables in a URI template or prompt.
   Map<String, String>? get arguments =>
@@ -179,7 +181,7 @@ extension type PromptReference.fromMap(Map<String, Object?> _value)
   factory PromptReference({required String name, String? title}) =>
       PromptReference.fromMap({
         Keys.name: name,
-        Keys.title: title,
+        if (title != null) Keys.title: title,
         Keys.type: expectedType,
       });
 

--- a/pkgs/dart_mcp/lib/src/api/elicitation.dart
+++ b/pkgs/dart_mcp/lib/src/api/elicitation.dart
@@ -132,7 +132,10 @@ extension type ElicitResult.fromMap(Map<String, Object?> _value)
   factory ElicitResult({
     required ElicitationAction action,
     Map<String, Object?>? content,
-  }) => ElicitResult.fromMap({Keys.action: action.name, Keys.content: content});
+  }) => ElicitResult.fromMap({
+    Keys.action: action.name,
+    if (content != null) Keys.content: content,
+  });
 
   /// The action taken by the user in response to an elicitation request.
   ///

--- a/pkgs/dart_mcp/test/api/api_test.dart
+++ b/pkgs/dart_mcp/test/api/api_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 void main() {
   // A getter reads the same null whether the key was omitted or written as
   // null, so these assert on the map.
-  test('optional fields stay off the wire when they are not given', () {
+  test('metadata and meta leave out what they are not given', () {
     expect(BaseMetadata(name: 'n') as Map<String, Object?>, {'name': 'n'});
     expect(BaseMetadata(name: 'n', title: 't') as Map<String, Object?>, {
       'name': 'n',

--- a/pkgs/dart_mcp/test/api/api_test.dart
+++ b/pkgs/dart_mcp/test/api/api_test.dart
@@ -6,6 +6,14 @@ import 'package:dart_mcp/client.dart';
 import 'package:test/test.dart';
 
 void main() {
+  // These assert on the map rather than on the getters, because a getter
+  // reads the same null whether the factory omitted the key or wrote null
+  // into it, and only the map shows which one went out on the wire.
+  test('optional fields stay off the wire when they are not given', () {
+    expect(BaseMetadata(name: 'n') as Map<String, Object?>, {'name': 'n'});
+    expect(MetaWithProgressToken() as Map<String, Object?>, isEmpty);
+  });
+
   test('protocol versions can be compared', () {
     expect(
       ProtocolVersion.latestSupported > ProtocolVersion.oldestSupported,

--- a/pkgs/dart_mcp/test/api/api_test.dart
+++ b/pkgs/dart_mcp/test/api/api_test.dart
@@ -6,12 +6,20 @@ import 'package:dart_mcp/client.dart';
 import 'package:test/test.dart';
 
 void main() {
-  // These assert on the map rather than on the getters, because a getter
-  // reads the same null whether the factory omitted the key or wrote null
-  // into it, and only the map shows which one went out on the wire.
+  // A getter reads the same null whether the key was omitted or written as
+  // null, so these assert on the map.
   test('optional fields stay off the wire when they are not given', () {
     expect(BaseMetadata(name: 'n') as Map<String, Object?>, {'name': 'n'});
+    expect(BaseMetadata(name: 'n', title: 't') as Map<String, Object?>, {
+      'name': 'n',
+      'title': 't',
+    });
     expect(MetaWithProgressToken() as Map<String, Object?>, isEmpty);
+    expect(
+      MetaWithProgressToken(progressToken: ProgressToken(1))
+          as Map<String, Object?>,
+      {'progressToken': 1},
+    );
   });
 
   test('protocol versions can be compared', () {

--- a/pkgs/dart_mcp/test/api/completions_test.dart
+++ b/pkgs/dart_mcp/test/api/completions_test.dart
@@ -10,6 +10,14 @@ import 'package:test/test.dart';
 import '../test_utils.dart';
 
 void main() {
+  test('optional fields stay off the wire when they are not given', () {
+    expect(CompletionContext() as Map<String, Object?>, isEmpty);
+    expect(PromptReference(name: 'p') as Map<String, Object?>, {
+      'name': 'p',
+      'type': PromptReference.expectedType,
+    });
+  });
+
   test('client can request prompt completions', () async {
     final environment = TestEnvironment(
       TestMCPClient(),

--- a/pkgs/dart_mcp/test/api/completions_test.dart
+++ b/pkgs/dart_mcp/test/api/completions_test.dart
@@ -10,7 +10,7 @@ import 'package:test/test.dart';
 import '../test_utils.dart';
 
 void main() {
-  test('optional fields stay off the wire when they are not given', () {
+  test('a context and a reference leave out what they are not given', () {
     expect(CompletionContext() as Map<String, Object?>, isEmpty);
     expect(CompletionContext(arguments: {'a': 'b'}) as Map<String, Object?>, {
       'arguments': {'a': 'b'},

--- a/pkgs/dart_mcp/test/api/completions_test.dart
+++ b/pkgs/dart_mcp/test/api/completions_test.dart
@@ -12,8 +12,16 @@ import '../test_utils.dart';
 void main() {
   test('optional fields stay off the wire when they are not given', () {
     expect(CompletionContext() as Map<String, Object?>, isEmpty);
+    expect(CompletionContext(arguments: {'a': 'b'}) as Map<String, Object?>, {
+      'arguments': {'a': 'b'},
+    });
     expect(PromptReference(name: 'p') as Map<String, Object?>, {
       'name': 'p',
+      'type': PromptReference.expectedType,
+    });
+    expect(PromptReference(name: 'p', title: 't') as Map<String, Object?>, {
+      'name': 'p',
+      'title': 't',
       'type': PromptReference.expectedType,
     });
   });

--- a/pkgs/dart_mcp/test/api/elicitation_test.dart
+++ b/pkgs/dart_mcp/test/api/elicitation_test.dart
@@ -12,6 +12,28 @@ import '../test_utils.dart';
 
 void main() {
   group('elicitation', () {
+    test('a result without form data carries no content key', () {
+      for (final action in [
+        ElicitationAction.decline,
+        ElicitationAction.cancel,
+      ]) {
+        expect(ElicitResult(action: action) as Map<String, Object?>, {
+          'action': action.name,
+        });
+      }
+      expect(
+        ElicitResult(
+              action: ElicitationAction.accept,
+              content: {'answer': 'yes'},
+            )
+            as Map<String, Object?>,
+        {
+          'action': 'accept',
+          'content': {'answer': 'yes'},
+        },
+      );
+    });
+
     test('server can elicit information from client', () async {
       final elicitationCompleter = Completer<ElicitResult>();
       final environment = TestEnvironment(


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

Five factories write an explicit `null` when an optional field is not given, and the schema does not allow null there. No other SDK puts those keys on the wire: python drops none values on the way out, go and rust leave an unset optional off it.
