### PR TITLE
fix the thisService spelling and the number field casts

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -122,6 +122,17 @@
   two took. `SubscribeRequest` and `UnsubscribeRequest` stay for the revisions
   which have them. Serving the request, and delivering notifications on the
   stream it opens, land as separate changes.
+- Deprecate `IncludeContext.thisService` and replace it with `thisServer`, the
+  name the specification uses, see
+  https://modelcontextprotocol.io/specification/2026-07-28/client/sampling.
+  Since the enum name is what a request carries, a server asking for that
+  context sent a value only another dart_mcp client could match. The
+  `CreateMessageRequest.includeContext` getter still reads `thisService`, since
+  this package sent it up to 0.5.2. Reading the corrected name needs 0.6.0.
+- Every getter returning a `double` now reads the JSON value as a `num` first.
+  A peer sending `1` for `1.0` used to throw except on the JavaScript
+  platforms. `CreateMessageRequest` takes `temperature` as a `num` because an
+  `int` cannot express a fractional one.
 - Fix `RequestId` so it can hold a JSON-RPC id. Its representation type was
   `json_rpc_2`'s `Parameter` rather than `Object`, which its sibling
   `ProgressToken` uses, so `CancelledNotification.requestId` threw for every

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -742,5 +742,5 @@ extension type Annotations.fromMap(Map<String, Object?> _value) {
   /// that the data is entirely optional.
   ///
   /// Must be between 0 and 1.
-  double? get priority => _value[Keys.priority] as double?;
+  double? get priority => (_value[Keys.priority] as num?)?.toDouble();
 }

--- a/pkgs/dart_mcp/lib/src/api/sampling.dart
+++ b/pkgs/dart_mcp/lib/src/api/sampling.dart
@@ -5,7 +5,18 @@
 part of 'api.dart';
 
 /// The types of context in which should be included in a prompt.
-enum IncludeContext { none, thisService, allServers }
+///
+/// The schema deprecates [thisServer] and [allServers], asking a server to omit
+/// the field or send [none] unless the client declares the `sampling.context`
+/// capability.
+enum IncludeContext {
+  none,
+  thisServer,
+  allServers;
+
+  @Deprecated('Use `IncludeContext.thisServer` instead.')
+  static const thisService = thisServer;
+}
 
 /// A request from the server to sample an LLM via the client.
 ///
@@ -21,7 +32,7 @@ extension type CreateMessageRequest.fromMap(Map<String, Object?> _value)
     ModelPreferences? modelPreferences,
     String? systemPrompt,
     IncludeContext? includeContext,
-    int? temperature,
+    num? temperature,
     required int maxTokens,
     List<String>? stopSequences,
     ToolChoice? toolChoice,
@@ -65,15 +76,20 @@ extension type CreateMessageRequest.fromMap(Map<String, Object?> _value)
   ///
   /// The client MAY ignore this request.
   IncludeContext? get includeContext {
-    final includeContext = _value[Keys.includeContext] as String?;
+    var includeContext = _value[Keys.includeContext] as String?;
     if (includeContext == null) return null;
+    // This package wrote `thisService` for the schema's `thisServer` up to
+    // 0.5.2. Treat it as an alias in case a server is still on that version.
+    if (includeContext == 'thisService') {
+      includeContext = IncludeContext.thisServer.name;
+    }
     return IncludeContext.values.firstWhere(
       (value) => value.name == includeContext,
     );
   }
 
   /// The temperature to use for sampling.
-  double? get temperature => _value[Keys.temperature] as double?;
+  double? get temperature => (_value[Keys.temperature] as num?)?.toDouble();
 
   /// The maximum number of tokens to sample, as requested by the server.
   ///
@@ -191,13 +207,13 @@ extension type ModelPreferences.fromMap(Map<String, Object?> _value) {
   ///
   /// A value of 0 means cost is not important, while a value of 1 means cost
   /// is the most important factor.
-  double? get costPriority => _value[Keys.costPriority] as double?;
+  double? get costPriority => (_value[Keys.costPriority] as num?)?.toDouble();
 
   /// How much to prioritize sampling speed (latency) when selecting a model.
   ///
   /// A value of 0 means speed is not important, while a value of 1 means speed
   /// is the most important factor.
-  double? get speedPriority => _value[Keys.speedPriority] as double?;
+  double? get speedPriority => (_value[Keys.speedPriority] as num?)?.toDouble();
 
   /// How much to prioritize intelligence and capabilities when selecting a
   /// model.
@@ -205,7 +221,7 @@ extension type ModelPreferences.fromMap(Map<String, Object?> _value) {
   /// A value of 0 means intelligence is not important, while a value of 1
   /// means intelligence is the most important factor.
   double? get intelligencePriority =>
-      _value[Keys.intelligencePriority] as double?;
+      (_value[Keys.intelligencePriority] as num?)?.toDouble();
 }
 
 /// Hints to use for model selection.

--- a/pkgs/dart_mcp/test/api/api_test.dart
+++ b/pkgs/dart_mcp/test/api/api_test.dart
@@ -247,6 +247,17 @@ void main() {
         expect(cancelled.requestId, id);
       }
     });
