### PR TITLE
answer a notifying request on an SSE response stream

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -142,16 +142,20 @@
   results, so the sixth operation the caching rules name is no longer the one
   which cannot carry the hints. This adds the types only; the server does not
   answer `server/discover` yet.
+- Answer a request whose handler emits related notifications on an SSE
+  response stream. A quiet handler keeps its JSON body. List changes and
+  resource updates reach `onNotification` alone, since this revision carries
+  those on a `subscriptions/listen` stream. Does not treat a closed stream as
+  cancellation, which the specification requires.
 - Add `package:dart_mcp/streamable_http.dart` with
   `handleStreamableHttpRequest`, the server side of the Streamable HTTP
   transport from the 2026-07-28 revision, see
   https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http.
   Each POST carries one JSON-RPC request or notification which is validated
   against the required headers and `_meta` envelope, then dispatched to a
-  fresh server instance via `handleRequestScopedMessage`. Responses are JSON
-  only. See `example/streamable_http_server.dart`. Does not add SSE response
-  streams, the legacy session routes, or an HTTP client; those land as
-  separate changes.
+  fresh server instance via `handleRequestScopedMessage`. See
+  `example/streamable_http_server.dart`. Does not add the legacy session
+  routes or an HTTP client; those land as separate changes.
 - Add `ProtocolVersion.addedMethods` and `.removedMethods`, listing what each
   revision of the protocol introduced and took out, and
   `ProtocolVersion.methodIsValid`, which walks back from a revision to answer

