### PR TITLE
fix four schema types in tools.dart against the spec

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -64,6 +64,12 @@
     revisions fill it in only when the server set none. `LoggingSupport` also
     stops registering `logging/setLevel` on that revision, which is what a
     transport dispatching on its own gets.
+  - `IntegerSchema`'s four bounds and its default read `num` now, and its
+    factory takes them that way. JSON Schema types the bounds `number`, and
+    the spec gives integers and numbers one definition whose `minimum`,
+    `maximum` and `default` are `number` too. A peer sending
+    `{"type": "integer", "minimum": 0.0}` sent something the getter threw on.
+    `multipleOf` next to them already read `num`.
 - Add `handleRequestScopedMessage` and `MCPServerFactory`, which serve each
   decoded JSON-RPC message on a fresh server instance for request-scoped
   transports. On 2026-07-28, successful results record the server
@@ -122,12 +128,6 @@
   two took. `SubscribeRequest` and `UnsubscribeRequest` stay for the revisions
   which have them. Serving the request, and delivering notifications on the
   stream it opens, land as separate changes.
-- **BREAKING**: `IntegerSchema`'s four bounds and its default read `num` now,
-  and its factory takes them that way. JSON Schema types the bounds `number`,
-  and the spec gives integers and numbers one definition whose `minimum`,
-  `maximum` and `default` are `number` too. A peer sending
-  `{"type": "integer", "minimum": 0.0}` sent something the getter threw on.
-  `multipleOf` next to them already read `num`.
 - `NumberSchema`, `IntegerSchema` and `BooleanSchema` take a `default`, which
   the schema gives them and `StringSchema` already had. A server could
   pre-fill a text field on an elicitation form but not a number or a checkbox.

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -122,6 +122,18 @@
   two took. `SubscribeRequest` and `UnsubscribeRequest` stay for the revisions
   which have them. Serving the request, and delivering notifications on the
   stream it opens, land as separate changes.
+- **BREAKING**: `IntegerSchema`'s four bounds and its default read `num` now,
+  and its factory takes them that way. JSON Schema types the bounds `number`,
+  and the spec gives integers and numbers one definition whose `minimum`,
+  `maximum` and `default` are `number` too. A peer sending
+  `{"type": "integer", "minimum": 0.0}` sent something the getter threw on.
+  `multipleOf` next to them already read `num`.
+- `NumberSchema`, `IntegerSchema` and `BooleanSchema` take a `default`, which
+  the schema gives them and `StringSchema` already had. A server could
+  pre-fill a text field on an elicitation form but not a number or a checkbox.
+- Fix `uniqueItems` on a list schema, which compared items with `Set`, so two
+  equal maps or lists decoded from JSON counted as different and a list the
+  schema forbids validated. JSON Schema compares by structural equality.
 - Fix `RequestId` so it can hold a JSON-RPC id. Its representation type was
   `json_rpc_2`'s `Parameter` rather than `Object`, which its sibling
   `ProgressToken` uses, so `CancelledNotification.requestId` threw for every

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -68,7 +68,7 @@
     factory takes them that way. JSON Schema types the bounds `number`, and
     the spec gives integers and numbers one definition whose `minimum`,
     `maximum` and `default` are `number` too. A peer sending
-    `{"type": "integer", "minimum": 0.0}` sent something the getter threw on.
+    `{"type": "integer", "minimum": 0.5}` sent something the getter threw on.
     `multipleOf` next to them already read `num`.
 - Add `handleRequestScopedMessage` and `MCPServerFactory`, which serve each
   decoded JSON-RPC message on a fresh server instance for request-scoped

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -1288,9 +1288,9 @@ extension type UntitledSingleSelectEnumSchema.fromMap(
     String? defaultValue,
     required Iterable<String> values,
   }) => UntitledSingleSelectEnumSchema.fromMap({
-    'type': JsonType.string.typeName,
-    if (title != null) 'title': title,
-    if (description != null) 'description': description,
+    Keys.type: JsonType.string.typeName,
+    if (title != null) Keys.title: title,
+    if (description != null) Keys.description: description,
     if (defaultValue != null) Keys.default_: defaultValue,
     Keys.enum_: values,
   });
@@ -1318,9 +1318,9 @@ extension type TitledSingleSelectEnumSchema.fromMap(Map<String, Object?> _value)
     String? defaultValue,
     required Iterable<EnumValueWithTitle> values,
   }) => TitledSingleSelectEnumSchema.fromMap({
-    'type': JsonType.string.typeName,
-    if (title != null) 'title': title,
-    if (description != null) 'description': description,
+    Keys.type: JsonType.string.typeName,
+    if (title != null) Keys.title: title,
+    if (description != null) Keys.description: description,
     if (defaultValue != null) Keys.default_: defaultValue,
     Keys.oneOf: values,
   });
