### PR TITLE
check the elicitation mode at both ends

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -51,9 +51,9 @@
     which comes from `package:json_rpc_2`.
   - `ElicitationRequestSupport.elicit` now checks which mode a request names. A
     server that guarded on `supportsElicitation` should read
-    `supportsFormElicitation` or `supportsUrlElicitation`. A request naming a
-    mode this version has no value for is answered with `-32602` (invalid
-    params) instead of going out with that mode still on it.
+    `supportsFormElicitation` or `supportsUrlElicitation`. A request naming an
+    unknown mode is answered with `-32602` (invalid params) instead of going out
+    with that mode still on it.
   - `ServerConnection` now answers an elicitation mode the client did not
     declare with `-32602` (invalid params), where it used to answer a `decline`,
     as if the user had sent it. An unrecognized one used to throw out of the
@@ -91,17 +91,17 @@
     revisions fill it in only when the server set none. `LoggingSupport` also
     stops registering `logging/setLevel` on that revision, which is what a
     transport dispatching on its own gets.
-- Add `supportsFormElicitation` and `supportsUrlElicitation` for a server to
-  ask before it sends. Naming neither mode still means form, the way
-  `elicitation` read before the split.
-- Add `ElicitRequest.rawMode`, which carries the mode as it arrived. `mode`
-  resolves it and throws on a value this version has no name for.
   - `IntegerSchema`'s four bounds and its default read `num` now, and its
     factory takes them that way. JSON Schema types the bounds `number`, and
     the spec gives integers and numbers one definition whose `minimum`,
     `maximum` and `default` are `number` too. A peer sending
     `{"type": "integer", "minimum": 0.5}` sent something the getter threw on.
     `multipleOf` next to them already read `num`.
+- Add `supportsFormElicitation` and `supportsUrlElicitation` for a server to
+  ask before it sends. An empty `elicitation` object still means form, the way
+  `elicitation` read before the split.
+- Add `ElicitRequest.rawMode`, which carries the mode as it arrived. `mode`
+  resolves it and throws on an unknown one.
 - Fix the `Meta` dartdoc, which still described the 2025-06-18 prefix rule, and
   document the `traceparent`, `tracestate`, and `baggage` keys reserved for
   OpenTelemetry trace context, see

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -32,13 +32,23 @@
     initialize response or version negotiation.
   - `ElicitationRequestSupport.elicit` now throws an `RpcException` with
     `McpErrorCodes.missingRequiredClientCapability` instead of a `StateError`
-    when the client did not declare the `elicitation` capability, naming the
+    when the client did not declare the capability the request needs, naming the
     missing capability under `data.requiredCapabilities`, which the 2026-07-28
     revision requires of that error. `ToolsSupport.callTool` rethrows an
     `RpcException`, so a tool which elicits reaches the client as that error
     rather than as a `CallToolResult` whose text is a Dart stack trace. A
     server catching the `StateError` needs to catch `RpcException` instead,
     which comes from `package:json_rpc_2`.
+  - `ElicitationRequestSupport.elicit` now checks which mode a request names. A
+    server that guarded on `supportsElicitation` should read
+    `supportsFormElicitation` or `supportsUrlElicitation`. A request naming a
+    mode this version has no value for is answered with `-32602` (invalid
+    params) instead of going out with that mode still on it.
+  - `ServerConnection` now answers an elicitation mode the client did not
+    declare with `-32602` (invalid params), where it used to answer a `decline`,
+    as if the user had sent it. An unrecognized one used to throw out of the
+    handler instead. The `-32042` retry path leaves the error
+    alone unless the request it carries names url.
   - `ResourcesSupport.readResource` now answers a URI it has no resource or
     template for with the `-32602` (invalid params) error the 2026-07-28
     revision requires, carrying the URI as `data.uri`, instead of letting an
@@ -64,6 +74,11 @@
     revisions fill it in only when the server set none. `LoggingSupport` also
     stops registering `logging/setLevel` on that revision, which is what a
     transport dispatching on its own gets.
