### PR TITLE
[dart_mcp_server] Add a field to capture the agent plugin information in analytics

### DIFF
--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.2-dev
+
+- Track `AGENT_PLUGIN` environment variable in analytics events.
+
 ## 1.1.1
 
 - Improve server instructions and error messages to encourage agents to

--- a/pkgs/dart_mcp_server/lib/src/mixins/analytics.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/analytics.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' show Platform;
 
 import 'package:dart_mcp/server.dart';
 import 'package:unified_analytics/unified_analytics.dart';
@@ -162,7 +161,7 @@ base mixin AnalyticsEvents
     clientVersion: clientInfo.version,
     serverVersion: implementation.version,
     type: type,
-    agentPlugin: Platform.environment[agentPluginEnvVar],
+    agentPlugin: agentPlugin,
     additionalData: additionalData,
   );
 

--- a/pkgs/dart_mcp_server/lib/src/mixins/analytics.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/analytics.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io' show Platform;
 
 import 'package:dart_mcp/server.dart';
 import 'package:unified_analytics/unified_analytics.dart';
@@ -20,10 +21,7 @@ base mixin AnalyticsEvents
   Future<InitializeResult> initialize(InitializeRequest request) async {
     final result = await super.initialize(request);
     analytics?.send(
-      Event.dartMCPEvent(
-        client: clientInfo.name,
-        clientVersion: clientInfo.version,
-        serverVersion: implementation.version,
+      _createDartMCPEvent(
         type: AnalyticsEvent.initialize.name,
         additionalData: InitializeMetrics(
           supportsElicitation: request.capabilities.elicitation != null,
@@ -38,12 +36,7 @@ base mixin AnalyticsEvents
   @override
   FutureOr<ListPromptsResult> listPrompts([ListPromptsRequest? request]) {
     trySendAnalyticsEvent(
-      Event.dartMCPEvent(
-        client: clientInfo.name,
-        clientVersion: clientInfo.version,
-        serverVersion: implementation.version,
-        type: AnalyticsEvent.listPrompts.name,
-      ),
+      _createDartMCPEvent(type: AnalyticsEvent.listPrompts.name),
     );
     return super.listPrompts(request);
   }
@@ -57,10 +50,7 @@ base mixin AnalyticsEvents
     } finally {
       watch.stop();
       trySendAnalyticsEvent(
-        Event.dartMCPEvent(
-          client: clientInfo.name,
-          clientVersion: clientInfo.version,
-          serverVersion: implementation.version,
+        _createDartMCPEvent(
           type: AnalyticsEvent.getPrompt.name,
           additionalData: GetPromptMetrics(
             name: request.name,
@@ -76,12 +66,7 @@ base mixin AnalyticsEvents
   @override
   FutureOr<ListResourcesResult> listResources([ListResourcesRequest? request]) {
     trySendAnalyticsEvent(
-      Event.dartMCPEvent(
-        client: clientInfo.name,
-        clientVersion: clientInfo.version,
-        serverVersion: implementation.version,
-        type: AnalyticsEvent.listResources.name,
-      ),
+      _createDartMCPEvent(type: AnalyticsEvent.listResources.name),
     );
     return super.listResources(request);
   }
@@ -91,12 +76,7 @@ base mixin AnalyticsEvents
     ListResourceTemplatesRequest? request,
   ]) {
     trySendAnalyticsEvent(
-      Event.dartMCPEvent(
-        client: clientInfo.name,
-        clientVersion: clientInfo.version,
-        serverVersion: implementation.version,
-        type: AnalyticsEvent.listResourceTemplates.name,
-      ),
+      _createDartMCPEvent(type: AnalyticsEvent.listResourceTemplates.name),
     );
     return super.listResourceTemplates(request);
   }
@@ -104,12 +84,7 @@ base mixin AnalyticsEvents
   @override
   Future<ListToolsResult> listTools([ListToolsRequest? request]) async {
     trySendAnalyticsEvent(
-      Event.dartMCPEvent(
-        client: clientInfo.name,
-        clientVersion: clientInfo.version,
-        serverVersion: implementation.version,
-        type: AnalyticsEvent.listTools.name,
-      ),
+      _createDartMCPEvent(type: AnalyticsEvent.listTools.name),
     );
     return super.listTools(request);
   }
@@ -159,10 +134,7 @@ base mixin AnalyticsEvents
           toolName += '.$command';
         }
         trySendAnalyticsEvent(
-          Event.dartMCPEvent(
-            client: clientInfo.name,
-            clientVersion: clientInfo.version,
-            serverVersion: implementation.version,
+          _createDartMCPEvent(
             type: AnalyticsEvent.callTool.name,
             additionalData: CallToolMetrics(
               tool: toolName,
@@ -181,6 +153,18 @@ base mixin AnalyticsEvents
       }
     }, validateArguments: false);
   }
+
+  Event _createDartMCPEvent({
+    required String type,
+    CustomMetrics? additionalData,
+  }) => Event.dartMCPEvent(
+    client: clientInfo.name,
+    clientVersion: clientInfo.version,
+    serverVersion: implementation.version,
+    type: type,
+    agentPlugin: Platform.environment[agentPluginEnvVar],
+    additionalData: additionalData,
+  );
 
   void trySendAnalyticsEvent(Event event) {
     try {

--- a/pkgs/dart_mcp_server/lib/src/mixins/analyzer.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/analyzer.dart
@@ -368,6 +368,9 @@ base mixin DartAnalyzerSupport
         // as a confirmation to the LLM that it was respected.
         messages.add(TextContent(text: 'Applied quick fixes'));
 
+        // Give the file watcher a moment to register file changes before
+        // waiting for analysis.
+        await Future<void>.delayed(const Duration(milliseconds: 100));
         await _waitForAnalysisToComplete(
           analysisServer,
           waitForSecondaryAnalysisInLegacyMode: true,
@@ -756,6 +759,7 @@ base mixin DartAnalyzerSupport
     final content = await file.readAsString();
     final newContent = _applyEditsToString(content, edits);
     await file.writeAsString(newContent);
+    diagnostics.remove(uri);
   }
 
   /// Applies a list of [edits] to [content] and returns the new content.

--- a/pkgs/dart_mcp_server/lib/src/mixins/analyzer.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/analyzer.dart
@@ -368,9 +368,6 @@ base mixin DartAnalyzerSupport
         // as a confirmation to the LLM that it was respected.
         messages.add(TextContent(text: 'Applied quick fixes'));
 
-        // Give the file watcher a moment to register file changes before
-        // waiting for analysis.
-        await Future<void>.delayed(const Duration(milliseconds: 100));
         await _waitForAnalysisToComplete(
           analysisServer,
           waitForSecondaryAnalysisInLegacyMode: true,

--- a/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' show InternetAddress, Platform;
+import 'dart:io' show InternetAddress;
 
 import 'package:collection/collection.dart';
 import 'package:dart_mcp/server.dart';
@@ -167,7 +167,7 @@ base mixin DartToolingDaemonSupport
             clientVersion: clientInfo.version,
             serverVersion: implementation.version,
             type: AnalyticsEvent.readResource.name,
-            agentPlugin: Platform.environment[agentPluginEnvVar],
+            agentPlugin: agentPlugin,
             additionalData: ReadResourceMetrics(
               kind: ResourceKind.runtimeErrors,
               length: result.contents.length,

--- a/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dtd.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' show InternetAddress;
+import 'dart:io' show InternetAddress, Platform;
 
 import 'package:collection/collection.dart';
 import 'package:dart_mcp/server.dart';
@@ -167,6 +167,7 @@ base mixin DartToolingDaemonSupport
             clientVersion: clientInfo.version,
             serverVersion: implementation.version,
             type: AnalyticsEvent.readResource.name,
+            agentPlugin: Platform.environment[agentPluginEnvVar],
             additionalData: ReadResourceMetrics(
               kind: ResourceKind.runtimeErrors,
               length: result.contents.length,

--- a/pkgs/dart_mcp_server/lib/src/server.dart
+++ b/pkgs/dart_mcp_server/lib/src/server.dart
@@ -113,7 +113,7 @@ package.
   /// The version of the MCP server.
   ///
   /// Should match the version in `pubspec.yaml` and `CHANGELOG.md`.
-  static final version = '1.1.1';
+  static final version = '1.1.2-dev';
 
   /// Runs the MCP server given command line arguments and an optional
   /// [Analytics] instance.

--- a/pkgs/dart_mcp_server/lib/src/utils/analytics.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/analytics.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:io' show Platform;
 
 import 'package:dart_mcp/server.dart';
@@ -20,13 +21,20 @@ abstract interface class AnalyticsSupport {
 /// The environment variable name used to specify the agent plugin.
 const agentPluginEnvVar = 'AGENT_PLUGIN';
 
-/// An override for the agent plugin name, used for testing.
-@visibleForTesting
-String? debugAgentPluginOverride;
+/// Key used to store the agent plugin override in a [Zone].
+const _agentPluginOverrideKey = #_agentPluginOverrideKey;
 
-/// Returns the agent plugin name from the environment (or test override).
+/// Runs [callback] in a zone where the agent plugin is overridden with
+/// [agentPlugin].
+@visibleForTesting
+R withAgentPluginOverride<R>(String agentPlugin, R Function() callback) =>
+    runZoned(callback, zoneValues: {_agentPluginOverrideKey: agentPlugin});
+
+/// Returns the agent plugin name from the current [Zone] (if overridden) or
+/// the environment.
 String? get agentPlugin =>
-    debugAgentPluginOverride ?? Platform.environment[agentPluginEnvVar];
+    Zone.current[_agentPluginOverrideKey] as String? ??
+    Platform.environment[agentPluginEnvVar];
 
 enum AnalyticsEvent {
   callTool,

--- a/pkgs/dart_mcp_server/lib/src/utils/analytics.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/analytics.dart
@@ -2,7 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io' show Platform;
+
 import 'package:dart_mcp/server.dart';
+import 'package:meta/meta.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
 /// An interface class that provides a access to an [Analytics] instance, if
@@ -16,6 +19,14 @@ abstract interface class AnalyticsSupport {
 
 /// The environment variable name used to specify the agent plugin.
 const agentPluginEnvVar = 'AGENT_PLUGIN';
+
+/// An override for the agent plugin name, used for testing.
+@visibleForTesting
+String? debugAgentPluginOverride;
+
+/// Returns the agent plugin name from the environment (or test override).
+String? get agentPlugin =>
+    debugAgentPluginOverride ?? Platform.environment[agentPluginEnvVar];
 
 enum AnalyticsEvent {
   callTool,

--- a/pkgs/dart_mcp_server/lib/src/utils/analytics.dart
+++ b/pkgs/dart_mcp_server/lib/src/utils/analytics.dart
@@ -14,6 +14,9 @@ abstract interface class AnalyticsSupport {
   Analytics? get analytics;
 }
 
+/// The environment variable name used to specify the agent plugin.
+const agentPluginEnvVar = 'AGENT_PLUGIN';
+
 enum AnalyticsEvent {
   callTool,
   initialize,

--- a/pkgs/dart_mcp_server/pubspec.yaml
+++ b/pkgs/dart_mcp_server/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/dart-lang/ai/tree/main/pkgs/dart_mcp_server
 issue_tracker: https://github.com/dart-lang/ai/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Adart_mcp_server
 
 # NOTE: Must also update version in pkgs/dart_mcp_server/lib/src/server.dart
-version: 1.1.1
+version: 1.1.2-dev
 
 environment:
   sdk: ^3.12.0

--- a/pkgs/dart_mcp_server/pubspec.yaml
+++ b/pkgs/dart_mcp_server/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   pool: ^1.5.1
   process: ^5.0.3
   stream_channel: ^2.1.4
-  unified_analytics: ^8.0.13
+  unified_analytics: ^8.0.17
   vm_service: ^15.0.0
   web_socket: ^1.0.1
   yaml: ^3.1.3

--- a/pkgs/dart_mcp_server/test/tools/analytics_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/analytics_test.dart
@@ -451,15 +451,22 @@ void main() {
       });
     });
 
-    test('includes agentPlugin in dartMCPEvent when provided', () {
-      final event = Event.dartMCPEvent(
-        client: 'testClient',
-        clientVersion: '1.0.0',
-        serverVersion: '1.0.0',
-        type: AnalyticsEvent.initialize.name,
-        agentPlugin: 'dart-flutter',
+    test('includes agentPlugin in sent events when provided', () async {
+      debugAgentPluginOverride = 'dart-flutter';
+      addTearDown(() => debugAgentPluginOverride = null);
+
+      await server.listTools();
+
+      expect(
+        analytics.sentEvents.last,
+        isA<Event>()
+            .having((e) => e.eventName, 'eventName', DashEvent.dartMCPEvent)
+            .having(
+              (e) => e.eventData,
+              'eventData',
+              containsPair('agentPlugin', 'dart-flutter'),
+            ),
       );
-      expect(event.eventData['agentPlugin'], 'dart-flutter');
     });
 
     test('Changelog version matches dart server version', () {

--- a/pkgs/dart_mcp_server/test/tools/analytics_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/analytics_test.dart
@@ -451,6 +451,17 @@ void main() {
       });
     });
 
+    test('includes agentPlugin in dartMCPEvent when provided', () {
+      final event = Event.dartMCPEvent(
+        client: 'testClient',
+        clientVersion: '1.0.0',
+        serverVersion: '1.0.0',
+        type: AnalyticsEvent.initialize.name,
+        agentPlugin: 'dart-flutter',
+      );
+      expect(event.eventData['agentPlugin'], 'dart-flutter');
+    });
+
     test('Changelog version matches dart server version', () {
       final changelogFile = File('CHANGELOG.md');
       expect(

--- a/pkgs/dart_mcp_server/test/tools/analytics_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/analytics_test.dart
@@ -452,21 +452,20 @@ void main() {
     });
 
     test('includes agentPlugin in sent events when provided', () async {
-      debugAgentPluginOverride = 'dart-flutter';
-      addTearDown(() => debugAgentPluginOverride = null);
+      await withAgentPluginOverride('dart-flutter', () async {
+        await server.listTools();
 
-      await server.listTools();
-
-      expect(
-        analytics.sentEvents.last,
-        isA<Event>()
-            .having((e) => e.eventName, 'eventName', DashEvent.dartMCPEvent)
-            .having(
-              (e) => e.eventData,
-              'eventData',
-              containsPair('agentPlugin', 'dart-flutter'),
-            ),
-      );
+        expect(
+          analytics.sentEvents.last,
+          isA<Event>()
+              .having((e) => e.eventName, 'eventName', DashEvent.dartMCPEvent)
+              .having(
+                (e) => e.eventData,
+                'eventData',
+                containsPair('agentPlugin', 'dart-flutter'),
+              ),
+        );
+      });
     });
 
     test('Changelog version matches dart server version', () {

--- a/pkgs/dart_mcp_server/test/tools/dtd_multiple_connection_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dtd_multiple_connection_test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Timeout.factor(2)
+library;
+
 import 'package:dart_mcp/server.dart';
 import 'package:dart_mcp_server/src/mixins/dtd.dart';
 
@@ -175,6 +178,7 @@ void main() async {
   stderr.writeln('error from app 1');
   stdin.listen((data) {
     if (String.fromCharCodes(data).trim() == 'q') exit(0);
+    stderr.writeln('error from app 1');
   }, onDone: () => exit(0));
   while (true) {
     await Future.delayed(Duration(seconds: 1));
@@ -204,6 +208,7 @@ void main() async {
   stderr.writeln('error from app 2');
   stdin.listen((data) {
     if (String.fromCharCodes(data).trim() == 'q') exit(0);
+    stderr.writeln('error from app 2');
   }, onDone: () => exit(0));
   while (true) {
     await Future.delayed(Duration(seconds: 1));
@@ -252,7 +257,8 @@ void main() async {
           );
       expect(connectedAppUris, hasLength(2));
 
-      // Verify errors for App 1
+      // Trigger stderr write and verify errors for App 1
+      session1.appProcess.stdin.writeln('');
       final errors1 = await testHarness.callToolWithRetry(
         CallToolRequest(
           name: ToolNames.getRuntimeErrors.name,
@@ -265,7 +271,8 @@ void main() async {
         contains('error from app 1'),
       );
 
-      // Verify errors for App 2
+      // Trigger stderr write and verify errors for App 2
+      session2.appProcess.stdin.writeln('');
       final errors2 = await testHarness.callToolWithRetry(
         CallToolRequest(
           name: ToolNames.getRuntimeErrors.name,

--- a/pkgs/dart_mcp_server/test/tools/dtd_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dtd_test.dart
@@ -57,6 +57,9 @@ void main() {
                 ParameterNames.summaryOnly: true,
               },
             ),
+            retryUntil: (result) => result.content.any(
+              (c) => c is TextContent && c.text.contains('MyHomePage'),
+            ),
           );
 
           expect(getWidgetTreeResult.isError, isNot(true));
@@ -713,6 +716,9 @@ void main() {
                 ParameterNames.command: WidgetInspectorCommand.getWidgetTree,
                 ParameterNames.summaryOnly: true,
               },
+            ),
+            retryUntil: (result) => result.content.any(
+              (c) => c is TextContent && c.text.contains('MyHomePage'),
             ),
           );
 


### PR DESCRIPTION
This PR 
- pulls in unified_analytics v 8.0.17
- reads the plugin info from env
- adds the plugin information to the MCP analytics events
- added test to verify the changes