### PR TITLE
Clean up skills CLI tests

### DIFF
--- a/pkgs/skills/AGENTS.md
+++ b/pkgs/skills/AGENTS.md
@@ -16,7 +16,7 @@ Fix any format, analysis, or test failures before finishing.
 
 ## Project conventions
 
-- **Manifest path:** The skills manifest path is defined in one place: `.dart_tool/skills/skills_config.json` (see `SkillManifest` in `lib/src/models/skill_manifest.dart`). Use `SkillManifest.pathIn(rootPath)`, `SkillManifest.dirName`, and `SkillManifest.baseName` — never hardcode the path or path separators elsewhere.
+- **Manifest path:** The skills manifest path is defined in one place: `.config/dart_skills/skills_config.json` (see `SkillManifest` in `lib/src/models/skill_manifest.dart`). Use `SkillManifest.pathIn(rootPath)`, `SkillManifest.dirName`, and `SkillManifest.baseName` — never hardcode the path or path separators elsewhere.
 - **Paths:** Use `package:path/path.dart` and `p.join()` for all path construction so behavior is correct on Windows.
 - **Empty manifest:** When all managed skills are removed, delete the `.dart_tool/skills` directory rather than leaving an empty manifest file (see `SkillManifest.cleanupDir` and `RemoveCommand`).
 - **Workspace resolution:** The CLI supports (1) a directory with a `pubspec.yaml` (pub workspace, melos, or single package) and (2) an implicit workspace: no root `pubspec.yaml`, but immediate subdirectories that have `pubspec.yaml` are treated as packages. Do not walk up the directory tree to find a project root; the user is expected to run from the project root.

--- a/pkgs/skills/AGENTS.md
+++ b/pkgs/skills/AGENTS.md
@@ -16,7 +16,7 @@ Fix any format, analysis, or test failures before finishing.
 
 ## Project conventions
 
-- **Manifest path:** The skills manifest path is defined in one place: `.config/dart_skills/skills_config.json` (see `SkillManifest` in `lib/src/models/skill_manifest.dart`). Use `SkillManifest.pathIn(rootPath)`, `SkillManifest.dirName`, and `SkillManifest.baseName` — never hardcode the path or path separators elsewhere.
+- **Manifest path:** The skills manifest path is defined in one place: `.config/dart_skills/skills_config.json` (see `SkillManifest` in `lib/src/models/skill_manifest.dart`). Use `SkillManifest.pathIn(rootPath)`, `SkillManifest.configDirPath`, `SkillManifest.configName` and `SkillManifest.cacheDirPath` — never hardcode the path or path separators elsewhere.
 - **Paths:** Use `package:path/path.dart` and `p.join()` for all path construction so behavior is correct on Windows.
 - **Empty manifest:** When all managed skills are removed, delete the `.dart_tool/skills` directory rather than leaving an empty manifest file (see `SkillManifest.cleanupDir` and `RemoveCommand`).
 - **Workspace resolution:** The CLI supports (1) a directory with a `pubspec.yaml` (pub workspace, melos, or single package) and (2) an implicit workspace: no root `pubspec.yaml`, but immediate subdirectories that have `pubspec.yaml` are treated as packages. Do not walk up the directory tree to find a project root; the user is expected to run from the project root.

--- a/pkgs/skills/lib/src/core/git_sync.dart
+++ b/pkgs/skills/lib/src/core/git_sync.dart
@@ -1,13 +1,17 @@
 import 'dart:io';
 
-import 'git_runner.dart';
+import 'package:logging/logging.dart';
+
 import 'git_repos.dart';
+import 'git_runner.dart';
 
 /// Syncs GitHub repos to the local `.dart_tool/skills/repos` directory.
 ///
 /// If a repo is not yet cloned, clones it. If it exists, runs git fetch and
 /// reset --hard to the remote HEAD. On clone/fetch failure, logs a warning
 /// and continues (Dart-only skills are still used).
