### PR TITLE
update the Meta dartdoc to the reverse DNS prefix rule

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -64,6 +64,10 @@
     revisions fill it in only when the server set none. `LoggingSupport` also
     stops registering `logging/setLevel` on that revision, which is what a
     transport dispatching on its own gets.
+- Fix the `Meta` dartdoc, which still described the 2025-06-18 prefix rule, and
+  document the `traceparent`, `tracestate`, and `baggage` keys reserved for
+  OpenTelemetry trace context, see
+  https://modelcontextprotocol.io/specification/2026-07-28/basic#_meta.
 - Add `handleRequestScopedMessage` and `MCPServerFactory`, which serve each
   decoded JSON-RPC message on a fresh server instance for request-scoped
   transports. On 2026-07-28, successful results record the server

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -173,14 +173,23 @@ extension type Cursor(String _) {}
 /// - Prefix: If specified, MUST be a series of labels separated by dots
 ///   (`.`), followed by a slash (`/`). Labels MUST start with a letter and
 ///   end with a letter or digit; interior characters can be letters, digits,
-///   or hyphens (`-`). Any prefix beginning with zero or more valid labels,
-///   followed by `modelcontextprotocol` or `mcp`, followed by any valid
-///   label, is reserved for MCP use. For example: `modelcontextprotocol.io/`,
-///   `mcp.dev/`, `api.modelcontextprotocol.org/`, and `tools.mcp.com/` are
-///   all reserved.
+///   or hyphens (`-`). From the 2025-11-25 revision, implementations SHOULD
+///   use reverse DNS notation (e.g., `com.example/` rather than
+///   `example.com/`), and any prefix whose second label is
+///   `modelcontextprotocol` or `mcp` is reserved for MCP use. For example:
+///   `io.modelcontextprotocol/`, `dev.mcp/`, `org.modelcontextprotocol.api/`,
+///   and `com.mcp.tools/` are all reserved, while `com.example.mcp/` is not,
+///   because its second label is `example`. The 2025-06-18 revision reserved
+///   any prefix carrying `modelcontextprotocol` or `mcp` in a label other
+///   than the last.
 /// - Name: Unless empty, MUST begin and end with an alphanumeric character
 ///   (`[a-z0-9A-Z]`). MAY contain hyphens (`-`), underscores (`_`), dots
 ///   (`.`), and alphanumerics in between.
+///
+/// From the 2026-07-28 revision, `traceparent`, `tracestate`, and `baggage`
+/// are reserved for OpenTelemetry trace context, as an exception to the prefix
+/// rule. When present, their values MUST follow the W3C Trace Context and
+/// W3C Baggage formats respectively.
 extension type Meta.fromMap(Map<String, Object?> _value) {
   Object? operator [](String key) => _value[key];
 }


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

These docs still describe the 2025-06-18 prefix rule, where a prefix was reserved if `modelcontextprotocol` or `mcp` sat in any label but the last. The 2025-11-25 revision keys it off the second label instead, so two of the four examples we carry, `modelcontextprotocol.io/` and `mcp.dev/`, are not reserved any more. The `io.modelcontextprotocol/` prefix we write keys under only became reserved with that change. I added the OpenTelemetry exception from 2026-07-28, since these docs do not mention it.