--- a/pkgs/dart_mcp/README.md
+++ b/pkgs/dart_mcp/README.md
@@ -127,7 +127,7 @@ can be used, but some are directly supported out of the box.
 | Transport | Support | Notes |
 | --- | --- | --- |
 | [Stdio](https://modelcontextprotocol.io/specification/2025-11-05/basic/transports#stdio) | :heavy_check_mark: |  |
-| [Streamable HTTP](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http) | :construction: | Server side only, as `handleStreamableHttpRequest` in `package:dart_mcp/streamable_http.dart`. Answers with JSON bodies; SSE response streams and the client side are not implemented yet. |
+| [Streamable HTTP](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http) | :construction: | Server side only, as `handleStreamableHttpRequest` in `package:dart_mcp/streamable_http.dart`. Answers a request whose handler emits related notifications on an SSE response stream, and every other request with a JSON body. The client side is not implemented yet. |
 
 ## Batching Requests
 

--- a/pkgs/dart_mcp/README.md
+++ b/pkgs/dart_mcp/README.md
@@ -126,7 +126,7 @@ can be used, but some are directly supported out of the box.
 
 | Transport | Support | Notes |
 | --- | --- | --- |
-| [Stdio](https://modelcontextprotocol.io/specification/2025-11-05/basic/transports#stdio) | :heavy_check_mark: |  |
+| [Stdio](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#stdio) | :heavy_check_mark: |  |
 | [Streamable HTTP](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http) | :construction: | Server side only, as `handleStreamableHttpRequest` in `package:dart_mcp/streamable_http.dart`. Answers a request whose handler emits related notifications on an SSE response stream, and every other request with a JSON body. The client side is not implemented yet. |
 
 ## Batching Requests

--- a/pkgs/dart_mcp/example/streamable_http_server.dart
+++ b/pkgs/dart_mcp/example/streamable_http_server.dart
@@ -7,8 +7,9 @@
 ///
 /// Run it with `dart run example/streamable_http_server.dart`. It prints a
 /// `curl` command for the tool it registers; the transport has no client in
-/// this package yet, so that is how to drive it. The command is answered
-/// with 200 and a JSON body containing `Hello, world!`.
+/// this package yet, so that is how to drive it. The command asks for progress
+/// and the tool reports it, so the answer comes back as an SSE response
+/// stream: the report first, then a result containing `Hello, world!`.
 library;
 
 import 'dart:io' as io;
@@ -60,15 +61,14 @@ void main() async {
       await handleStreamableHttpRequest(
         request,
         MCPServerWithGreeting.new,
-        // A JSON response body cannot carry notifications, so anything the
-        // server sends while handling the request is dropped without this.
-        // `greet` sends one when the request carries a progress token, which
-        // the command below does.
+        // `greet` sends a notification when the request carries a progress
+        // token, which the command below does. It goes out on the response
+        // stream, and this callback is the host's own copy of it.
         onNotification:
             (notification) => io.stderr.writeln('notification: $notification'),
       );
     } catch (error) {
-      // The request already has its 500; this is the copy the host keeps.
+      // The request already carries the failure. This is the host's copy.
       io.stderr.writeln('request failed: $error');
     }
   });
@@ -126,8 +126,8 @@ base class MCPServerWithGreeting extends MCPServer with ToolsSupport {
 
   /// The implementation of the `greet` tool.
   CallToolResult _greet(CallToolRequest request) {
-    // The JSON body carries the result and nothing else, so this notification
-    // reaches the host through `onNotification` or not at all.
+    // Sending this commits the response to an SSE response stream, and the
+    // `curl` command above gets one back.
     if (request.meta?.progressToken case final progressToken?) {
       notifyProgress(
         ProgressNotification(

--- a/pkgs/dart_mcp/lib/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/streamable_http.dart
@@ -7,9 +7,10 @@
 /// https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http.
 ///
 /// Every POST carries a single JSON-RPC request or notification along with
-/// its own client context; there is no session state between requests. This
-/// library only answers with JSON bodies; SSE response streams are not
-/// implemented yet.
+/// its own client context; there is no session state between requests. A
+/// request is answered on an SSE response stream if its handler emits related
+/// notifications, and with a JSON body otherwise. The list and resource change
+/// notifications reach `onNotification` alone.
 library;
 
 import 'dart:convert';
@@ -60,18 +61,20 @@ import 'src/utils/json_rpc_2_object.dart';
 /// error a request handler throws reaches the client with whatever payload
 /// `package:json_rpc_2` attached to it, including a Dart stack trace for
 /// errors which are not an [RpcException]. Handlers which must not disclose
-/// server internals to a remote client throw [RpcException]s instead. The
-/// status such a body gets follows its error code: an internal or server
-/// error is a 500, so a handler which fails is visible to intermediaries
-/// which never read the body, and a code the specification has not mapped to
-/// a status keeps 200.
+/// server internals to a remote client throw [RpcException]s instead. Until
+/// something has been written the status such a body gets follows its error
+/// code: an internal or server error is a 500, so a failing handler is visible
+/// to intermediaries that never read the body, and a code the specification
+/// has not mapped to a status keeps 200. Once a notification has gone out on
+/// the stream the status was spent on it at 200, and the error goes out as the
+/// last event of the stream instead.
 ///
-/// If [serverFactory] or [MCPServer.initialize] throws, the request is
-/// answered with 500 and an internal-error body, and the returned future then
-/// completes with that error so an embedder which awaits it can log or rethrow
-/// it. A client which disconnects while its body is still arriving leaves
-/// nothing to answer, so the returned future completes normally without
-/// writing a response.
+/// If [serverFactory] or [MCPServer.initialize] throws, the request gets an
+/// internal-error body, on the stream when one is open and with a 500 when it
+/// is not, and the returned future then completes with that error so an
+/// embedder awaiting it can log or rethrow it. If a client disconnects while
+/// its body is still arriving there is nothing to answer, so the returned
+/// future completes normally without writing a response.
 ///
 /// `Mcp-Session-Id` and `Last-Event-ID` headers are ignored, and no session
 /// id is ever minted: sessions and resumable streams were removed in this
@@ -80,9 +83,13 @@ import 'src/utils/json_rpc_2_object.dart';
 /// header is ever recognized, and it is ignored along with every other
 /// header this handler does not read.
 ///
-/// Notifications the server produces while handling the request are passed
-/// to [onNotification]; a JSON response body cannot carry them, so without a
-/// handler they are dropped.
+/// Notifications the server produces while handling the request go out on an
+/// SSE response stream. The first one commits `text/event-stream`, and the
+/// result follows it as the last event. A request answered without one gets a
+/// JSON body instead. The long-lived change notifications this revision
+/// delivers on a `subscriptions/listen` stream are held back from the response
+/// stream, since a server emits several of them without choosing to.
+/// [onNotification] sees every notification either way, held back or not.
 Future<void> handleStreamableHttpRequest(
   HttpRequest request,
   MCPServerFactory serverFactory, {
@@ -221,8 +228,7 @@ Future<void> handleStreamableHttpRequest(
   }
 
   // A request may be answered with either a JSON object or an SSE stream, so
-  // the client has to accept both shapes even though this handler only sends
-  // the first.
+  // the client has to accept both shapes.
   if (!_accepts(request, ContentType.json.mimeType) ||
       !_accepts(request, _eventStreamMimeType)) {
     return _reject(
@@ -429,6 +435,7 @@ Future<void> handleStreamableHttpRequest(
     );
   }
 
+  final answer = _Answer(response);
   final Map<String, Object?>? result;
   try {
     result = await handleRequestScopedMessage(
@@ -441,30 +448,32 @@ Future<void> handleStreamableHttpRequest(
         logLevel: logLevel,
       ),
       serverFactory,
-      onNotification: onNotification,
+      onNotification: (notification) {
+        if (!_listenStreamNotifications.contains(notification[Keys.method])) {
+          answer.notify(notification);
+        }
+        onNotification?.call(notification);
+      },
     );
   } catch (_) {
     // The server could not be built for this request. Answer before the error
     // leaves this function, so an embedder which discards the returned future
-    // does not leave the connection open.
-    await _reject(
-      response,
-      HttpStatus.internalServerError,
+    // does not leave the connection open. A server that emitted a notification
+    // while initializing has already committed the stream, and headers cannot
+    // be set on it a second time. The answer goes out on the stream instead of
+    // starting a fresh response.
+    await answer.finish(
       RpcException(
         error_code.INTERNAL_ERROR,
         'The server failed to initialize',
-      ),
-      decoded,
+      ).serialize(decoded),
     );
     rethrow;
   }
 
   // Notifications returned above, so a dispatched request always has a
   // response.
-  response.statusCode = _statusFor(result!);
-  response.headers.contentType = ContentType.json;
-  response.write(jsonEncode(result));
-  await response.close();
+  await answer.finish(result!);
 }
 
 /// The HTTP status for a dispatched JSON-RPC [response] map.
@@ -487,6 +496,75 @@ int _statusFor(Map<String, Object?> response) {
     error_code.SERVER_ERROR => HttpStatus.internalServerError,
     _ => HttpStatus.ok,
   };
+}
+
+/// The notifications this revision delivers on the stream of a
+/// `subscriptions/listen` request, so a response stream never carries them.
+///
+/// The four are the notifications `SubscriptionFilter` names.
+///
+/// [handleStreamableHttpRequest] passes them to its `onNotification` instead,
+/// where an embedder serving a listen stream picks them up. See
+/// https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http.
+const _listenStreamNotifications = {
+  ToolListChangedNotification.methodName,
+  PromptListChangedNotification.methodName,
+  ResourceListChangedNotification.methodName,
+  ResourceUpdatedNotification.methodName,
+};
+
+/// Frames [message] as one SSE `event: message` block.
+String _sseEvent(Map<String, Object?> message) =>
+    'event: message\ndata: ${jsonEncode(message)}\n\n';
+
+/// Answers one request, choosing between a JSON body and an SSE stream.
+///
+/// The choice is deferred. As long as nothing has been written the answer is a
+/// JSON body with the status [_statusFor] maps, keeping the `400` and `404`
+/// answers this revision defines available. The first notification
+/// commits `text/event-stream`, since a JSON body has nowhere to put one.
+/// Committing settles the status at `200`. An error raised after that goes out
+/// as the stream's last event, and the mapped status
+/// no longer applies to it, including the `400` this revision requires of a
+/// missing client capability.
+class _Answer {
+  _Answer(this._response);
+
+  final HttpResponse _response;
+  bool _committed = false;
+
+  /// Sends [notification] on the stream, committing to it if this is the first.
+  void notify(Map<String, Object?> notification) {
+    if (!_committed) _commit();
+    _response.write(_sseEvent(notification));
+  }
+
+  void _commit() {
+    _committed = true;
+    _response
+      ..statusCode = HttpStatus.ok
+      ..bufferOutput = false
+      ..headers.contentType = ContentType(
+        'text',
+        'event-stream',
+        charset: 'utf-8',
+      )
+      ..headers.set(HttpHeaders.cacheControlHeader, 'no-cache, no-transform')
+      ..headers.set('x-accel-buffering', 'no');
+  }
+
+  /// Sends [result] and closes.
+  Future<void> finish(Map<String, Object?> result) async {
+    if (_committed) {
+      _response.write(_sseEvent(result));
+    } else {
+      _response
+        ..statusCode = _statusFor(result)
+        ..headers.contentType = ContentType.json
+        ..write(jsonEncode(result));
+    }
+    await _response.close();
+  }
 }
 
 /// Writes [exception] serialized against [origin] as a JSON body with

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -1629,9 +1629,7 @@ base class _PromptNoisyServer extends MCPServer
       );
 
   @override
-  FutureOr<ServerCapabilities> initialize(
-    MCPServerInitialization initialization,
-  ) {
+  FutureOr<void> initialize(MCPServerInitialization initialization) {
     registerTool(Tool(name: 'test/adds-prompt', inputSchema: ObjectSchema()), (
       _,
     ) {

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -116,6 +116,33 @@ void main() {
   Map<String, Object?> decode(String text) =>
       jsonDecode(text) as Map<String, Object?>;
 
+  /// The field lines of one SSE frame, keyed by field name.
+  Map<String, String> fields(String frame) {
+    final fields = <String, String>{};
+    for (final line in frame.split('\n')) {
+      final colon = line.indexOf(':');
+      if (colon > 0) {
+        fields[line.substring(0, colon)] = line.substring(colon + 1).trim();
+      }
+    }
+    return fields;
+  }
+
+  /// The frames an SSE response [text] carries.
+  ///
+  /// Reads the fields the way a client does instead of matching the bytes the
+  /// transport writes, which lets a change to the framing fail a test here.
+  List<Map<String, String>> frames(String text) => [
+    for (final frame in text.split('\n\n'))
+      if (frame.trim().isNotEmpty) fields(frame),
+  ];
+
+  /// The JSON-RPC messages an SSE response [text] carries, in order.
+  List<Map<String, Object?>> events(String text) => [
+    for (final frame in frames(text))
+      jsonDecode(frame['data']!) as Map<String, Object?>,
+  ];
+
   Object? errorCode(String text) =>
       (decode(text)[Keys.error] as Map<String, Object?>?)?[Keys.code];
 
@@ -730,7 +757,12 @@ void main() {
         json: logBody(logLevel: LoggingLevel.error.name),
       );
       expect(status, 200);
-      expect(errorCode(text), isNull);
+      final messages = events(text);
+      expect(
+        messages.first[Keys.method],
+        LoggingMessageNotification.methodName,
+      );
+      expect(messages.last[Keys.error], isNull);
       expect(
         notifications.single[Keys.method],
         LoggingMessageNotification.methodName,
@@ -1215,7 +1247,12 @@ void main() {
         json: body(callTool, params: {Keys.name: 'test/notify'}),
       );
       expect(status, 200);
-      expect(errorCode(text), isNull);
+      final messages = events(text);
+      expect(
+        messages.first[Keys.method],
+        LoggingMessageNotification.methodName,
+      );
+      expect(messages.last[Keys.error], isNull);
       expect(notifications, hasLength(1));
       expect(
         notifications.single[Keys.method],
@@ -1223,7 +1260,237 @@ void main() {
       );
     });
   });
+
+  group('response shape', () {
+    test('keeps a list change off the response stream', () async {
+      const tool = 'test/registers-then-fails';
+      final (status, responseHeaders, text) = await post(
+        headers: {...headers(callTool), 'Mcp-Name': tool},
+        json: body(callTool, params: {Keys.name: tool}),
+      );
+
+      // The list change belongs on a `subscriptions/listen` stream. Writing it
+      // here would commit the response and spend the 400 this revision
+      // requires of the error the handler goes on to throw.
+      expect(status, 400);
+      expect(responseHeaders.contentType?.mimeType, 'application/json');
+      expect(errorCode(text), -32021);
+      expect(
+        notifications.map((notification) => notification[Keys.method]),
+        contains(ToolListChangedNotification.methodName),
+      );
+    });
+
+    test('answers a quiet handler with a json body', () async {
+      final (status, responseHeaders, text) = await post(
+        headers: {...headers(listTools)},
+        json: body(listTools),
+      );
+      expect(status, 200);
+      expect(responseHeaders.contentType?.mimeType, 'application/json');
+      expect(decode(text)[Keys.error], isNull);
+    });
+
+    test('delivers a notification before the result', () async {
+      releaseNotifyThenWait = Completer<void>();
+      addTearDown(() {
+        if (!releaseNotifyThenWait.isCompleted) {
+          releaseNotifyThenWait.complete();
+        }
+      });
+      final client = HttpClient();
+      addTearDown(client.close);
+      final request = await client.openUrl('POST', uri);
+      headers(callTool).forEach(request.headers.set);
+      request.headers.set('Mcp-Name', 'test/notify-then-wait');
+      request.write(
+        jsonEncode(
+          body(callTool, params: {Keys.name: 'test/notify-then-wait'}),
+        ),
+      );
+      final response = await request.close();
+
+      // The handler is still parked. Anything read here arrived before the
+      // result did, and a buffered response would deliver nothing until close.
+      final chunks = StringBuffer();
+      final firstFrame = Completer<String>();
+      final subscription = response.transform(utf8.decoder).listen((chunk) {
+        chunks.write(chunk);
+        if (!firstFrame.isCompleted && chunks.toString().contains('\n\n')) {
+          firstFrame.complete(chunks.toString());
+        }
+      });
+      addTearDown(subscription.cancel);
+
+      final early = await firstFrame.future;
+      expect(
+        events(early).single[Keys.method],
+        LoggingMessageNotification.methodName,
+      );
+
+      releaseNotifyThenWait.complete();
+      await subscription.asFuture<void>();
+      expect(events(chunks.toString()), hasLength(2));
+    });
+
+    test('keeps the stream open for a second notification', () async {
+      final (status, responseHeaders, text) = await post(
+        headers: {...headers(callTool), 'Mcp-Name': 'test/notify-twice'},
+        json: body(callTool, params: {Keys.name: 'test/notify-twice'}),
+      );
+      expect(status, 200);
+      expect(responseHeaders.contentType?.mimeType, 'text/event-stream');
+      final messages = events(text);
+      expect(messages, hasLength(3));
+      expect(
+        messages.take(2).map((m) => m[Keys.method]),
+        everyElement(LoggingMessageNotification.methodName),
+      );
+      expect(messages.last[Keys.id], isNotNull);
+    });
+
+    test('answers an unknown method with 404 and a json body', () async {
+      const unknown = 'test/nothing-defines-this';
+      final (status, responseHeaders, text) = await post(
+        headers: headers(unknown),
+        json: body(unknown),
+      );
+      expect(status, 404);
+      expect(responseHeaders.contentType?.mimeType, 'application/json');
+      expect(errorCode(text), error_code.METHOD_NOT_FOUND);
+    });
+
+    test('sets the streaming headers with the first event', () async {
+      final (_, responseHeaders, text) = await post(
+        headers: {...headers(callTool), 'Mcp-Name': 'test/notify'},
+        json: body(callTool, params: {Keys.name: 'test/notify'}),
+      );
+      expect(responseHeaders.contentType?.charset, 'utf-8');
+      expect(
+        responseHeaders.value(HttpHeaders.cacheControlHeader),
+        contains('no-cache'),
+      );
+      // A SHOULD of this revision. A reverse proxy that honors it stops
+      // holding the events back until the response closes.
+      expect(responseHeaders.value('x-accel-buffering'), 'no');
+      expect(
+        frames(text).map((frame) => frame['event']),
+        everyElement('message'),
+      );
+    });
+
+    test('sends a late error as the last event on the stream', () async {
+      final (status, responseHeaders, text) = await post(
+        headers: {...headers(callTool), 'Mcp-Name': 'test/notify-then-throw'},
+        json: body(callTool, params: {Keys.name: 'test/notify-then-throw'}),
+      );
+      // The status is spent on the first notification. The mapped 400 this
+      // error carries when it arrives alone is no longer reachable.
+      expect(status, 200);
+      expect(responseHeaders.contentType?.mimeType, 'text/event-stream');
+      final messages = events(text);
+      expect(messages, hasLength(2));
+      expect(
+        (messages.last[Keys.error] as Map<String, Object?>)[Keys.code],
+        error_code.INVALID_PARAMS,
+      );
+    });
+
+    test('keeps a prompt list change off the response stream', () async {
+      final noisy = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => noisy.close(force: true));
+      const tool = 'test/adds-prompt';
+      noisy.listen(
+        (request) =>
+            handleStreamableHttpRequest(request, _PromptNoisyServer.new),
+      );
+      final client = HttpClient();
+      addTearDown(client.close);
+      final request = await client.postUrl(
+        Uri.http('${noisy.address.host}:${noisy.port}', '/mcp'),
+      );
+      final callHeaders = {...headers(callTool), 'Mcp-Name': tool};
+      callHeaders.forEach(request.headers.set);
+      request.write(jsonEncode(body(callTool, params: {Keys.name: tool})));
+      final response = await request.close();
+      final text = await utf8.decodeStream(response);
+
+      expect(response.statusCode, 200);
+      expect(response.headers.contentType?.mimeType, 'application/json');
+      expect(text, isNot(contains(PromptListChangedNotification.methodName)));
+    });
+
+    test('closes the stream when a notifying server fails', () async {
+      final failing = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => failing.close(force: true));
+      final failure = Completer<Object>();
+      failing.listen(
+        (request) => handleStreamableHttpRequest(
+          request,
+          _NoisyFailingServer.new,
+        ).onError<Object>((error, _) => failure.complete(error)),
+      );
+      final client = HttpClient();
+      addTearDown(client.close);
+      final request = await client.postUrl(
+        Uri.http('${failing.address.host}:${failing.port}', '/mcp'),
+      );
+      headers(listTools).forEach(request.headers.set);
+      request.write(jsonEncode(body(listTools)));
+      final response = await request.close();
+      // Without an answer through the stream this read never returns. The
+      // headers are already sent, and starting a fresh response throws inside
+      // the error path and leaves the connection open.
+      final text = await utf8.decodeStream(response);
+      expect(response.statusCode, 200);
+      expect(response.headers.contentType?.mimeType, 'text/event-stream');
+      final messages = events(text);
+      expect(messages, hasLength(2));
+      expect(
+        (messages.last[Keys.error] as Map<String, Object?>)[Keys.code],
+        error_code.INTERNAL_ERROR,
+      );
+      expect(await failure.future, isStateError);
+    });
+
+    test('writes the event before the handler callback sees it', () async {
+      final rude = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => rude.close(force: true));
+      final swallowed = <Object>[];
+      runZonedGuarded(
+        () => rude.listen(
+          (request) => handleStreamableHttpRequest(
+            request,
+            _HttpTestServer.new,
+            onNotification: (_) => throw StateError('a rude embedder'),
+          ),
+        ),
+        (error, _) => swallowed.add(error),
+      );
+      final client = HttpClient();
+      addTearDown(client.close);
+      final request = await client.postUrl(
+        Uri.http('${rude.address.host}:${rude.port}', '/mcp'),
+      );
+      final sent = {...headers(callTool), 'Mcp-Name': 'test/notify'};
+      sent.forEach(request.headers.set);
+      request.write(
+        jsonEncode(body(callTool, params: {Keys.name: 'test/notify'})),
+      );
+      final response = await request.close();
+      final text = await utf8.decodeStream(response);
+      // An embedder which throws must not be able to keep a notification off
+      // the protocol stream. Writing it first prevents that.
+      expect(response.statusCode, 200);
+      expect(response.headers.contentType?.mimeType, 'text/event-stream');
+      expect(events(text), hasLength(2));
+      expect(swallowed, isNotEmpty);
+    });
+  });
 }
+
+/// Held by `test/notify-then-wait` until a test releases it.
+Completer<void> releaseNotifyThenWait = Completer<void>();
 
 base class _HttpTestServer extends MCPServer with LoggingSupport, ToolsSupport {
   bool get _declaredSampling => clientCapabilities.sampling != null;
@@ -1287,10 +1554,113 @@ base class _HttpTestServer extends MCPServer with LoggingSupport, ToolsSupport {
       );
       return CallToolResult(content: [TextContent(text: 'notified')]);
     });
+    registerTool(Tool(name: 'test/notify-twice', inputSchema: ObjectSchema()), (
+      _,
+    ) {
+      for (final data in ['first', 'second']) {
+        sendNotification(
+          LoggingMessageNotification.methodName,
+          LoggingMessageNotification(level: LoggingLevel.error, data: data),
+        );
+      }
+      return CallToolResult(content: [TextContent(text: 'twice')]);
+    });
+    registerTool(
+      Tool(name: 'test/notify-then-wait', inputSchema: ObjectSchema()),
+      (_) async {
+        sendNotification(
+          LoggingMessageNotification.methodName,
+          LoggingMessageNotification(
+            level: LoggingLevel.error,
+            data: 'before the wait',
+          ),
+        );
+        await releaseNotifyThenWait.future;
+        return CallToolResult(content: [TextContent(text: 'released')]);
+      },
+    );
+    registerTool(
+      Tool(name: 'test/notify-then-throw', inputSchema: ObjectSchema()),
+      (_) {
+        sendNotification(
+          LoggingMessageNotification.methodName,
+          LoggingMessageNotification(
+            level: LoggingLevel.error,
+            data: 'before the failure',
+          ),
+        );
+        throw RpcException.invalidParams('This tool fails after notifying');
+      },
+    );
+    registerTool(
+      Tool(name: 'test/registers-then-fails', inputSchema: ObjectSchema()),
+      (_) {
+        // Registering a tool emits a list change on its own, which is what a
+        // dynamic tool set does while it answers.
+        registerTool(
+          Tool(name: 'test/added-while-answering', inputSchema: ObjectSchema()),
+          (_) => CallToolResult(content: [TextContent(text: 'added')]),
+        );
+        throw RpcException(
+          McpErrorCodes.missingRequiredClientCapability,
+          'This tool needs a capability the client left out',
+        );
+      },
+    );
     registerTool(Tool(name: 'test/log', inputSchema: ObjectSchema()), (_) {
       log(LoggingLevel.error, 'from tool');
       return CallToolResult(content: [TextContent(text: 'logged')]);
     });
+  }
+}
+
+/// A server whose tool registers a prompt while it answers, so the prompt list
+/// change lands mid-request the way a dynamic prompt set makes it.
+base class _PromptNoisyServer extends MCPServer
+    with LoggingSupport, ToolsSupport, PromptsSupport {
+  _PromptNoisyServer(super.channel)
+    : super.fromStreamChannel(
+        implementation: Implementation(
+          name: 'prompt noisy test server',
+          version: '0.1.0',
+        ),
+      );
+
+  @override
+  FutureOr<ServerCapabilities> initialize(
+    MCPServerInitialization initialization,
+  ) {
+    registerTool(Tool(name: 'test/adds-prompt', inputSchema: ObjectSchema()), (
+      _,
+    ) {
+      addPrompt(
+        Prompt(name: 'added-while-answering'),
+        (_) => GetPromptResult(messages: []),
+      );
+      return CallToolResult(content: [TextContent(text: 'added')]);
+    });
+    return super.initialize(initialization);
+  }
+}
+
+/// A server which announces itself and then fails. The transport has already
+/// committed the stream by the time the error reaches it.
+base class _NoisyFailingServer extends _HttpTestServer {
+  _NoisyFailingServer(super.channel);
+
+  @override
+  FutureOr<ServerCapabilities> initialize(
+    MCPServerInitialization initialization,
+  ) async {
+    await super.initialize(initialization);
+    sendNotification(
+      LoggingMessageNotification.methodName,
+      LoggingMessageNotification(
+        level: LoggingLevel.error,
+        data: 'while starting up',
+      ),
+    );
+    throw StateError('initialize failed after announcing');
   }
 }
 


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

Notifications a handler emits while it works now reach the caller on an SSE response stream instead of being dropped. The first one commits the response to `text/event-stream`, so a call that never notifies keeps its JSON body. Progress and log messages ride their own request's stream. The four list-changed and resource-updated notifications stay off it, since a `subscriptions/listen` request owns those.

The README row and the dartdoc that named response streams as missing now describe this. A client closing the stream is not treated as cancellation yet, which the specification requires once a server streams.