+final _logger = Logger('GitSync');
+
 class GitSync {
   final GitRunner gitRunner;
 
@@ -60,7 +64,7 @@ class GitSync {
       runInShell: true,
     );
     if (result.exitCode != 0) {
-      stderr.writeln(
+      _logger.warning(
         'Warning: Failed to clone ${repo.cloneUrl}: ${result.stderr}',
       );
     }
@@ -79,7 +83,7 @@ class GitSync {
       runInShell: true,
     );
     if (result.exitCode != 0) {
-      stderr.writeln(
+      _logger.warning(
         'Warning: Failed to fetch ${repo.cloneUrl}: ${result.stderr}',
       );
       return;
@@ -91,7 +95,7 @@ class GitSync {
       runInShell: true,
     );
     if (result.exitCode != 0) {
-      stderr.writeln(
+      _logger.warning(
         'Warning: Failed to reset ${repo.cloneUrl}: ${result.stderr}',
       );
     }

--- a/pkgs/skills/test/commands/add_command_test.dart
+++ b/pkgs/skills/test/commands/add_command_test.dart
@@ -146,6 +146,8 @@ Test skill body.
         await realGitRunner.run([
           'add',
           '--global',
+          '--directory',
+          projectPath,
           '--agent',
           'cursor',
           '--all',

--- a/pkgs/skills/test/commands/get_command_select_skills_test.dart
+++ b/pkgs/skills/test/commands/get_command_select_skills_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'package:io/ansi.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:skills/src/commands/get_command.dart';
@@ -78,15 +79,17 @@ void main() {
         final runner = SkillsCommandRunner('skills', 'Test')
           ..addCommand(getCommand);
 
-        await runner.run([
-          'get',
-          '--directory',
-          projectPath,
-          '--agent',
-          Agent.generic.cliName,
-          '--package',
-          'dep1',
-        ]);
+        await overrideAnsiOutput(false, () async {
+          await runner.run([
+            'get',
+            '--directory',
+            projectPath,
+            '--agent',
+            Agent.generic.cliName,
+            '--package',
+            'dep1',
+          ]);
+        });
 
         expect(fakeDialogSupport.allMultiSelectOptions, hasLength(1));
         expect(
@@ -128,13 +131,15 @@ void main() {
           final runner = SkillsCommandRunner('skills', 'Test')
             ..addCommand(getCommand);
 
-          await runner.run([
-            'get',
-            '--directory',
-            projectPath,
-            '--agent',
-            Agent.generic.cliName,
-          ]);
+          await overrideAnsiOutput(false, () async {
+            await runner.run([
+              'get',
+              '--directory',
+              projectPath,
+              '--agent',
+              Agent.generic.cliName,
+            ]);
+          });
 
           expect(fakeDialogSupport.allMultiSelectOptions, hasLength(3));
           expect(
@@ -238,13 +243,15 @@ void main() {
         final runner = SkillsCommandRunner('skills', 'Test')
           ..addCommand(getCommand);
 
-        await runner.run([
-          'get',
-          '--directory',
-          projectPath,
-          '--agent',
-          Agent.generic.cliName,
-        ]);
+        await overrideAnsiOutput(false, () async {
+          await runner.run([
+            'get',
+            '--directory',
+            projectPath,
+            '--agent',
+            Agent.generic.cliName,
+          ]);
+        });
 
         expect(fakeDialogSupport.allMultiSelectOptions, hasLength(3));
         expect(

--- a/pkgs/skills/test/commands/get_command_test.dart
+++ b/pkgs/skills/test/commands/get_command_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:io/ansi.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:skills/skills.dart';
@@ -268,14 +269,16 @@ New skill body.
       final projectPath = d.path('project');
 
       // 1. Initial installation
-      await runner.run([
-        'get',
-        '--directory',
-        projectPath,
-        '--agent',
-        Agent.cursor.cliName,
-        '--all',
-      ]);
+      await overrideAnsiOutput(false, () async {
+        await runner.run([
+          'get',
+          '--directory',
+          projectPath,
+          '--agent',
+          Agent.cursor.cliName,
+          '--all',
+        ]);
+      });
 
       final skillPath = p.join(
         projectPath,
@@ -294,15 +297,17 @@ New skill body.
       // 3. User selects nothing to update
       fakeDialogSupport.multiSelectResults.add({});
 
-      await runner.run([
-        'get',
-        '--directory',
-        projectPath,
-        '--agent',
-        Agent.cursor.cliName,
-        '-p',
-        'dep_with_skills',
-      ]);
+      await overrideAnsiOutput(false, () async {
+        await runner.run([
+          'get',
+          '--directory',
+          projectPath,
+          '--agent',
+          Agent.cursor.cliName,
+          '-p',
+          'dep_with_skills',
+        ]);
+      });
 
       expect(fakeDialogSupport.allMultiSelectOptions, [
         [contains('dep_with_skills-test-skill (Local edits)')],

--- a/pkgs/skills/test/commands/get_command_update_states_test.dart
+++ b/pkgs/skills/test/commands/get_command_update_states_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:io/ansi.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:skills/src/commands/get_command.dart';
@@ -50,16 +51,19 @@ void main() {
       );
       final runner = SkillsCommandRunner('skills', 'Test')
         ..addCommand(getCommand);
-      await runner.run([
-        'get',
-        '--directory',
-        projectPath,
-        '--agent',
-        Agent.generic.cliName,
-        '--package',
-        'dep',
-        if (all) '--all',
-      ]);
+
+      await overrideAnsiOutput(false, () async {
+        await runner.run([
+          'get',
+          '--directory',
+          projectPath,
+          '--agent',
+          Agent.generic.cliName,
+          '--package',
+          'dep',
+          if (all) '--all',
+        ]);
+      });
     }
 
     Future<void> expectSkill({

--- a/pkgs/skills/test/commands/remove_command_select_skills_test.dart
+++ b/pkgs/skills/test/commands/remove_command_select_skills_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:io/ansi.dart';
 import 'package:logging/logging.dart';
 import 'package:skills/src/commands/remove_command.dart';
 import 'package:skills/src/commands/skills_command_runner.dart';
@@ -88,15 +89,17 @@ void main() {
         // We select only index 0 (dep1-skill-1) to remove.
         fakeDialogSupport.multiSelectResults.add({0});
 
-        await runner.run([
-          'remove',
-          '--directory',
-          projectPath,
-          '--agent',
-          'cursor',
-          '--package',
-          'dep1',
-        ]);
+        await overrideAnsiOutput(false, () async {
+          await runner.run([
+            'remove',
+            '--directory',
+            projectPath,
+            '--agent',
+            'cursor',
+            '--package',
+            'dep1',
+          ]);
+        });
 
         expect(fakeDialogSupport.allMultiSelectOptions, hasLength(1));
         expect(
@@ -143,13 +146,15 @@ void main() {
           {0, 3},
         ];
 
-        await runner.run([
-          'remove',
-          '--directory',
-          projectPath,
-          '--agent',
-          'cursor',
-        ]);
+        await overrideAnsiOutput(false, () async {
+          await runner.run([
+            'remove',
+            '--directory',
+            projectPath,
+            '--agent',
+            'cursor',
+          ]);
+        });
 
         expect(fakeDialogSupport.allMultiSelectOptions, hasLength(2));
         expect(


### PR DESCRIPTION
This PR fixes tests breaking in non-TTY environments due to ANSI output injection by explicitly wrapping tests evaluating multi-select dialogs in `overrideAnsiOutput(false, ...)`. Additionally, changes `GitSync` raw `stderr.writeln` to use `package:logging` so that clone warnings are correctly swallowed by test suites.

It also fixes one test that was running the CLI in the current working directory instead of the temp directory, which was leaving artifacts on disk.