### PR TITLE
Add missing license headers

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 # Customize Gemini Code Assist behavior this repo.
 #
 # Schema: https://developers.google.com/gemini-code-assist/docs/customize-repo-review#config.yaml-schema

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 # Dependabot configuration file.
 # See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
 version: 2

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 # Configuration for .github/workflows/pull_request_label.yml.
 
 'type-infra':

--- a/.github/workflows/dart_mcp.yaml
+++ b/.github/workflows/dart_mcp.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 name: package:dart_mcp
 permissions: read-all
 

--- a/.github/workflows/dart_mcp_server.yaml
+++ b/.github/workflows/dart_mcp_server.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 name: package:dart_mcp_server
 permissions: read-all
 

--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 name: Health
 on:
   pull_request:

--- a/.github/workflows/mcp_examples.yaml
+++ b/.github/workflows/mcp_examples.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 name: mcp_examples
 permissions: read-all
 

--- a/.github/workflows/post_summaries.yaml
+++ b/.github/workflows/post_summaries.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 # A CI configuration to write comments on PRs.
 
 name: Comment on the pull request

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 # A CI configuration to auto-publish pub packages.
 
 name: Publish

--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 # This workflow applies labels to pull requests based on the paths that are
 # modified in the pull request.
 #

--- a/mcp_examples/pubspec.yaml
+++ b/mcp_examples/pubspec.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 name: dart_mcp_examples
 description: Examples for the Dart MCP package.
 publish_to: none

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -272,6 +272,7 @@
 - Point the documentation at `modelcontextprotocol.io` and at protocol
   revision 2025-11-25. The old host stopped serving HTTPS, and the old
   revision number 2025-11-05 was never a published revision.
+- Add missing license headers.
 
 ## 0.5.2
 

--- a/pkgs/dart_mcp/analysis_options.yaml
+++ b/pkgs/dart_mcp/analysis_options.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 # https://dart.dev/guides/language/analysis-options
 
 include: package:dart_flutter_team_lints/analysis_options.yaml

--- a/pkgs/dart_mcp/dart_test.yaml
+++ b/pkgs/dart_mcp/dart_test.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 override_platforms:
   chrome:
     settings:

--- a/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 part of 'server.dart';
 
 /// A mixin that adds support for making `elicitation/create` requests to a

--- a/pkgs/dart_mcp/pubspec.yaml
+++ b/pkgs/dart_mcp/pubspec.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 name: dart_mcp
 version: 0.6.0-wip
 description: A package for making MCP servers and clients.

--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.1.2-dev
 
 - Track `AGENT_PLUGIN` environment variable in analytics events.
+- Add missing license headers.
 
 ## 1.1.1
 

--- a/pkgs/dart_mcp_server/analysis_options.yaml
+++ b/pkgs/dart_mcp_server/analysis_options.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 # https://dart.dev/guides/language/analysis-options
 
 include: package:dart_flutter_team_lints/analysis_options.yaml

--- a/pkgs/dart_mcp_server/pubspec.yaml
+++ b/pkgs/dart_mcp_server/pubspec.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 name: dart_mcp_server
 description: >-
   An MCP server for Dart projects, exposing various developer tools to AI

--- a/pkgs/dart_mcp_server/test_fixtures/counter_app/analysis_options.yaml
+++ b/pkgs/dart_mcp_server/test_fixtures/counter_app/analysis_options.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 # https://dart.dev/guides/language/analysis-options
 
 include: package:dart_flutter_team_lints/analysis_options.yaml

--- a/pkgs/dart_mcp_server/test_fixtures/counter_app/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
+++ b/pkgs/dart_mcp_server/test_fixtures/counter_app/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 package io.flutter.plugins;
 
 import androidx.annotation.Keep;

--- a/pkgs/dart_mcp_server/test_fixtures/counter_app/ios/Runner/AppDelegate.swift
+++ b/pkgs/dart_mcp_server/test_fixtures/counter_app/ios/Runner/AppDelegate.swift
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import Flutter
 import UIKit
 

--- a/pkgs/dart_mcp_server/test_fixtures/counter_app/ios/Runner/Runner-Bridging-Header.h
+++ b/pkgs/dart_mcp_server/test_fixtures/counter_app/ios/Runner/Runner-Bridging-Header.h
@@ -1,1 +1,5 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 #import "GeneratedPluginRegistrant.h"

--- a/pkgs/dart_mcp_server/test_fixtures/counter_app/ios/RunnerTests/RunnerTests.swift
+++ b/pkgs/dart_mcp_server/test_fixtures/counter_app/ios/RunnerTests/RunnerTests.swift
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import Flutter
 import UIKit
 import XCTest

--- a/pkgs/dart_mcp_server/test_fixtures/counter_app/linux/CMakeLists.txt
+++ b/pkgs/dart_mcp_server/test_fixtures/counter_app/linux/CMakeLists.txt
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 # Project-level configuration.
 cmake_minimum_required(VERSION 3.13)
 project(runner LANGUAGES CXX)

