### PR TITLE
add the input-required result types

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -111,6 +111,10 @@
   and `.unsupportedProtocolVersion`. The same registry reserves `-32042`, so
   `urlElicitationRequired` now documents that only the 2025-11-25 revision
   emits it.
+- Add `InputRequiredResult` and `InputRequest`, the result a server answers with
+  when it needs input first, see
+  https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr.
+  Nothing sends or answers one yet.
 - Add `SubscriptionFilter`, `SubscriptionsListenRequest`,
   `SubscriptionsListenResult`, and `SubscriptionsAcknowledgedNotification`,
   modeling the `subscriptions/listen` request the 2026-07-28 revision adds, see

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -17,6 +17,7 @@ part 'elicitation.dart';
 part 'error_codes.dart';
 part 'icons.dart';
 part 'initialization.dart';
+part 'input_required.dart';
 part 'logging.dart';
 part 'prompts.dart';
 part 'resources.dart';

--- a/pkgs/dart_mcp/lib/src/api/input_required.dart
+++ b/pkgs/dart_mcp/lib/src/api/input_required.dart
@@ -66,8 +66,10 @@ extension type InputRequest._(Map<String, Object?> _value) {
 ///
 /// The schema requires at least one of [inputRequests] and [requestState],
 /// since a result carrying neither asks for nothing and hands back nothing to
-/// retry with. The unnamed constructor asserts it. Reading one back with
-/// `fromMap` takes whatever a server sent.
+/// retry with. The unnamed constructor asserts it, and goes one step further
+/// by treating an empty [inputRequests] the same way. An empty map is valid on
+/// the wire and a server may mean something by it, and `fromMap` keeps
+/// whatever a server sent.
 ///
 /// From the 2026-07-28 revision.
 extension type InputRequiredResult.fromMap(Map<String, Object?> _value)
@@ -80,8 +82,9 @@ extension type InputRequiredResult.fromMap(Map<String, Object?> _value)
     assert(
       (inputRequests != null && inputRequests.isNotEmpty) ||
           requestState != null,
-      'The schema requires at least one of `inputRequests` and `requestState`, '
-      'and an empty `inputRequests` asks for nothing.',
+      'The schema requires at least one of `inputRequests` and `requestState`. '
+      'An empty `inputRequests` is valid on the wire, and this constructor '
+      'still takes it as asking for nothing.',
     );
     return InputRequiredResult.fromMap({
       Keys.resultType: ResultTypes.inputRequired,

--- a/pkgs/dart_mcp/lib/src/api/input_required.dart
+++ b/pkgs/dart_mcp/lib/src/api/input_required.dart
@@ -1,0 +1,106 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+part of 'api.dart';
+
+/// A request an [InputRequiredResult] carries, written the way the schema
+/// writes it: the method name next to the request it applies to.
+///
+/// The schema names [ElicitRequest], [CreateMessageRequest] and
+/// [ListRootsRequest] here and nothing else, so there is a constructor for
+/// each. Reading one back, dispatch on [method] and then read [params] as the
+/// matching type.
+///
+/// From the 2026-07-28 revision.
+extension type InputRequest._(Map<String, Object?> _value) {
+  factory InputRequest.fromMap(Map<String, Object?> value) {
+    assert(value.containsKey(Keys.method));
+    return InputRequest._(value);
+  }
+
+  factory InputRequest.elicit(ElicitRequest request) => InputRequest._({
+    Keys.method: ElicitRequest.methodName,
+    Keys.params: request,
+  });
+
+  factory InputRequest.sample(CreateMessageRequest request) => InputRequest._({
+    Keys.method: CreateMessageRequest.methodName,
+    Keys.params: request,
+  });
+
+  factory InputRequest.listRoots(ListRootsRequest request) => InputRequest._({
+    Keys.method: ListRootsRequest.methodName,
+    Keys.params: request,
+  });
+
+  /// The method this request is made under.
+  ///
+  /// The schema requires this on every kind it allows here.
+  String get method => _value[Keys.method] as String;
+
+  /// The request itself, which [method] says how to read.
+  ///
+  /// The schema requires this next to `elicitation/create` and
+  /// `sampling/createMessage`. For `roots/list` it only requires the method.
+  Request? get params => _value[Keys.params] as Request?;
+
+  /// Whether this carries an [ElicitRequest].
+  bool get isElicit => _value[Keys.method] == ElicitRequest.methodName;
+
+  /// Whether this carries a [CreateMessageRequest].
+  bool get isSample => _value[Keys.method] == CreateMessageRequest.methodName;
+
+  /// Whether this carries a [ListRootsRequest].
+  bool get isListRoots => _value[Keys.method] == ListRootsRequest.methodName;
+}
+
+/// Sent by a server in place of the result a request asked for, when it needs
+/// something from the client first.
+///
+/// The schema answers with one on `tools/call`, `prompts/get` and
+/// `resources/read`, and [Result.resultType] reads `input_required` on it. The
+/// client answers the [inputRequests] and then sends the original request
+/// again, with the answers and the [requestState] attached. That retry is a
+/// new request, so this result ends the exchange it belongs to.
+///
+/// The schema requires at least one of [inputRequests] and [requestState],
+/// since a result carrying neither asks for nothing and hands back nothing to
+/// retry with. The unnamed constructor asserts it. Reading one back with
+/// `fromMap` takes whatever a server sent.
+///
+/// From the 2026-07-28 revision.
+extension type InputRequiredResult.fromMap(Map<String, Object?> _value)
+    implements Result {
+  factory InputRequiredResult({
+    Map<String, InputRequest>? inputRequests,
+    String? requestState,
+    Meta? meta,
+  }) {
+    assert(
+      (inputRequests != null && inputRequests.isNotEmpty) ||
+          requestState != null,
+      'The schema requires at least one of `inputRequests` and `requestState`, '
+      'and an empty `inputRequests` asks for nothing.',
+    );
+    return InputRequiredResult.fromMap({
+      Keys.resultType: ResultTypes.inputRequired,
+      if (inputRequests != null) Keys.inputRequests: inputRequests,
+      if (requestState != null) Keys.requestState: requestState,
+      if (meta != null) Keys.meta: meta,
+    });
+  }
+
+  /// The requests the server issued, keyed by the name the client answers each
+  /// one under.
+  ///
+  /// The keys are the server's own identifiers, and the answers go back under
+  /// the same ones.
+  Map<String, InputRequest>? get inputRequests =>
+      (_value[Keys.inputRequests] as Map?)?.cast<String, InputRequest>();
+
+  /// State the server wants back when the client retries the request.
+  ///
+  /// This is opaque to the client, which sends it on unread.
+  String? get requestState => _value[Keys.requestState] as String?;
+}

--- a/pkgs/dart_mcp/lib/src/utils/constants.dart
+++ b/pkgs/dart_mcp/lib/src/utils/constants.dart
@@ -67,6 +67,7 @@ extension Keys on Never {
   static const id = 'id';
   static const idempotentHint = 'idempotentHint';
   static const includeContext = 'includeContext';
+  static const inputRequests = 'inputRequests';
   static const inputSchema = 'inputSchema';
   static const instructions = 'instructions';
   static const intelligencePriority = 'intelligencePriority';
@@ -124,6 +125,7 @@ extension Keys on Never {
   static const ref = 'ref';
   static const request = 'request';
   static const requestId = 'requestId';
+  static const requestState = 'requestState';
   static const requested = 'requested';
   static const requestedSchema = 'requestedSchema';
   static const required = 'required';

--- a/pkgs/dart_mcp/test/api/input_required_test.dart
+++ b/pkgs/dart_mcp/test/api/input_required_test.dart
@@ -148,7 +148,7 @@ void main() {
       );
     });
 
-    test('reports a malformed entry rather than throwing', () {
+    test('tells no kind apart when an entry has no method', () {
       final result = InputRequiredResult.fromMap({
         'resultType': 'input_required',
         'inputRequests': {'a': <String, Object?>{}},

--- a/pkgs/dart_mcp/test/api/input_required_test.dart
+++ b/pkgs/dart_mcp/test/api/input_required_test.dart
@@ -1,0 +1,171 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dart_mcp/client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('InputRequest', () {
+    test('writes the method next to the request it applies to', () {
+      final sample = CreateMessageRequest(messages: [], maxTokens: 1);
+      expect(InputRequest.sample(sample) as Map<String, Object?>, {
+        'method': 'sampling/createMessage',
+        'params': sample,
+      });
+
+      final elicit = ElicitRequest.form(
+        message: 'What is your name?',
+        requestedSchema: ObjectSchema(
+          properties: {'name': StringSchema()},
+          required: ['name'],
+        ),
+      );
+      expect(InputRequest.elicit(elicit) as Map<String, Object?>, {
+        'method': 'elicitation/create',
+        'params': elicit,
+      });
+
+      final roots = ListRootsRequest();
+      expect(InputRequest.listRoots(roots) as Map<String, Object?>, {
+        'method': 'roots/list',
+        'params': roots,
+      });
+    });
+
+    test('reads back a request a server sent', () {
+      final request = InputRequest.fromMap({
+        'method': 'roots/list',
+        'params': <String, Object?>{},
+      });
+
+      expect(request.method, 'roots/list');
+      expect(request.params as Map<String, Object?>?, isEmpty);
+    });
+
+    test('tells the kinds apart by method', () {
+      final elicit = InputRequest.elicit(
+        ElicitRequest.form(
+          message: 'What is your name?',
+          requestedSchema: ObjectSchema(
+            properties: {'name': StringSchema()},
+            required: ['name'],
+          ),
+        ),
+      );
+      final sample = InputRequest.sample(
+        CreateMessageRequest(messages: [], maxTokens: 1),
+      );
+      final roots = InputRequest.listRoots(ListRootsRequest());
+
+      expect(
+        [elicit.isElicit, elicit.isSample, elicit.isListRoots],
+        [true, false, false],
+      );
+      expect(
+        [sample.isElicit, sample.isSample, sample.isListRoots],
+        [false, true, false],
+      );
+      expect(
+        [roots.isElicit, roots.isSample, roots.isListRoots],
+        [false, false, true],
+      );
+    });
+
+    test('rejects a request with no method', () {
+      expect(
+        () => InputRequest.fromMap({'params': <String, Object?>{}}),
+        throwsA(isA<AssertionError>()),
+      );
+      // A compiled executable has asserts stripped, so there is nothing to
+      // catch there.
+    }, testOn: '!exe');
+  });
+
+  group('InputRequiredResult', () {
+    test('marks itself as the interim result type', () {
+      expect(
+        InputRequiredResult(requestState: 'opaque').resultType,
+        'input_required',
+      );
+    });
+
+    test('writes only the fields it is given', () {
+      expect(
+        InputRequiredResult(requestState: 'opaque') as Map<String, Object?>,
+        {'resultType': 'input_required', 'requestState': 'opaque'},
+      );
+      expect(
+        InputRequiredResult(
+              inputRequests: {
+                'roots': InputRequest.listRoots(ListRootsRequest()),
+              },
+            )
+            as Map<String, Object?>,
+        {
+          'resultType': 'input_required',
+          'inputRequests': {
+            'roots': {'method': 'roots/list', 'params': <String, Object?>{}},
+          },
+        },
+      );
+    });
+
+    test('reads back the requests a server sent', () {
+      final result = InputRequiredResult.fromMap({
+        'resultType': 'input_required',
+        'inputRequests': {
+          'roots': {'method': 'roots/list', 'params': <String, Object?>{}},
+        },
+        'requestState': 'opaque',
+      });
+
+      expect(result.inputRequests, hasLength(1));
+      expect(result.inputRequests!['roots']!.method, 'roots/list');
+      expect(result.requestState, 'opaque');
+    });
+
+    test('leaves both fields null when a server omits them', () {
+      final result = InputRequiredResult.fromMap({
+        'resultType': 'input_required',
+      });
+
+      expect(result.inputRequests, isNull);
+      expect(result.requestState, isNull);
+    });
+
+    test('writes the metadata it is given', () {
+      expect(
+        InputRequiredResult(
+              requestState: 'opaque',
+              meta: Meta.fromMap({'io.modelcontextprotocol/serverInfo': {}}),
+            )
+            as Map<String, Object?>,
+        containsPair(
+          '_meta',
+          containsPair('io.modelcontextprotocol/serverInfo', isEmpty),
+        ),
+      );
+    });
+
+    test('reports a malformed entry rather than throwing', () {
+      final result = InputRequiredResult.fromMap({
+        'resultType': 'input_required',
+        'inputRequests': {'a': <String, Object?>{}},
+      });
+      final entry = result.inputRequests!['a']!;
+
+      expect(entry.isElicit, isFalse);
+      expect(entry.isSample, isFalse);
+      expect(entry.isListRoots, isFalse);
+    });
+
+    test('rejects a result which asks for nothing', () {
+      expect(InputRequiredResult.new, throwsA(isA<AssertionError>()));
+      expect(
+        () => InputRequiredResult(inputRequests: {}),
+        throwsA(isA<AssertionError>()),
+      );
+    }, testOn: '!exe');
+  });
+}

--- a/pkgs/dart_mcp/test/api/input_required_test.dart
+++ b/pkgs/dart_mcp/test/api/input_required_test.dart
@@ -167,5 +167,17 @@ void main() {
         throwsA(isA<AssertionError>()),
       );
     }, testOn: '!exe');
+
+    test('writes an empty inputRequests next to a request state', () {
+      expect(
+        InputRequiredResult(inputRequests: {}, requestState: 'opaque')
+            as Map<String, Object?>,
+        {
+          'resultType': 'input_required',
+          'inputRequests': <String, InputRequest>{},
+          'requestState': 'opaque',
+        },
+      );
+    });
   });
 }

--- a/pkgs/dart_mcp/test/api/input_required_test.dart
+++ b/pkgs/dart_mcp/test/api/input_required_test.dart
@@ -83,13 +83,6 @@ void main() {
   });
 
   group('InputRequiredResult', () {
-    test('marks itself as the interim result type', () {
-      expect(
-        InputRequiredResult(requestState: 'opaque').resultType,
-        'input_required',
-      );
-    });
-
     test('writes only the fields it is given', () {
       expect(
         InputRequiredResult(requestState: 'opaque') as Map<String, Object?>,


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

On 2026-07-28 a server answers `tools/call`, `prompts/get` or `resources/read` with an `input_required` result when it needs something from the client first. The result carries the requests it needs under server-assigned keys, and a `requestState` the client sends back untouched on the retry. This adds those two types. Nothing dispatches them yet.
