### PR TITLE
add input-response request fields

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -159,6 +159,10 @@
   when it needs input first, see
   https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr.
   Nothing sends or answers one yet.
+- Add `WithInputResponses`, the type a client's retry carries.
+  `CallToolRequest`, `GetPromptRequest` and `ReadResourceRequest` take an
+  `inputResponses` and a `requestState`, matching the three requests the schema
+  answers with an `InputRequiredResult`.
 - Add `SubscriptionFilter`, `SubscriptionsListenRequest`,
   `SubscriptionsListenResult`, and `SubscriptionsAcknowledgedNotification`,
   modeling the `subscriptions/listen` request the 2026-07-28 revision adds, see

--- a/pkgs/dart_mcp/lib/src/api/input_required.dart
+++ b/pkgs/dart_mcp/lib/src/api/input_required.dart
@@ -107,3 +107,36 @@ extension type InputRequiredResult.fromMap(Map<String, Object?> _value)
   /// This is opaque to the client, which sends it on unread.
   String? get requestState => _value[Keys.requestState] as String?;
 }
+
+/// A "mixin"-like extension type for any request that contains input responses
+/// at the keys "inputResponses" and "requestState".
+///
+/// These are the other half of an [InputRequiredResult], what a client puts on
+/// the retry. The requests which can answer with one take them.
+///
+/// Should be "mixed in" by implementing this type from other extension types.
+///
+/// This type is not intended to be constructed directly and thus has no public
+/// constructor.
+///
+/// From the 2026-07-28 revision.
+extension type WithInputResponses._fromMap(Map<String, Object?> _value)
+    implements Request {
+  /// What the client got for each request in
+  /// [InputRequiredResult.inputRequests], under the keys the server gave them.
+  ///
+  /// These carry no method field the way an [InputRequest] does, so a server
+  /// reads each back as the type it asked for under that key. A key it did not
+  /// ask for is one to ignore.
+  Map<String, Result>? get inputResponses =>
+      (_value[Keys.inputResponses] as Map?)?.cast<String, Result>();
+
+  /// The [InputRequiredResult.requestState] the server sent, echoed back
+  /// unread.
+  ///
+  /// The value arrives from the client, and the spec has the server treat it
+  /// as attacker-controlled input. Nothing here signs or verifies it. A server
+  /// whose state carries anything it would not accept straight off the wire
+  /// has to protect and check it itself.
+  String? get requestState => _value[Keys.requestState] as String?;
+}

--- a/pkgs/dart_mcp/lib/src/api/prompts.dart
+++ b/pkgs/dart_mcp/lib/src/api/prompts.dart
@@ -42,16 +42,20 @@ extension type ListPromptsResult.fromMap(Map<String, Object?> _value)
 
 /// Used by the client to get a prompt provided by the server.
 extension type GetPromptRequest.fromMap(Map<String, Object?> _value)