--- a/pkgs/dart_mcp_server/test_fixtures/counter_app/linux/flutter/CMakeLists.txt
+++ b/pkgs/dart_mcp_server/test_fixtures/counter_app/linux/flutter/CMakeLists.txt
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 # This file controls Flutter-level build steps. It should not be edited.
 cmake_minimum_required(VERSION 3.10)
 

--- a/pkgs/dart_mcp_server/test_fixtures/counter_app/linux/flutter/generated_plugin_registrant.cc
+++ b/pkgs/dart_mcp_server/test_fixtures/counter_app/linux/flutter/generated_plugin_registrant.cc
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 //
 //  Generated file. Do not edit.
 //

--- a/pkgs/dart_mcp_server/test_fixtures/counter_app/linux/flutter/generated_plugin_registrant.h
+++ b/pkgs/dart_mcp_server/test_fixtures/counter_app/linux/flutter/generated_plugin_registrant.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 //
 //  Generated file. Do not edit.
 //

--- a/pkgs/dart_mcp_server/test_fixtures/counter_app/linux/flutter/generated_plugins.cmake
+++ b/pkgs/dart_mcp_server/test_fixtures/counter_app/linux/flutter/generated_plugins.cmake
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 #
 # Generated file, do not edit.
 #

--- a/pkgs/dart_mcp_server/test_fixtures/counter_app/linux/runner/CMakeLists.txt
+++ b/pkgs/dart_mcp_server/test_fixtures/counter_app/linux/runner/CMakeLists.txt
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 cmake_minimum_required(VERSION 3.13)
 project(runner LANGUAGES CXX)
 

--- a/pkgs/dart_mcp_server/test_fixtures/counter_app/linux/runner/main.cc
+++ b/pkgs/dart_mcp_server/test_fixtures/counter_app/linux/runner/main.cc
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 #include "my_application.h"
 
 int main(int argc, char** argv) {

--- a/pkgs/dart_mcp_server/test_fixtures/counter_app/linux/runner/my_application.cc
+++ b/pkgs/dart_mcp_server/test_fixtures/counter_app/linux/runner/my_application.cc
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 #include "my_application.h"
 
 #include <flutter_linux/flutter_linux.h>

--- a/pkgs/dart_mcp_server/test_fixtures/counter_app/linux/runner/my_application.h
+++ b/pkgs/dart_mcp_server/test_fixtures/counter_app/linux/runner/my_application.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 #ifndef FLUTTER_MY_APPLICATION_H_
 #define FLUTTER_MY_APPLICATION_H_
 

--- a/pkgs/dart_mcp_server/test_fixtures/counter_app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/pkgs/dart_mcp_server/test_fixtures/counter_app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 //
 //  Generated file. Do not edit.
 //

--- a/pkgs/dart_mcp_server/test_fixtures/counter_app/macos/Runner/AppDelegate.swift
+++ b/pkgs/dart_mcp_server/test_fixtures/counter_app/macos/Runner/AppDelegate.swift
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import Cocoa
 import FlutterMacOS
 

--- a/pkgs/dart_mcp_server/test_fixtures/counter_app/macos/Runner/MainFlutterWindow.swift
+++ b/pkgs/dart_mcp_server/test_fixtures/counter_app/macos/Runner/MainFlutterWindow.swift
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import Cocoa
 import FlutterMacOS
 

--- a/pkgs/dart_mcp_server/test_fixtures/counter_app/macos/RunnerTests/RunnerTests.swift
+++ b/pkgs/dart_mcp_server/test_fixtures/counter_app/macos/RunnerTests/RunnerTests.swift
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import Cocoa
 import FlutterMacOS
 import XCTest

--- a/pkgs/dart_mcp_server/test_fixtures/counter_app/pubspec.yaml
+++ b/pkgs/dart_mcp_server/test_fixtures/counter_app/pubspec.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 name: counter_app
 description: "A new Flutter project."
 publish_to: 'none'

--- a/pkgs/dart_mcp_server/test_fixtures/dart_cli_app/analysis_options.yaml
+++ b/pkgs/dart_mcp_server/test_fixtures/dart_cli_app/analysis_options.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 # https://dart.dev/guides/language/analysis-options
 
 include: package:dart_flutter_team_lints/analysis_options.yaml

--- a/pkgs/dart_mcp_server/test_fixtures/dart_cli_app/pubspec.yaml
+++ b/pkgs/dart_mcp_server/test_fixtures/dart_cli_app/pubspec.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 name: example_dart_cli_app
 publish_to: none
 environment:


### PR DESCRIPTION
Adds missing license/copyright headers to files flagged during open source review.

- Add BSD-style copyright headers across repository config, workflows, `dart_mcp`, `dart_mcp_server`, and `counter_app` test fixture files.
- Update `CHANGELOG.md` for `dart_mcp` and `dart_mcp_server`.