### PR TITLE
update the spec links to modelcontextprotocol.io and 2025-11-25

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -173,6 +173,9 @@
   Streamable HTTP handler already requires; the server map travels with
   `ServerCapabilities`, which is held by the legacy `initialize` result and
   by `DiscoverResult`.
+- Point the documentation at `modelcontextprotocol.io` and at protocol
+  revision 2025-11-25. The old host stopped serving HTTPS, and the old
+  revision number 2025-11-05 was never a published revision.
 
 ## 0.5.2
 

--- a/pkgs/dart_mcp/README.md
+++ b/pkgs/dart_mcp/README.md
@@ -89,14 +89,14 @@ Before attempting to call methods on the server however, you should first verify
 the capabilities of the server by reading them from the `InitializeResult` returned
 from `ServerConnection.initialize`.
 
-[initialization_lifecycle]: https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/lifecycle/#initialization
+[initialization_lifecycle]: https://modelcontextprotocol.io/specification/2024-11-05/basic/lifecycle/#initialization
 
 ## Supported Protocol Versions
 
-[2024-11-05](https://spec.modelcontextprotocol.io/specification/2024-11-05/)
-[2025-03-26](https://spec.modelcontextprotocol.io/specification/2025-03-26/)
-[2025-06-18](https://spec.modelcontextprotocol.io/specification/2025-06-18/)
-[2025-11-05](https://spec.modelcontextprotocol.io/specification/2025-11-05/)
+[2024-11-05](https://modelcontextprotocol.io/specification/2024-11-05/)
+[2025-03-26](https://modelcontextprotocol.io/specification/2025-03-26/)
+[2025-06-18](https://modelcontextprotocol.io/specification/2025-06-18/)
+[2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25/)
 
 If support for a given protocol version is dropped, that will be released as a
 breaking change in this package.
@@ -106,27 +106,27 @@ However, we will strive to maintain backwards compatibility where possible.
 ## Base Utilities
 
 This table describes the state of implementation for the base protocol
-[utilities](https://spec.modelcontextprotocol.io/specification/2025-11-05/basic/utilities).
+[utilities](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities).
 
 Both the `MCPServer` and `MCPClient` support these.
 
 | Utility | Support | Notes |
 | --- | --- | --- |
-| [Ping](https://spec.modelcontextprotocol.io/specification/2025-11-05/basic/utilities/ping) | :heavy_check_mark: |  |
-| [Cancellation](https://spec.modelcontextprotocol.io/specification/2025-11-05/basic/utilities/cancellation/) | :x: | https://github.com/dart-lang/ai/issues/37 |
-| [Progress](https://spec.modelcontextprotocol.io/specification/2025-11-05/basic/utilities/progress/) | :heavy_check_mark: |  |
+| [Ping](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/ping) | :heavy_check_mark: |  |
+| [Cancellation](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/cancellation/) | :x: | https://github.com/dart-lang/ai/issues/37 |
+| [Progress](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/progress/) | :heavy_check_mark: |  |
 
 ## Transport Mechanisms
 
 This table describes the supported
-[transport mechanisms](https://modelcontextprotocol.io/specification/2025-11-05/basic/transports).
+[transport mechanisms](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports).
 
 At its core this package is just built on streams, so any transport mechanism
 can be used, but some are directly supported out of the box.
 
 | Transport | Support | Notes |
 | --- | --- | --- |
-| [Stdio](https://modelcontextprotocol.io/specification/2025-11-05/basic/transports#stdio) | :heavy_check_mark: |  |
+| [Stdio](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#stdio) | :heavy_check_mark: |  |
 | [Streamable HTTP](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http) | :construction: | Server side only, as `handleStreamableHttpRequest` in `package:dart_mcp/streamable_http.dart`. Answers with JSON bodies; SSE response streams and the client side are not implemented yet. |
 
 ## Batching Requests
@@ -143,32 +143,32 @@ at local MCP server usage for now.
 ## Server Capabilities
 
 This table describes the state of implementation for the
-[server capabilities](https://spec.modelcontextprotocol.io/specification/2025-11-05/server/).
+[server capabilities](https://modelcontextprotocol.io/specification/2025-11-25/server/).
 
 **Note:** Servers can also invoke all [client capabilities](#client-capabilities),
 see [Invoking Client Capabilities](#invoking-client-capabilities).
 
 | Capability | Support | Notes |
 | --- | --- | --- |
-| [Prompts](https://spec.modelcontextprotocol.io/specification/2025-11-05/server/prompts/) | :heavy_check_mark: |  |
-| [Resources](https://spec.modelcontextprotocol.io/specification/2025-11-05/server/resources/) | :heavy_check_mark: |  |
-| [Tools](https://spec.modelcontextprotocol.io/specification/2025-11-05/server/tools/) | :heavy_check_mark: |  |
+| [Prompts](https://modelcontextprotocol.io/specification/2025-11-25/server/prompts/) | :heavy_check_mark: |  |
+| [Resources](https://modelcontextprotocol.io/specification/2025-11-25/server/resources/) | :heavy_check_mark: |  |
+| [Tools](https://modelcontextprotocol.io/specification/2025-11-25/server/tools/) | :heavy_check_mark: |  |
 
 ## Server Utilities
 
 This table describes the state of implementation for the
-[server utilities](https://spec.modelcontextprotocol.io/specification/2025-11-05/server/utilities/).
+[server utilities](https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/).
 
 | Utility | Support | Notes |
 | --- | --- | --- |
-| [Completion](https://spec.modelcontextprotocol.io/specification/2025-11-05/server/utilities/completion/) | :heavy_check_mark: |  |
-| [Logging](https://spec.modelcontextprotocol.io/specification/2025-11-05/server/utilities/logging/) | :heavy_check_mark: |  |
-| [Pagination](https://spec.modelcontextprotocol.io/specification/2025-11-05/server/utilities/pagination/) | :construction: | https://github.com/dart-lang/ai/issues/28 |
+| [Completion](https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/completion/) | :heavy_check_mark: |  |
+| [Logging](https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/logging/) | :heavy_check_mark: |  |
+| [Pagination](https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/pagination/) | :construction: | https://github.com/dart-lang/ai/issues/28 |
 
 ## Client Capabilities
 
 This table describes the state of implementation for the client
-[capabilities](https://spec.modelcontextprotocol.io/specification/2025-11-05/client/).
+[capabilities](https://modelcontextprotocol.io/specification/2025-11-25/client/).
 
 **Note:** Clients can also invoke all [server capabilities](#server-capabilities)
 and [server utilities](#server-utilities),
@@ -176,5 +176,5 @@ see [Invoking Server Capabilities and Utilities](#invoking-server-capabilities-a
 
 | Capability | Support | Notes |
 | --- | --- | --- |
-| [Roots](https://spec.modelcontextprotocol.io/specification/2025-11-05/client/roots/)| :heavy_check_mark: | |
-| [Sampling](https://spec.modelcontextprotocol.io/specification/2025-11-05/client/sampling/)| :heavy_check_mark: | |
+| [Roots](https://modelcontextprotocol.io/specification/2025-11-25/client/roots/)| :heavy_check_mark: | |
+| [Sampling](https://modelcontextprotocol.io/specification/2025-11-25/client/sampling/)| :heavy_check_mark: | |

--- a/pkgs/dart_mcp/lib/src/client/roots_support.dart
+++ b/pkgs/dart_mcp/lib/src/client/roots_support.dart
@@ -8,7 +8,7 @@ part of 'client.dart';
 ///
 /// Supports "listChanged" notifications.
 ///
-/// See https://spec.modelcontextprotocol.io/specification/2025-11-05/client/roots/.
+/// See https://modelcontextprotocol.io/specification/2025-11-25/client/roots/.
 base mixin RootsSupport on MCPClient {
   /// The known roots by URI.
   ///

--- a/pkgs/dart_mcp/lib/src/client/sampling_support.dart
+++ b/pkgs/dart_mcp/lib/src/client/sampling_support.dart
@@ -6,7 +6,7 @@ part of 'client.dart';
 
 /// Adds support for "sampling" to an [MCPClient].
 ///
-/// See https://spec.modelcontextprotocol.io/specification/2025-11-05/client/sampling/.
+/// See https://modelcontextprotocol.io/specification/2025-11-25/client/sampling/.
 base mixin SamplingSupport on MCPClient {
   @override
   void initialize() {
@@ -20,7 +20,7 @@ base mixin SamplingSupport on MCPClient {
   /// request approval from a human before sending this prompt to the LLM,
   /// as well as before sending the response back to the server.
   ///
-  /// See https://spec.modelcontextprotocol.io/specification/2025-11-05/client/sampling/#message-flow
+  /// See https://modelcontextprotocol.io/specification/2025-11-25/client/sampling/#message-flow
   ///
   /// The [serverInfo] is the description that the server initiating this
   /// request gave when it was initialized.

--- a/pkgs/dart_mcp/lib/src/server/completions_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/completions_support.dart
@@ -6,7 +6,7 @@ part of 'server.dart';
 
 /// A mixin for MCP servers which support the `completion` capability.
 ///
-/// See https://spec.modelcontextprotocol.io/specification/2025-11-05/server/utilities/completion/.
+/// See https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/completion/.
 base mixin CompletionsSupport on MCPServer {
   @override
   FutureOr<ServerCapabilities> initialize(

--- a/pkgs/dart_mcp/lib/src/server/logging_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/logging_support.dart
@@ -6,7 +6,7 @@ part of 'server.dart';
 
 /// A mixin for MCP servers which support the `logging` capability.
 ///
-/// See https://spec.modelcontextprotocol.io/specification/2025-11-05/server/utilities/logging/.
+/// See https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/logging/.
 base mixin LoggingSupport on MCPServer {
   /// The level at or above which [log] sends messages, or `null` to send none.
   ///

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -238,7 +238,7 @@ abstract base class MCPServer extends MCPBase {
 
   /// A request to prompt the LLM owned by the client with a message.
   ///
-  /// See https://spec.modelcontextprotocol.io/specification/2025-11-05/client/sampling/.
+  /// See https://modelcontextprotocol.io/specification/2025-11-25/client/sampling/.
   ///
   /// This method will only succeed if the client has advertised the `sampling`
   /// capability.


### PR DESCRIPTION
The package has 42 spec links and 28 of them do not load. They sit in the readme and five source files. Most point at spec.modelcontextprotocol.io, which no longer serves HTTPS. Most also use revision 2025-11-05, never published. The same typo got fixed in `ProtocolVersion` in https://github.com/dart-lang/ai/pull/366, and that change moved the changelog link onto the canonical host too, so I followed it here. I kept 2025-11-25, since that is what `latestSupported` still points to.