-    implements Request {
+    implements WithInputResponses {
   static const methodName = 'prompts/get';
 
   factory GetPromptRequest({
     required String name,
     Map<String, Object?>? arguments,
+    Map<String, Result>? inputResponses,
+    String? requestState,
     MetaWithProgressToken? meta,
   }) => GetPromptRequest.fromMap({
     Keys.name: name,
     if (arguments != null) Keys.arguments: arguments,
+    if (inputResponses != null) Keys.inputResponses: inputResponses,
+    if (requestState != null) Keys.requestState: requestState,
     if (meta != null) Keys.meta: meta,
   });
 

--- a/pkgs/dart_mcp/lib/src/api/resources.dart
+++ b/pkgs/dart_mcp/lib/src/api/resources.dart
@@ -81,14 +81,18 @@ extension type ListResourceTemplatesResult.fromMap(Map<String, Object?> _value)
 
 /// Sent from the client to the server, to read a specific resource URI.
 extension type ReadResourceRequest.fromMap(Map<String, Object?> _value)
-    implements Request {
+    implements WithInputResponses {
   static const methodName = 'resources/read';
 
   factory ReadResourceRequest({
     required String uri,
+    Map<String, Result>? inputResponses,
+    String? requestState,
     MetaWithProgressToken? meta,
   }) => ReadResourceRequest.fromMap({
     Keys.uri: uri,
+    if (inputResponses != null) Keys.inputResponses: inputResponses,
+    if (requestState != null) Keys.requestState: requestState,
     if (meta != null) Keys.meta: meta,
   });
 

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -92,16 +92,20 @@ extension type CallToolResult.fromMap(Map<String, Object?> _value)
 
 /// Used by the client to invoke a tool provided by the server.
 extension type CallToolRequest._fromMap(Map<String, Object?> _value)
-    implements Request {
+    implements WithInputResponses {
   static const methodName = 'tools/call';
 
   factory CallToolRequest({
     required String name,
     Map<String, Object?>? arguments,
+    Map<String, Result>? inputResponses,
+    String? requestState,
     MetaWithProgressToken? meta,
   }) => CallToolRequest._fromMap({
     Keys.name: name,
     if (arguments != null) Keys.arguments: arguments,
+    if (inputResponses != null) Keys.inputResponses: inputResponses,
+    if (requestState != null) Keys.requestState: requestState,
     if (meta != null) Keys.meta: meta,
   });
 

--- a/pkgs/dart_mcp/lib/src/utils/constants.dart
+++ b/pkgs/dart_mcp/lib/src/utils/constants.dart
@@ -68,6 +68,7 @@ extension Keys on Never {
   static const idempotentHint = 'idempotentHint';
   static const includeContext = 'includeContext';
   static const inputRequests = 'inputRequests';
+  static const inputResponses = 'inputResponses';
   static const inputSchema = 'inputSchema';
   static const instructions = 'instructions';
   static const intelligencePriority = 'intelligencePriority';

--- a/pkgs/dart_mcp/test/api/input_required_test.dart
+++ b/pkgs/dart_mcp/test/api/input_required_test.dart
@@ -173,4 +173,127 @@ void main() {
       );
     });
   });
+
+  group('WithInputResponses', () {
+    final elicited = ElicitResult(action: ElicitationAction.accept);
+    final sampled = CreateMessageResult(
+      role: Role.assistant,
+      content: Content.text(text: 'Paris'),
+      model: 'a-model',
+    );
+
+    test('the retry carries what the client gathered', () {
+      final request = CallToolRequest(
+        name: 'deploy',
+        inputResponses: {'github_login': elicited, 'capital': sampled},
+        requestState: 'an opaque blob',
+      );
+
+      expect(request as Map<String, Object?>, {
+        'name': 'deploy',
+        'inputResponses': {'github_login': elicited, 'capital': sampled},
+        'requestState': 'an opaque blob',
+      });
+    });
+
+    test('a first attempt writes neither field', () {
+      expect(CallToolRequest(name: 'deploy') as Map<String, Object?>, {
+        'name': 'deploy',
+      });
+      expect(GetPromptRequest(name: 'review') as Map<String, Object?>, {
+        'name': 'review',
+      });
+      expect(ReadResourceRequest(uri: 'file:///a') as Map<String, Object?>, {
+        'uri': 'file:///a',
+      });
+    });
+
+    test('a server reads each response back as what it asked for', () {
+      final request = GetPromptRequest.fromMap({
+        'name': 'review',
+        'inputResponses': {'github_login': elicited, 'capital': sampled},
+      });
+
+      expect(
+        (request.inputResponses!['github_login']! as ElicitResult).action,
+        ElicitationAction.accept,
+      );
+      expect(
+        (request.inputResponses!['capital']! as CreateMessageResult).model,
+        'a-model',
+      );
+    });
+
+    test('writes an empty inputResponses next to a request state', () {
+      expect(
+        CallToolRequest(
+              name: 'deploy',
+              inputResponses: {},
+              requestState: 'opaque',
+            )
+            as Map<String, Object?>,
+        {
+          'name': 'deploy',
+          'inputResponses': <String, Result>{},
+          'requestState': 'opaque',
+        },
+      );
+      expect(
+        GetPromptRequest(
+              name: 'review',
+              inputResponses: {},
+              requestState: 'opaque',
+            )
+            as Map<String, Object?>,
+        {
+          'name': 'review',
+          'inputResponses': <String, Result>{},
+          'requestState': 'opaque',
+        },
+      );
+      expect(
+        ReadResourceRequest(
+              uri: 'file:///a',
+              inputResponses: {},
+              requestState: 'opaque',
+            )
+            as Map<String, Object?>,
+        {
+          'uri': 'file:///a',
+          'inputResponses': <String, Result>{},
+          'requestState': 'opaque',
+        },
+      );
+    });
+
+    test('reads both fields back off all three', () {
+      for (var request in <WithInputResponses>[
+        CallToolRequest(
+          name: 'deploy',
+          inputResponses: {'github_login': elicited},
+          requestState: 'state',
+        ),
+        GetPromptRequest(
+          name: 'review',
+          inputResponses: {'github_login': elicited},
+          requestState: 'state',
+        ),
+        ReadResourceRequest(
+          uri: 'file:///a',
+          inputResponses: {'github_login': elicited},
+          requestState: 'state',
+        ),
+      ]) {
+        expect(request.requestState, 'state');
+        expect(request.inputResponses, {'github_login': elicited});
+      }
+    });
+
+    test('a request without them reads both as null', () {
+      final request = ReadResourceRequest.fromMap({'uri': 'file:///a'});
+
+      expect(request.inputResponses, isNull);
+      expect(request.requestState, isNull);
+    });
+  });
 }


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

This adds the request side of https://github.com/dart-lang/ai/pull/602. The three requests a server can answer with an `InputRequiredResult` now take an `inputResponses` map and a `requestState`, which is what a retry carries back.

I left the handler return types alone for now. Nothing sends or reads these yet, and widening those three signatures would be a breaking change.