@@ -1365,11 +1365,11 @@ extension type UntitledMultiSelectEnumSchema.fromMap(
     int? maxItems,
     required Iterable<String> values,
   }) => UntitledMultiSelectEnumSchema.fromMap({
-    'type': JsonType.list.typeName,
-    if (title != null) 'title': title,
-    if (description != null) 'description': description,
-    if (defaultValue != null) 'default': defaultValue,
-    if (minItems != null) 'minItems': minItems,
+    Keys.type: JsonType.list.typeName,
+    if (title != null) Keys.title: title,
+    if (description != null) Keys.description: description,
+    if (defaultValue != null) Keys.default_: defaultValue,
+    if (minItems != null) Keys.minItems: minItems,
     if (maxItems != null) Keys.maxItems: maxItems,
     Keys.items: {Keys.enum_: values, Keys.type: JsonType.string.typeName},
   });
@@ -1455,10 +1455,12 @@ extension type NumberSchema.fromMap(Map<String, Object?> _value)
     num? exclusiveMinimum,
     num? exclusiveMaximum,
     num? multipleOf,
+    num? defaultValue,
   }) => NumberSchema.fromMap({
     Keys.type: JsonType.num.typeName,
     if (title != null) Keys.title: title,
     if (description != null) Keys.description: description,
+    if (defaultValue != null) Keys.default_: defaultValue,
     if (minimum != null) Keys.minimum: minimum,
     if (maximum != null) Keys.maximum: maximum,
     if (exclusiveMinimum != null) Keys.exclusiveMinimum: exclusiveMinimum,
@@ -1480,6 +1482,9 @@ extension type NumberSchema.fromMap(Map<String, Object?> _value)
 
   /// The value must be a multiple of this number.
   num? get multipleOf => _value[Keys.multipleOf] as num?;
+
+  /// The default value for this schema.
+  num? get defaultValue => _value[Keys.default_] as num?;
 
   bool _validateNumber(
     Object? data,
@@ -1562,15 +1567,17 @@ extension type IntegerSchema.fromMap(Map<String, Object?> _value)
   factory IntegerSchema({
     String? title,
     String? description,
-    int? minimum,
-    int? maximum,
-    int? exclusiveMinimum,
-    int? exclusiveMaximum,
+    num? minimum,
+    num? maximum,
+    num? exclusiveMinimum,
+    num? exclusiveMaximum,
     num? multipleOf,
+    num? defaultValue,
   }) => IntegerSchema.fromMap({
     Keys.type: JsonType.int.typeName,
     if (title != null) Keys.title: title,
     if (description != null) Keys.description: description,
+    if (defaultValue != null) Keys.default_: defaultValue,
     if (minimum != null) Keys.minimum: minimum,
     if (maximum != null) Keys.maximum: maximum,
     if (exclusiveMinimum != null) Keys.exclusiveMinimum: exclusiveMinimum,
@@ -1579,19 +1586,22 @@ extension type IntegerSchema.fromMap(Map<String, Object?> _value)
   });
 
   /// The minimum value (inclusive) for this integer.
-  int? get minimum => _value[Keys.minimum] as int?;
+  num? get minimum => _value[Keys.minimum] as num?;
 
   /// The maximum value (inclusive) for this integer.
-  int? get maximum => _value[Keys.maximum] as int?;
+  num? get maximum => _value[Keys.maximum] as num?;
 
   /// The minimum value (exclusive) for this integer.
-  int? get exclusiveMinimum => _value[Keys.exclusiveMinimum] as int?;
+  num? get exclusiveMinimum => _value[Keys.exclusiveMinimum] as num?;
 
   /// The maximum value (exclusive) for this integer.
-  int? get exclusiveMaximum => _value[Keys.exclusiveMaximum] as int?;
+  num? get exclusiveMaximum => _value[Keys.exclusiveMaximum] as num?;
 
   /// The value must be a multiple of this number.
   num? get multipleOf => _value[Keys.multipleOf] as num?;
+
+  /// The default value for this schema.
+  num? get defaultValue => _value[Keys.default_] as num?;
 
   bool _validateInteger(
     Object? data,
@@ -1683,12 +1693,19 @@ extension type IntegerSchema.fromMap(Map<String, Object?> _value)
 /// A JSON Schema definition for a [bool].
 extension type BooleanSchema.fromMap(Map<String, Object?> _value)
     implements Schema {
-  factory BooleanSchema({String? title, String? description}) =>
-      BooleanSchema.fromMap({
-        Keys.type: JsonType.bool.typeName,
-        if (title != null) Keys.title: title,
-        if (description != null) Keys.description: description,
-      });
+  factory BooleanSchema({
+    String? title,
+    String? description,
+    bool? defaultValue,
+  }) => BooleanSchema.fromMap({
+    Keys.type: JsonType.bool.typeName,
+    if (title != null) Keys.title: title,
+    if (description != null) Keys.description: description,
+    if (defaultValue != null) Keys.default_: defaultValue,
+  });
+
+  /// The default value for this schema.
+  bool? get defaultValue => _value[Keys.default_] as bool?;
 }
 
 /// A JSON Schema definition for `null`.
@@ -1875,24 +1892,31 @@ extension type ListSchema.fromMap(Map<String, Object?> _value)
       );
     }
 
-    if (uniqueItems == true && data.toSet().length != data.length) {
-      final seenItems = <Object?>{};
-      final duplicates = <Object?>{};
-      for (final item in data) {
-        if (seenItems.contains(item)) {
-          duplicates.add(item);
-        } else {
-          seenItems.add(item);
-        }
-      }
-      isValid = false;
-      accumulatedFailures.add(
-        ValidationError(
-          ValidationErrorType.uniqueItemsViolated,
-          path: currentPath,
-          details: 'List contains duplicate items: ${duplicates.join(', ')}',
-        ),
+    if (uniqueItems == true) {
+      // JSON Schema compares items by instance equality, which is structural
+      // for arrays and objects, so `==` is not enough for decoded JSON.
+      const equality = DeepCollectionEquality();
+      final seenItems = LinkedHashSet<Object?>(
+        equals: equality.equals,
+        hashCode: equality.hash,
       );
+      final duplicates = LinkedHashSet<Object?>(
+        equals: equality.equals,
+        hashCode: equality.hash,
+      );
+      for (final item in data) {
+        if (!seenItems.add(item)) duplicates.add(item);
+      }
+      if (duplicates.isNotEmpty) {
+        isValid = false;
+        accumulatedFailures.add(
+          ValidationError(
+            ValidationErrorType.uniqueItemsViolated,
+            path: currentPath,
+            details: 'List contains duplicate items: ${duplicates.join(', ')}',
+          ),
+        );
+      }
     }
 
     final evaluatedItems = List<bool>.filled(data.length, false);

--- a/pkgs/dart_mcp/test/api/tools_test.dart
+++ b/pkgs/dart_mcp/test/api/tools_test.dart
@@ -144,6 +144,7 @@ void main() {
         exclusiveMinimum: 0,
         exclusiveMaximum: 11,
         multipleOf: 2,
+        defaultValue: 5,
       );
       expect(schema, {
         'type': 'number',
@@ -154,34 +155,49 @@ void main() {
         'exclusiveMinimum': 0,
         'exclusiveMaximum': 11,
         'multipleOf': 2,
+        'default': 5,
       });
+      expect(schema.defaultValue, 5);
     });
 
     test('IntegerSchema', () {
       final schema = IntegerSchema(
         title: 'Foo',
         description: 'Bar',
-        minimum: 1,
+        minimum: 1.0,
         maximum: 10,
         exclusiveMinimum: 0,
         exclusiveMaximum: 11,
         multipleOf: 2,
+        defaultValue: 5,
       );
       expect(schema, {
         'type': 'integer',
         'title': 'Foo',
         'description': 'Bar',
-        'minimum': 1,
+        'minimum': 1.0,
         'maximum': 10,
         'exclusiveMinimum': 0,
         'exclusiveMaximum': 11,
         'multipleOf': 2,
+        'default': 5,
       });
+      expect(schema.defaultValue, 5);
     });
 
     test('BooleanSchema', () {
-      final schema = BooleanSchema(title: 'Foo', description: 'Bar');
-      expect(schema, {'type': 'boolean', 'title': 'Foo', 'description': 'Bar'});
+      final schema = BooleanSchema(
+        title: 'Foo',
+        description: 'Bar',
+        defaultValue: true,
+      );
+      expect(schema, {
+        'type': 'boolean',
+        'title': 'Foo',
+        'description': 'Bar',
+        'default': true,
+      });
+      expect(schema.defaultValue, isTrue);
     });
 
     test('NullSchema', () {
@@ -387,6 +403,59 @@ void main() {
           ValidationError(ValidationErrorType.typeMismatch, path: const []),
         ]);
       });
+      test('integer schema with integer-like num bounds (e.g. 11.0)', () {
+        // MCP's own `NumberSchema` covers both `integer` and `number` types
+        // and types `minimum`/`maximum` as `number`, so a conforming peer may
+        // send whole-number bounds as JSON doubles.
+        final schema =
+            Schema.fromMap(
+                  (jsonDecode(
+                            '{"type":"integer","minimum":11.0,"maximum":20.0,'
+                            '"default":15.0}',
+                          )
+                          as Map)
+                      .cast<String, Object?>(),
+                )
+                as IntegerSchema;
+        expect(schema.minimum, 11.0);
+        expect(schema.maximum, 20.0);
+        expect(schema.defaultValue, 15.0);
+        expectFailuresMatch(schema, 10, [
+          ValidationError(ValidationErrorType.minimumNotMet, path: const []),
+        ]);
+        expect(schema.validate(12), isEmpty);
+      });
+
+      test('number schema with a whole default from the wire', () {
+        final schema =
+            Schema.fromMap(
+                  (jsonDecode('{"type":"number","default":5.0}') as Map)
+                      .cast<String, Object?>(),
+                )
+                as NumberSchema;
+        expect(schema.defaultValue, 5.0);
+      });
+
+      test('integer schema with exclusive num bounds from the wire', () {
+        final schema =
+            Schema.fromMap(
+                  (jsonDecode(
+                            '{"type":"integer","exclusiveMinimum":0.0,'
+                            '"exclusiveMaximum":10.0}',
+                          )
+                          as Map)
+                      .cast<String, Object?>(),
+                )
+                as IntegerSchema;
+        expect(schema.validate(5), isEmpty);
+        expectFailuresMatch(schema, 0, [
+          ValidationError(
+            ValidationErrorType.exclusiveMinimumNotMet,
+            path: const [],
+          ),
+        ]);
+      });
+
       test('integer schema with integer-like num data (e.g. 10.0)', () {
         // This test expects minimumNotMet because 10.0 is converted to int 10,
         // which is less than the minimum of 11.
@@ -649,6 +718,32 @@ void main() {
             ),
           ],
         );
+      });
+
+      test('uniqueItemsViolated - structurally equal objects', () {
+        // JSON Schema compares items by instance equality, which is
+        // structural for objects and arrays, and property order does not
+        // matter.
+        final schema = ListSchema(uniqueItems: true);
+        for (final duplicates in [
+          '[{"id": 1}, {"id": 1}]',
+          '[{"a": 1, "b": 2}, {"b": 2, "a": 1}]',
+          '[[1, {"b": 2}], [1, {"b": 2}]]',
+        ]) {
+          expectFailuresMatch(schema, jsonDecode(duplicates), [
+            ValidationError(
+              ValidationErrorType.uniqueItemsViolated,
+              path: const [],
+            ),
+          ], reason: duplicates);
+        }
+        for (final unique in [
+          '[{"id": 1}, {"id": 2}]',
+          '[[1], [2]]',
+          '[[1, 2], [2, 1]]',
+        ]) {
+          expect(schema.validate(jsonDecode(unique)), isEmpty, reason: unique);
+        }
       });
 
       test('uniqueItemsViolated', () {

--- a/pkgs/dart_mcp/test/api/tools_test.dart
+++ b/pkgs/dart_mcp/test/api/tools_test.dart
@@ -721,9 +721,8 @@ void main() {
       });
 
       test('uniqueItemsViolated - structurally equal objects', () {
-        // JSON Schema compares items by instance equality, which is
-        // structural for objects and arrays, and property order does not
-        // matter.
+        // Key order does not make two objects distinct, and element order
+        // does make two arrays distinct.
         final schema = ListSchema(uniqueItems: true);
         for (final duplicates in [
           '[{"id": 1}, {"id": 1}]',

--- a/pkgs/dart_mcp/test/api/tools_test.dart
+++ b/pkgs/dart_mcp/test/api/tools_test.dart
@@ -160,6 +160,16 @@ void main() {
       expect(schema.defaultValue, 5);
     });
 
+    test('number schema with a whole default from the wire', () {
+      final schema =
+          Schema.fromMap(
+                (jsonDecode('{"type":"number","default":5.0}') as Map)
+                    .cast<String, Object?>(),
+              )
+              as NumberSchema;
+      expect(schema.defaultValue, 5.0);
+    });
+
     test('IntegerSchema', () {
       final schema = IntegerSchema(
         title: 'Foo',
@@ -403,59 +413,6 @@ void main() {
           ValidationError(ValidationErrorType.typeMismatch, path: const []),
         ]);
       });
-      test('integer schema with integer-like num bounds (e.g. 11.0)', () {
-        // MCP's own `NumberSchema` covers both `integer` and `number` types
-        // and types `minimum`/`maximum` as `number`, so a conforming peer may
-        // send whole-number bounds as JSON doubles.
-        final schema =
-            Schema.fromMap(
-                  (jsonDecode(
-                            '{"type":"integer","minimum":11.0,"maximum":20.0,'
-                            '"default":15.0}',
-                          )
-                          as Map)
-                      .cast<String, Object?>(),
-                )
-                as IntegerSchema;
-        expect(schema.minimum, 11.0);
-        expect(schema.maximum, 20.0);
-        expect(schema.defaultValue, 15.0);
-        expectFailuresMatch(schema, 10, [
-          ValidationError(ValidationErrorType.minimumNotMet, path: const []),
-        ]);
-        expect(schema.validate(12), isEmpty);
-      });
-
-      test('number schema with a whole default from the wire', () {
-        final schema =
-            Schema.fromMap(
-                  (jsonDecode('{"type":"number","default":5.0}') as Map)
-                      .cast<String, Object?>(),
-                )
-                as NumberSchema;
-        expect(schema.defaultValue, 5.0);
-      });
-
-      test('integer schema with exclusive num bounds from the wire', () {
-        final schema =
-            Schema.fromMap(
-                  (jsonDecode(
-                            '{"type":"integer","exclusiveMinimum":0.0,'
-                            '"exclusiveMaximum":10.0}',
-                          )
-                          as Map)
-                      .cast<String, Object?>(),
-                )
-                as IntegerSchema;
-        expect(schema.validate(5), isEmpty);
-        expectFailuresMatch(schema, 0, [
-          ValidationError(
-            ValidationErrorType.exclusiveMinimumNotMet,
-            path: const [],
-          ),
-        ]);
-      });
-
       test('integer schema with integer-like num data (e.g. 10.0)', () {
         // This test expects minimumNotMet because 10.0 is converted to int 10,
         // which is less than the minimum of 11.
@@ -842,6 +799,48 @@ void main() {
         ]);
       });
       // ... other integer specific tests using expectFailuresMatch
+      test('integer schema with integer-like num bounds (e.g. 11.0)', () {
+        // MCP's own `NumberSchema` covers both `integer` and `number` types
+        // and types `minimum`/`maximum` as `number`, so a conforming peer may
+        // send whole-number bounds as JSON doubles.
+        final schema =
+            Schema.fromMap(
+                  (jsonDecode(
+                            '{"type":"integer","minimum":11.0,"maximum":20.0,'
+                            '"default":15.0}',
+                          )
+                          as Map)
+                      .cast<String, Object?>(),
+                )
+                as IntegerSchema;
+        expect(schema.minimum, 11.0);
+        expect(schema.maximum, 20.0);
+        expect(schema.defaultValue, 15.0);
+        expectFailuresMatch(schema, 10, [
+          ValidationError(ValidationErrorType.minimumNotMet, path: const []),
+        ]);
+        expect(schema.validate(12), isEmpty);
+      });
+
+      test('integer schema with exclusive num bounds from the wire', () {
+        final schema =
+            Schema.fromMap(
+                  (jsonDecode(
+                            '{"type":"integer","exclusiveMinimum":0.0,'
+                            '"exclusiveMaximum":10.0}',
+                          )
+                          as Map)
+                      .cast<String, Object?>(),
+                )
+                as IntegerSchema;
+        expect(schema.validate(5), isEmpty);
+        expectFailuresMatch(schema, 0, [
+          ValidationError(
+            ValidationErrorType.exclusiveMinimumNotMet,
+            path: const [],
+          ),
+        ]);
+      });
     });
   });
 


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

Four of the schema types in `tools.dart` disagree with the JSON Schema the spec points at.

Integer bounds were typed as ints. JSON Schema types them as numbers, and the spec gives integers and numbers one definition. A valid `minimum: 0.5` threw on read. Number, integer and boolean schemas could not carry a default at all, leaving a server able to pre-fill a text field but not a checkbox. Two equal maps decoded from JSON got past `uniqueItems` on a list schema, since it compared them with `Set`. I picked up the enum factories spelling their own keys while I was in there.