+- Add `supportsFormElicitation` and `supportsUrlElicitation` for a server to
+  ask before it sends. Naming neither mode still means form, the way
+  `elicitation` read before the split.
+- Add `ElicitRequest.rawMode`, which carries the mode as it arrived. `mode`
+  resolves it and throws on a value this version has no name for.
 - Add `handleRequestScopedMessage` and `MCPServerFactory`, which serve each
   decoded JSON-RPC message on a fresh server instance for request-scoped
   transports. On 2026-07-28, successful results record the server

--- a/pkgs/dart_mcp/lib/src/api/elicitation.dart
+++ b/pkgs/dart_mcp/lib/src/api/elicitation.dart
@@ -49,9 +49,17 @@ extension type ElicitRequest._fromMap(Map<String, Object?> _value)
     });
   }
 
+  /// The mode of this elicitation as it came in, before [mode] resolves it.
+  ///
+  /// Null when the sender named no mode, which [mode] reads as
+  /// [ElicitationMode.form]. A caller that has to tell a missing mode apart
+  /// from one this version does not know reads this instead, since [mode]
+  /// throws on the second.
+  Object? get rawMode => _value[Keys.mode];
+
   /// The mode of this elicitation.
   ElicitationMode get mode {
-    final mode = _value[Keys.mode] as String?;
+    final mode = rawMode;
     // Default to form for backward compatibility unless specified.
     if (mode == null) return ElicitationMode.form;
     return ElicitationMode.values.firstWhere((value) => value.name == mode);

--- a/pkgs/dart_mcp/lib/src/api/elicitation.dart
+++ b/pkgs/dart_mcp/lib/src/api/elicitation.dart
@@ -53,8 +53,8 @@ extension type ElicitRequest._fromMap(Map<String, Object?> _value)
   ///
   /// Null when the sender named no mode, which [mode] reads as
   /// [ElicitationMode.form]. A caller that has to tell a missing mode apart
-  /// from one this version does not know reads this instead, since [mode]
-  /// throws on the second.
+  /// from an unknown one reads this instead, since [mode] throws on the
+  /// second.
   Object? get rawMode => _value[Keys.mode];
 
   /// The mode of this elicitation.

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -13,6 +13,7 @@ import 'package:stream_channel/stream_channel.dart';
 import '../../stdio.dart';
 import '../api/api.dart';
 import '../shared.dart';
+import '../utils/constants.dart';
 
 part 'elicitation_support.dart';
 part 'roots_support.dart';
@@ -229,19 +230,28 @@ base class ServerConnection extends MCPBase {
 
     if (elicitationFormSupport != null || elicitationUrlSupport != null) {
       registerRequestHandler(ElicitRequest.methodName, (ElicitRequest request) {
+        final raw = request.rawMode;
+        if (raw != null && !ElicitationMode.values.any((m) => m.name == raw)) {
+          throw RpcException.invalidParams(
+            'The elicitation mode was "$raw", which is not one of: '
+            '${ElicitationMode.values.map((m) => m.name).join(', ')}',
+          );
+        }
         switch (request.mode) {
           case ElicitationMode.form:
-            if (elicitationFormSupport != null) {
-              return elicitationFormSupport.handleElicitation(request, this);
-            } else {
-              return ElicitResult(action: ElicitationAction.decline);
+            if (elicitationFormSupport == null) {
+              throw RpcException.invalidParams(
+                'This client did not declare the elicitation.form capability',
+              );
             }
+            return elicitationFormSupport.handleElicitation(request, this);
           case ElicitationMode.url:
-            if (elicitationUrlSupport != null) {
-              return elicitationUrlSupport.handleElicitation(request, this);
-            } else {
-              return ElicitResult(action: ElicitationAction.decline);
+            if (elicitationUrlSupport == null) {
+              throw RpcException.invalidParams(
+                'This client did not declare the elicitation.url capability',
+              );
             }
+            return elicitationUrlSupport.handleElicitation(request, this);
         }
       });
     }
@@ -334,7 +344,11 @@ base class ServerConnection extends MCPBase {
       final data = e.data;
       if (_elicitationUrlSupport?.autoHandleUrlElicitationRequired == true &&
           e.code == McpErrorCodes.urlElicitationRequired &&
-          data is Map) {
+          data is Map &&
+          // The schema makes `mode` required on a url elicitation, so a
+          // payload naming anything else does not belong on this path. Read
+          // it off the raw map, since the error is whatever the peer sent.
+          data[Keys.mode] == ElicitationMode.url.name) {
         // `RpcException.serialize` spreads the error data into an untyped map
         // literal (adding a `request` key), so the map arriving here is not a
         // `Map<String, Object?>` and a representation type check against

--- a/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
@@ -9,6 +9,29 @@ base mixin ElicitationRequestSupport on LoggingSupport {
   /// is based on the client capabilities.
   bool get supportsElicitation => clientCapabilities.elicitation != null;
 
+  /// Whether or not the connected client supports [ElicitationMode.form]
+  /// requests.
+  ///
+  /// Only safe to call after calling [initialize] on `super` since this
+  /// is based on the client capabilities.
+  ///
+  /// A client which declared `elicitation` but named neither mode counts as
+  /// form support, the rule the 2025-11-25 revision added alongside the mode
+  /// split.
+  bool get supportsFormElicitation {
+    final elicitation = clientCapabilities.elicitation;
+    if (elicitation == null) return false;
+    return elicitation.form != null || elicitation.url == null;
+  }
+
+  /// Whether or not the connected client supports [ElicitationMode.url]
+  /// requests.
+  ///
+  /// Only safe to call after calling [initialize] on `super` since this
+  /// is based on the client capabilities.
+  bool get supportsUrlElicitation =>
+      clientCapabilities.elicitation?.url != null;
+
   @override
   FutureOr<ServerCapabilities> initialize(
     MCPServerInitialization initialization,
@@ -27,23 +50,41 @@ base mixin ElicitationRequestSupport on LoggingSupport {
 
   /// Sends an `elicitation/create` request to the client.
   ///
-  /// This method will only succeed if the client has advertised the
-  /// `elicitation` capability.
+  /// This method will only succeed if the client has advertised the mode the
+  /// request asks for, as [supportsFormElicitation] and
+  /// [supportsUrlElicitation] read it.
   ///
   /// Throws an [RpcException] with
-  /// [McpErrorCodes.missingRequiredClientCapability] when it has not, naming
-  /// the capability the client is missing under `data.requiredCapabilities`,
+  /// [McpErrorCodes.missingRequiredClientCapability] when the client has not,
+  /// naming the capability it is missing under `data.requiredCapabilities`,
   /// which the 2026-07-28 revision requires of that error.
   ///
   /// [ToolsSupport.callTool] rethrows an [RpcException] instead of folding it
   /// into a [CallToolResult], so a tool which elicits reaches the client as
   /// that error rather than as a result whose text is a Dart stack trace.
   Future<ElicitResult> elicit(ElicitRequest request) async {
-    if (!supportsElicitation) {
-      throw _missingClientCapability(
-        'elicitation',
-        ClientCapabilities(elicitation: ElicitationCapability()),
+    final raw = request.rawMode;
+    if (raw != null && !ElicitationMode.values.any((m) => m.name == raw)) {
+      throw RpcException.invalidParams(
+        'The elicitation mode was "$raw", which is not one of: '
+        '${ElicitationMode.values.map((m) => m.name).join(', ')}',
       );
+    }
+    switch (request.mode) {
+      case ElicitationMode.url:
+        if (!supportsUrlElicitation) {
+          throw _missingClientCapability(
+            'elicitation.url',
+            ClientCapabilities(elicitation: ElicitationCapability(url: {})),
+          );
+        }
+      case ElicitationMode.form:
+        if (!supportsFormElicitation) {
+          throw _missingClientCapability(
+            'elicitation.form',
+            ClientCapabilities(elicitation: ElicitationCapability(form: {})),
+          );
+        }
     }
     return sendRequest(ElicitRequest.methodName, request);
   }

--- a/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
@@ -15,13 +15,14 @@ base mixin ElicitationRequestSupport on LoggingSupport {
   /// Only safe to call after calling [initialize] on `super` since this
   /// is based on the client capabilities.
   ///
-  /// A client which declared `elicitation` but named neither mode counts as
-  /// form support, the rule the 2025-11-25 revision added alongside the mode
-  /// split.
+  /// An empty `elicitation` object counts as form support, the backwards
+  /// compatibility rule the 2025-11-25 revision added alongside the mode
+  /// split. A client which named some other mode does not.
   bool get supportsFormElicitation {
     final elicitation = clientCapabilities.elicitation;
     if (elicitation == null) return false;
-    return elicitation.form != null || elicitation.url == null;
+    return elicitation.form != null ||
+        (elicitation as Map<String, Object?>).isEmpty;
   }
 
   /// Whether or not the connected client supports [ElicitationMode.url]

--- a/pkgs/dart_mcp/test/client/elicitation_test.dart
+++ b/pkgs/dart_mcp/test/client/elicitation_test.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:dart_mcp/client.dart';
 import 'package:dart_mcp/server.dart';
 import 'package:dart_mcp/src/utils/constants.dart';
+import 'package:json_rpc_2/error_code.dart' as error_code;
 import 'package:json_rpc_2/json_rpc_2.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
@@ -150,6 +151,58 @@ void main() {
       expect(toolCallCount, 1);
     });
 
+    test('rethrows when the error data is not a url elicitation', () async {
+      final environment = TestEnvironment(
+        TestMCPClientWithElicitationUrlSupport(
+          elicitationHandler: (request, connection) async {
+            fail(
+              'should not hand a ${request.rawMode} request to the url '
+              'handler',
+            );
+          },
+        ),
+        TestMCPServerWithTools.new,
+      );
+
+      await environment.initializeServer();
+      final server = environment.server;
+
+      // A payload with no mode reads as form, and one naming a mode this
+      // version has no value for is not a url request either.
+      final payloads = [
+        <String, Object?>{Keys.message: 'Fill this in'},
+        <String, Object?>{Keys.mode: 'voice', Keys.message: 'Fill this in'},
+        // The error is whatever the peer sent, so the mode need not be a
+        // string at all. Reading it must not lose the error it came with.
+        <String, Object?>{Keys.mode: 42, Keys.message: 'Fill this in'},
+      ];
+      for (var i = 0; i < payloads.length; i++) {
+        final data = payloads[i];
+        server.registerTool(
+          Tool(name: 'test_tool_$i', inputSchema: ObjectSchema()),
+          (request) =>
+              throw RpcException(
+                McpErrorCodes.urlElicitationRequired,
+                'Url required',
+                data: data as ElicitRequest,
+              ),
+        );
+
+        await expectLater(
+          () => environment.serverConnection.callTool(
+            CallToolRequest(name: 'test_tool_$i'),
+          ),
+          throwsA(
+            isA<RpcException>().having(
+              (e) => e.code,
+              'code',
+              McpErrorCodes.urlElicitationRequired,
+            ),
+          ),
+        );
+      }
+    });
+
     test('rethrows when the error data is not a map', () async {
       final clientController = StreamController<Map<String, Object?>>();
       final serverController = StreamController<Map<String, Object?>>();
@@ -189,6 +242,178 @@ void main() {
                 McpErrorCodes.urlElicitationRequired,
               )
               .having((e) => e.data, 'data', 'not a map'),
+        ),
+      );
+    });
+  });
+
+  group('elicitation mode mismatches', () {
+    // `sendRequest` skips the check `elicit` runs, so a request from a server
+    // without one of its own reaches the client guard.
+    test('answers a form request with invalid params', () async {
+      final environment = TestEnvironment(
+        TestMCPClientWithElicitationUrlSupport(
+          elicitationHandler:
+              (request, connection) =>
+                  fail('the client should not be asked to handle a form'),
+        ),
+        TestMCPServer.new,
+      );
+      final server = environment.server;
+      await environment.initializeServer();
+
+      await expectLater(
+        server.sendRequest<ElicitResult>(
+          ElicitRequest.methodName,
+          ElicitRequest.form(
+            message: 'What is your name?',
+            requestedSchema: ObjectSchema(),
+          ),
+        ),
+        throwsA(
+          isA<RpcException>()
+              .having((e) => e.code, 'code', error_code.INVALID_PARAMS)
+              .having(
+                (e) => e.message,
+                'message',
+                contains('elicitation.form'),
+              ),
+        ),
+      );
+    });
+
+    test('a request with no mode reaches the form handler', () async {
+      final environment = TestEnvironment(
+        TestMCPClientWithElicitationFormSupport(
+          elicitationHandler:
+              (request, connection) =>
+                  ElicitResult(action: ElicitationAction.accept),
+        ),
+        TestMCPServer.new,
+      );
+      final server = environment.server;
+      await environment.initializeServer();
+
+      final result = await server.sendRequest<ElicitResult>(
+        ElicitRequest.methodName,
+        <String, Object?>{Keys.message: 'need input'} as ElicitRequest,
+      );
+      expect(result.action, ElicitationAction.accept);
+    });
+
+    test('rawMode is the value the sender put on the wire', () {
+      final request =
+          <String, Object?>{Keys.message: 'hi', Keys.mode: 'voice'}
+              as ElicitRequest;
+
+      expect(request.rawMode, 'voice');
+      expect(() => request.mode, throwsStateError);
+    });
+
+    test('rawMode is null with no mode field', () {
+      final request = <String, Object?>{Keys.message: 'hi'} as ElicitRequest;
+
+      expect(request.rawMode, isNull);
+      expect(request.mode, ElicitationMode.form);
+    });
+
+    test('refuses an unknown mode', () async {
+      final environment = TestEnvironment(
+        TestMCPClientWithElicitationFormSupport(
+          elicitationHandler:
+              (request, connection) => fail(
+                'the client should not be asked to handle an unknown mode',
+              ),
+        ),
+        TestMCPServer.new,
+      );
+      final server = environment.server;
+      await environment.initializeServer();
+
+      await expectLater(
+        server.sendRequest<ElicitResult>(
+          ElicitRequest.methodName,
+          <String, Object?>{Keys.mode: 'voice', Keys.message: 'pick one'}
+              as ElicitRequest,
+        ),
+        throwsA(
+          isA<RpcException>()
+              .having((e) => e.code, 'code', error_code.INVALID_PARAMS)
+              .having((e) => e.message, 'message', contains('voice')),
+        ),
+      );
+
+      // A peer can put anything in that field.
+      await expectLater(
+        server.sendRequest<ElicitResult>(
+          ElicitRequest.methodName,
+          <String, Object?>{Keys.mode: 42, Keys.message: 'pick one'}
+              as ElicitRequest,
+        ),
+        throwsA(
+          isA<RpcException>().having(
+            (e) => e.code,
+            'code',
+            error_code.INVALID_PARAMS,
+          ),
+        ),
+      );
+    });
+
+    test('a url client answers an unknown mode the same way', () async {
+      final environment = TestEnvironment(
+        TestMCPClientWithElicitationUrlSupport(
+          elicitationHandler:
+              (request, connection) => fail(
+                'the client should not be asked to handle an unknown mode',
+              ),
+        ),
+        TestMCPServer.new,
+      );
+      final server = environment.server;
+      await environment.initializeServer();
+
+      await expectLater(
+        server.sendRequest<ElicitResult>(
+          ElicitRequest.methodName,
+          <String, Object?>{Keys.mode: 'voice', Keys.message: 'pick one'}
+              as ElicitRequest,
+        ),
+        throwsA(
+          isA<RpcException>().having(
+            (e) => e.code,
+            'code',
+            error_code.INVALID_PARAMS,
+          ),
+        ),
+      );
+    });
+
+    test('answers a url request with invalid params', () async {
+      final environment = TestEnvironment(
+        TestMCPClientWithElicitationFormSupport(
+          elicitationHandler:
+              (request, connection) =>
+                  fail('the client should not be asked to handle a url'),
+        ),
+        TestMCPServer.new,
+      );
+      final server = environment.server;
+      await environment.initializeServer();
+
+      await expectLater(
+        server.sendRequest<ElicitResult>(
+          ElicitRequest.methodName,
+          ElicitRequest.url(
+            message: 'Grant access',
+            url: 'https://example.com',
+            elicitationId: '1',
+          ),
+        ),
+        throwsA(
+          isA<RpcException>()
+              .having((e) => e.code, 'code', error_code.INVALID_PARAMS)
+              .having((e) => e.message, 'message', contains('elicitation.url')),
         ),
       );
     });

--- a/pkgs/dart_mcp/test/client/elicitation_test.dart
+++ b/pkgs/dart_mcp/test/client/elicitation_test.dart
@@ -170,8 +170,8 @@ void main() {
       await environment.initializeServer();
       final server = environment.server;
 
-      // A payload with no mode reads as form, and one naming a mode this
-      // version has no value for is not a url request either.
+      // A payload with no mode reads as form, and an unknown mode is not a
+      // url request either.
       final payloads = [
         <String, Object?>{Keys.message: 'Fill this in'},
         <String, Object?>{Keys.mode: 'voice', Keys.message: 'Fill this in'},

--- a/pkgs/dart_mcp/test/server/elicitation_request_support_test.dart
+++ b/pkgs/dart_mcp/test/server/elicitation_request_support_test.dart
@@ -39,7 +39,7 @@ final class _ElicitingServer extends MCPServer
       _,
     ) async {
       // Cast the way `ServerConnection` does when it reads a request off the
-      // wire, since no constructor here can name a mode this version lacks.
+      // wire, since no constructor here can name an unknown mode.
       await elicit(
         <String, Object?>{Keys.mode: 'voice', Keys.message: 'speak up'}
             as ElicitRequest,
@@ -137,6 +137,21 @@ void main() {
     final result = await _call(
       'test/ask',
       ClientCapabilities(elicitation: ElicitationCapability(url: {})),
+    );
+
+    expect(_requiredCapabilities(result!), {
+      Keys.elicitation: {Keys.form: <String, Object?>{}},
+    });
+  });
+
+  test('a voice-only client does not clear the form check', () async {
+    final result = await _call(
+      'test/ask',
+      ClientCapabilities(
+        elicitation: ElicitationCapability.fromMap({
+          'voice': <String, Object?>{},
+        }),
+      ),
     );
 
     expect(_requiredCapabilities(result!), {

--- a/pkgs/dart_mcp/test/server/elicitation_request_support_test.dart
+++ b/pkgs/dart_mcp/test/server/elicitation_request_support_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:dart_mcp/server.dart';
 import 'package:dart_mcp/src/utils/constants.dart';
+import 'package:json_rpc_2/error_code.dart' as error_code;
 import 'package:test/test.dart';
 
 final class _ElicitingServer extends MCPServer
@@ -20,32 +21,198 @@ final class _ElicitingServer extends MCPServer
       );
       return CallToolResult(content: [TextContent(text: 'asked')]);
     });
+    registerTool(Tool(name: 'test/no-mode', inputSchema: ObjectSchema()), (
+      _,
+    ) async {
+      // The 2025-11-25 revision lets a server leave `mode` out of a form
+      // request, and no constructor here builds one without it.
+      await elicit(
+        <String, Object?>{
+              Keys.message: 'need input',
+              Keys.requestedSchema: ObjectSchema(),
+            }
+            as ElicitRequest,
+      );
+      return CallToolResult(content: [TextContent(text: 'asked')]);
+    });
+    registerTool(Tool(name: 'test/unknown', inputSchema: ObjectSchema()), (
+      _,
+    ) async {
+      // Cast the way `ServerConnection` does when it reads a request off the
+      // wire, since no constructor here can name a mode this version lacks.
+      await elicit(
+        <String, Object?>{Keys.mode: 'voice', Keys.message: 'speak up'}
+            as ElicitRequest,
+      );
+      return CallToolResult(content: [TextContent(text: 'asked')]);
+    });
+    registerTool(Tool(name: 'test/send', inputSchema: ObjectSchema()), (
+      _,
+    ) async {
+      await elicit(
+        ElicitRequest.url(
+          message: 'sign in',
+          url: 'https://e.test',
+          elicitationId: 'e1',
+        ),
+      );
+      return CallToolResult(content: [TextContent(text: 'sent')]);
+    });
   }
+}
+
+Future<Map<String, Object?>?> _call(
+  String tool,
+  ClientCapabilities capabilities,
+) => handleRequestScopedMessage(
+  {
+    Keys.jsonrpc: '2.0',
+    Keys.id: 1,
+    Keys.method: CallToolRequest.methodName,
+    Keys.params: {Keys.name: tool},
+  },
+  MCPServerInitialization(
+    protocolVersion: ProtocolVersion.v2026_07_28,
+    clientCapabilities: capabilities,
+  ),
+  _ElicitingServer.new,
+);
+
+const _missingCapability = McpErrorCodes.missingRequiredClientCapability;
+
+Object? _errorCode(Map<String, Object?> result) =>
+    (result[Keys.error] as Map<String, Object?>)[Keys.code];
+
+/// The request-scoped transport cannot route a request back to the client, so
+/// a call that clears the capability check still fails. These assert that it
+/// got that far.
+final _clearedTheCheck = isNot(_missingCapability);
+
+Object? _requiredCapabilities(Map<String, Object?> result) {
+  expect(_errorCode(result), _missingCapability);
+  final error = result[Keys.error] as Map<String, Object?>;
+  // In memory the data skips the JSON round trip and stays an untyped map.
+  return (error[Keys.data] as Map)[Keys.requiredCapabilities];
 }
 
 void main() {
   test('a tool which elicits fails with the missing capability code', () async {
-    final result = await handleRequestScopedMessage(
-      {
-        Keys.jsonrpc: '2.0',
-        Keys.id: 1,
-        Keys.method: CallToolRequest.methodName,
-        Keys.params: {Keys.name: 'test/ask'},
-      },
-      MCPServerInitialization(
-        protocolVersion: ProtocolVersion.v2026_07_28,
-        clientCapabilities: ClientCapabilities(),
-      ),
-      _ElicitingServer.new,
+    final result = await _call('test/ask', ClientCapabilities());
+
+    expect(_requiredCapabilities(result!), {
+      Keys.elicitation: {Keys.form: <String, Object?>{}},
+    });
+    expect(
+      (result[Keys.error] as Map<String, Object?>)[Keys.message],
+      contains('elicitation.form'),
+    );
+    expect(result[Keys.result], isNull);
+  });
+
+  test('the error names the mode the request needs', () async {
+    final result = await _call(
+      'test/send',
+      ClientCapabilities(elicitation: ElicitationCapability(form: {})),
     );
 
-    final error = result![Keys.error] as Map<String, Object?>;
-    expect(error[Keys.code], McpErrorCodes.missingRequiredClientCapability);
-    // In memory the data skips the JSON round trip, so it is an untyped map.
-    final data = error[Keys.data] as Map;
-    expect(data[Keys.requiredCapabilities], {
-      Keys.elicitation: <String, Object?>{},
+    expect(_requiredCapabilities(result!), {
+      Keys.elicitation: {Keys.url: <String, Object?>{}},
     });
-    expect(result[Keys.result], isNull);
+    expect(
+      (result[Keys.error] as Map<String, Object?>)[Keys.message],
+      contains('elicitation.url'),
+    );
+  });
+
+  test('a declared mode clears the capability check', () async {
+    final result = await _call(
+      'test/send',
+      ClientCapabilities(elicitation: ElicitationCapability(url: {})),
+    );
+
+    expect(_errorCode(result!), _clearedTheCheck);
+  });
+
+  test('naming one mode does not sign a client up for the other', () async {
+    final result = await _call(
+      'test/ask',
+      ClientCapabilities(elicitation: ElicitationCapability(url: {})),
+    );
+
+    expect(_requiredCapabilities(result!), {
+      Keys.elicitation: {Keys.form: <String, Object?>{}},
+    });
+  });
+
+  test('elicitation with no mode named clears the form check', () async {
+    final result = await _call(
+      'test/ask',
+      ClientCapabilities(elicitation: ElicitationCapability()),
+    );
+
+    expect(_errorCode(result!), _clearedTheCheck);
+  });
+
+  test('naming both modes clears either check', () async {
+    final capabilities = ClientCapabilities(
+      elicitation: ElicitationCapability(form: {}, url: {}),
+    );
+
+    expect(
+      _errorCode((await _call('test/ask', capabilities))!),
+      _clearedTheCheck,
+    );
+    expect(
+      _errorCode((await _call('test/send', capabilities))!),
+      _clearedTheCheck,
+    );
+  });
+
+  test('a url request needs the url mode, not just elicitation', () async {
+    final noElicitation = await _call('test/send', ClientCapabilities());
+    expect(_requiredCapabilities(noElicitation!), {
+      Keys.elicitation: {Keys.url: <String, Object?>{}},
+    });
+
+    final noModeNamed = await _call(
+      'test/send',
+      ClientCapabilities(elicitation: ElicitationCapability()),
+    );
+    expect(_requiredCapabilities(noModeNamed!), {
+      Keys.elicitation: {Keys.url: <String, Object?>{}},
+    });
+  });
+
+  test('an omitted mode is held to the form capability', () async {
+    final result = await _call(
+      'test/no-mode',
+      ClientCapabilities(elicitation: ElicitationCapability(url: {})),
+    );
+
+    expect(_requiredCapabilities(result!), {
+      Keys.elicitation: {Keys.form: <String, Object?>{}},
+    });
+  });
+
+  test('an unrecognized mode answers with invalid params', () async {
+    for (final capabilities in [
+      ElicitationCapability(url: {}),
+      ElicitationCapability(form: {}),
+    ]) {
+      final result = await _call(
+        'test/unknown',
+        ClientCapabilities(elicitation: capabilities),
+      );
+
+      expect(_errorCode(result!), error_code.INVALID_PARAMS);
+      expect(
+        (result[Keys.error] as Map<String, Object?>)[Keys.message],
+        allOf([
+          contains('"voice"'),
+          for (final mode in ElicitationMode.values) contains(mode.name),
+        ]),
+        reason: 'the rejection names the value and every mode it could be',
+      );
+    }
   });
 }


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

The server side only asked whether the client had `elicitation`, but a client declares which modes it takes and the [spec](https://modelcontextprotocol.io/specification/2026-07-28/client/elicitation#capabilities) says a server must not send one it did not. A url-only client saw form requests and declined them as if the user had.

I split that guard into `supportsFormElicitation` and `supportsUrlElicitation`, and both ends now answer an unknown mode with invalid params. Auto-handling a `-32042` only runs when the request inside it names url. Both are breaking. The resolved getter throws on an unknown one, so the guards read a new `rawMode`.