+    test('an annotation reads an integer priority as a double', () {
+      expect(Annotations.fromMap({'priority': 1}).priority, 1.0);
+    });
+
+    test('an annotation reads a fractional priority', () {
+      expect(Annotations.fromMap({'priority': 0.5}).priority, 0.5);
+    });
+
+    test('an annotation leaves an absent priority null', () {
+      expect(Annotations.fromMap({}).priority, isNull);
+    });
   });
 
   group('cacheable result factory', () {

--- a/pkgs/dart_mcp/test/api/sampling_test.dart
+++ b/pkgs/dart_mcp/test/api/sampling_test.dart
@@ -11,6 +11,106 @@ import 'package:test/test.dart';
 import '../test_utils.dart';
 
 void main() {
+  test('includeContext round trips the values the schema names', () {
+    for (final (value, wire) in const [
+      (IncludeContext.none, 'none'),
+      (IncludeContext.thisServer, 'thisServer'),
+      (IncludeContext.allServers, 'allServers'),
+    ]) {
+      final sent =
+          CreateMessageRequest(
+                messages: [],
+                maxTokens: 1,
+                includeContext: value,
+              )
+              as Map<String, Object?>;
+      expect(sent['includeContext'], wire);
+      expect(
+        CreateMessageRequest.fromMap({
+          'messages': <Object?>[],
+          'maxTokens': 1,
+          'includeContext': wire,
+        }).includeContext,
+        value,
+      );
+    }
+  });
+
+  test('includeContext reads the name this package used to send', () {
+    expect(
+      CreateMessageRequest.fromMap({
+        'messages': <Object?>[],
+        'maxTokens': 1,
+        'includeContext': 'thisService',
+      }).includeContext,
+      IncludeContext.thisServer,
+    );
+  });
+
+  test('model preferences read an integer priority as a double', () {
+    final prefs = ModelPreferences.fromMap({
+      'costPriority': 1,
+      'speedPriority': 0,
+      'intelligencePriority': 1,
+    });
+
+    expect(prefs.costPriority, 1.0);
+    expect(prefs.speedPriority, 0.0);
+    expect(prefs.intelligencePriority, 1.0);
+  });
+
+  test('model preferences leave an absent priority null', () {
+    final prefs = ModelPreferences.fromMap({});
+
+    expect(prefs.costPriority, isNull);
+    expect(prefs.speedPriority, isNull);
+    expect(prefs.intelligencePriority, isNull);
+  });
+
+  test('model preferences read a fractional priority', () {
+    final prefs = ModelPreferences.fromMap({
+      'costPriority': 0.3,
+      'speedPriority': 0.8,
+      'intelligencePriority': 0.5,
+    });
+
+    expect(prefs.costPriority, 0.3);
+    expect(prefs.speedPriority, 0.8);
+    expect(prefs.intelligencePriority, 0.5);
+  });
+
+  test('temperature takes a fractional value', () {
+    expect(
+      CreateMessageRequest(
+        messages: [],
+        maxTokens: 1,
+        temperature: 0.7,
+      ).temperature,
+      0.7,
+    );
+  });
+
+  test('temperature is null when the map leaves it out', () {
+    expect(
+      CreateMessageRequest.fromMap({
+        'messages': <Object?>[],
+        'maxTokens': 1,
+      }).temperature,
+      isNull,
+    );
+  });
+
+  test('temperature reads an integer as a double', () {
+    expect(
+      CreateMessageRequest.fromMap({
+        'messages': <Object?>[],
+        'maxTokens': 1,
+        'temperature': 1,
+      }).temperature,
+      1.0,
+    );
+  });
+
   test('server can request LLM messages from the client', () async {
     final environment = TestEnvironment(
       SamplingTestMCPClient(),


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

The `IncludeContext` enum has spelled one value `thisService` since 0.1.0. No schema revision spells it that way, and the factory puts the enum name straight on the wire. I kept the old name as a deprecated alias, the same way `ElicitationAction` keeps `reject`. A client on 0.5.2 or earlier throws on the corrected name.

Five getters cast the schema's number fields to a `double`. A whole number arriving from a peer throws except on the JavaScript platforms. They read `num` now. The `temperature` parameter only took an integer, which ruled out the `0.1` the spec's own `sampling/createMessage` request sends.
