### PR TITLE
validate x-mcp-header params in the Streamable HTTP handler

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -276,6 +276,8 @@
   - A missing, extra, malformed, or mismatched header answers `400 Bad Request`
     with `McpErrorCodes.headerMismatch` and drops any notification the server
     emitted before dispatch.
+  - A `tools/call` whose `arguments` is not an object answers `400 Bad Request`
+    with invalid params.
   - `handleRequestScopedMessage` gained `beforeDispatch`, and
     `ToolsSupport.registeredTools` exposes the registered tools by name.
 - Point the documentation at `modelcontextprotocol.io` and at protocol

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -269,21 +269,21 @@
   Streamable HTTP handler already requires; the server map travels with
   `ServerCapabilities`, which is held by the legacy `initialize` result and
   by `DiscoverResult`.
-- Support `x-mcp-header` in `handleStreamableHttpRequest`. For annotated
-  string, integer, and boolean tool arguments, matching `Mcp-Param-{Name}`
-  headers are checked against the corresponding argument. Nested `properties`
-  paths and the `=?base64?...?=` encoding are supported. Missing required
-  headers, headers for absent values, malformed headers, and mismatches return
-  `400 Bad Request` with `McpErrorCodes.headerMismatch`. A rejected call sends
-  none of the notifications the server emitted before dispatch, because a
-  `400` cannot be set on a stream one of them has committed. An annotation on
-  any other type asserts, and a `500` from the handler now reads `The server
-  failed to answer the request`: the check shares that answer with server
-  construction and initialization, so it names neither.
-  `handleRequestScopedMessage` gained `beforeDispatch`, which runs against the
-  initialized server, and `ToolsSupport.registeredTools` exposes the
-  registered tools by name so a transport can read one's schema without
-  running a `listTools` override.
+- Support `x-mcp-header` in `handleStreamableHttpRequest`. For `tools/call`, a
+  string, integer, or boolean argument annotated with `x-mcp-header` is checked
+  against its `Mcp-Param-{Name}` header.
+  - Nested `properties` paths and the `=?base64?...?=` encoding are supported.
+  - Missing required headers, headers for absent values, malformed headers, and
+    mismatches return `400 Bad Request` with `McpErrorCodes.headerMismatch`.
+  - A rejected call sends none of the notifications the server emitted before
+    dispatch, because a `400` cannot be set on a stream one of them has
+    committed.
+  - An annotation on any other type asserts. A `500` from the handler now reads
+    `The server failed to answer the request`, because the check shares that
+    answer with server construction and initialization.
+  - `handleRequestScopedMessage` gained `beforeDispatch`, which runs against the
+    initialized server, and `ToolsSupport.registeredTools` exposes the
+    registered tools by name.
 - Point the documentation at `modelcontextprotocol.io` and at protocol
   revision 2025-11-25. The old host stopped serving HTTPS, and the old
   revision number 2025-11-05 was never a published revision.

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -269,21 +269,15 @@
   Streamable HTTP handler already requires; the server map travels with
   `ServerCapabilities`, which is held by the legacy `initialize` result and
   by `DiscoverResult`.
-- Support `x-mcp-header` in `handleStreamableHttpRequest`. For `tools/call`, a
-  string, integer, or boolean argument annotated with `x-mcp-header` is checked
-  against its `Mcp-Param-{Name}` header.
-  - Nested `properties` paths and the `=?base64?...?=` encoding are supported.
-  - Missing required headers, headers for absent values, malformed headers, and
-    mismatches return `400 Bad Request` with `McpErrorCodes.headerMismatch`.
-  - A rejected call sends none of the notifications the server emitted before
-    dispatch, because a `400` cannot be set on a stream one of them has
-    committed.
-  - An annotation on any other type asserts. A `500` from the handler now reads
-    `The server failed to answer the request`, because the check shares that
-    answer with server construction and initialization.
-  - `handleRequestScopedMessage` gained `beforeDispatch`, which runs against the
-    initialized server, and `ToolsSupport.registeredTools` exposes the
-    registered tools by name.
+- Support `x-mcp-header` in `handleStreamableHttpRequest`. A `tools/call`
+  argument annotated with it is checked against its `Mcp-Param-{Name}` header.
+  - Nested `properties` paths and `=?base64?...?=` values are supported, and
+    integers are compared numerically.
+  - A missing, extra, malformed, or mismatched header answers `400 Bad Request`
+    with `McpErrorCodes.headerMismatch` and drops any notification the server
+    emitted before dispatch.
+  - `handleRequestScopedMessage` gained `beforeDispatch`, and
+    `ToolsSupport.registeredTools` exposes the registered tools by name.
 - Point the documentation at `modelcontextprotocol.io` and at protocol
   revision 2025-11-25. The old host stopped serving HTTPS, and the old
   revision number 2025-11-05 was never a published revision.

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -276,7 +276,10 @@
   headers, headers for absent values, malformed headers, and mismatches return
   `400 Bad Request` with `McpErrorCodes.headerMismatch`. A rejected call sends
   none of the notifications the server emitted before dispatch, because a
-  `400` cannot be set on a stream one of them has committed.
+  `400` cannot be set on a stream one of them has committed. An annotation on
+  any other type asserts, and a `500` from the handler now reads `The server
+  failed to answer the request`: the check shares that answer with server
+  construction and initialization, so it names neither.
   `handleRequestScopedMessage` gained `beforeDispatch`, which runs against the
   initialized server, and `ToolsSupport.registeredTools` exposes the
   registered tools by name so a transport can read one's schema without

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -269,6 +269,13 @@
   Streamable HTTP handler already requires; the server map travels with
   `ServerCapabilities`, which is held by the legacy `initialize` result and
   by `DiscoverResult`.
+- Support `x-mcp-header` in `handleStreamableHttpRequest`. For annotated
+  string, integer, and boolean tool arguments, matching `Mcp-Param-{Name}`
+  headers are checked against the corresponding argument. Nested `properties`
+  paths and the `=?base64?...?=` encoding are supported. Missing required
+  headers, headers for absent values, malformed headers, and mismatches return
+  `400 Bad Request` with `McpErrorCodes.headerMismatch`.
+  `handleRequestScopedMessage` gained `beforeDispatch` for this validation.
 - Point the documentation at `modelcontextprotocol.io` and at protocol
   revision 2025-11-25. The old host stopped serving HTTPS, and the old
   revision number 2025-11-05 was never a published revision.

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -274,8 +274,13 @@
   headers are checked against the corresponding argument. Nested `properties`
   paths and the `=?base64?...?=` encoding are supported. Missing required
   headers, headers for absent values, malformed headers, and mismatches return
-  `400 Bad Request` with `McpErrorCodes.headerMismatch`.
-  `handleRequestScopedMessage` gained `beforeDispatch` for this validation.
+  `400 Bad Request` with `McpErrorCodes.headerMismatch`. A rejected call sends
+  none of the notifications the server emitted before dispatch, because a
+  `400` cannot be set on a stream one of them has committed.
+  `handleRequestScopedMessage` gained `beforeDispatch`, which runs against the
+  initialized server, and `ToolsSupport.registeredTools` exposes the
+  registered tools by name so a transport can read one's schema without
+  running a `listTools` override.
 - Point the documentation at `modelcontextprotocol.io` and at protocol
   revision 2025-11-25. The old host stopped serving HTTPS, and the old
   revision number 2025-11-05 was never a published revision.

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -68,6 +68,11 @@ typedef MCPServerFactory =
 /// [RpcException] inside their handler, or with a [StateError] if the exchange
 /// has already been torn down.
 ///
+/// If [beforeDispatch] is given, it receives the initialized server and the
+/// registered [Tool] for a `tools/call`, if found. It runs before [message] is
+/// delivered. A non-`null` result stops dispatch. Requests receive the
+/// serialized error and notifications receive no response.
+///
 /// Throws an [ArgumentError] if [message] is not a JSON-RPC request or
 /// notification (no string `method`, a `null` id, or a `result` or `error`
 /// member), or if its method is the legacy `initialize` request or
@@ -82,6 +87,8 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
   MCPServerInitialization initialization,
   MCPServerFactory serverFactory, {
   void Function(Map<String, Object?> notification)? onNotification,
+  FutureOr<RpcException?> Function(MCPServer server, Tool? tool)?
+  beforeDispatch,
 }) async {
   final object = JsonRpc2Object.fromMap(message);
   if (object.kind == JsonRpc2Kind.response) {
@@ -195,6 +202,22 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
   try {
     await server.initialize(initialization);
     server.handleInitialized();
+    Tool? tool;
+    final params = message[Keys.params];
+    if (method == CallToolRequest.methodName &&
+        server is ToolsSupport &&
+        params is Map<String, Object?>) {
+      final toolName = params[Keys.name];
+      if (toolName is String) tool = server._registeredTools[toolName];
+    }
+    final rejection = await beforeDispatch?.call(server, tool);
+    if (rejection != null) {
+      // The message is never added to `inbound`, so the server never sees
+      // it. The `finally` block below still tears the server down exactly
+      // as it would after a dispatched exchange, by closing `inbound` on an
+      // empty stream.
+      return isRequest ? rejection.serialize(message) : null;
+    }
     inbound.add(message);
     if (isRequest) return await response.future;
     return null;

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -68,10 +68,9 @@ typedef MCPServerFactory =
 /// [RpcException] inside their handler, or with a [StateError] if the exchange
 /// has already been torn down.
 ///
-/// If [beforeDispatch] is given, it receives the initialized server and the
-/// registered [Tool] for a `tools/call`, if found. It runs before [message] is
-/// delivered. A non-`null` result stops dispatch. Requests receive the
-/// serialized error and notifications receive no response.
+/// If [beforeDispatch] is given, it receives the initialized server and runs
+/// before [message] is delivered. A non-`null` result stops dispatch: requests
+/// receive the serialized error and notifications receive no response.
 ///
 /// Throws an [ArgumentError] if [message] is not a JSON-RPC request or
 /// notification (no string `method`, a `null` id, or a `result` or `error`
@@ -87,8 +86,7 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
   MCPServerInitialization initialization,
   MCPServerFactory serverFactory, {
   void Function(Map<String, Object?> notification)? onNotification,
-  FutureOr<RpcException?> Function(MCPServer server, Tool? tool)?
-  beforeDispatch,
+  FutureOr<RpcException?> Function(MCPServer server)? beforeDispatch,
 }) async {
   final object = JsonRpc2Object.fromMap(message);
   if (object.kind == JsonRpc2Kind.response) {
@@ -202,15 +200,7 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
   try {
     await server.initialize(initialization);
     server.handleInitialized();
-    Tool? tool;
-    final params = message[Keys.params];
-    if (method == CallToolRequest.methodName &&
-        server is ToolsSupport &&
-        params is Map<String, Object?>) {
-      final toolName = params[Keys.name];
-      if (toolName is String) tool = server._registeredTools[toolName];
-    }
-    final rejection = await beforeDispatch?.call(server, tool);
+    final rejection = await beforeDispatch?.call(server);
     if (rejection != null) {
       // The message is never added to `inbound`, so the server never sees
       // it. The `finally` block below still tears the server down exactly

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:collection';
 
 import 'package:json_rpc_2/error_code.dart' as error_code;
 import 'package:json_rpc_2/json_rpc_2.dart';

--- a/pkgs/dart_mcp/lib/src/server/tools_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/tools_support.dart
@@ -15,6 +15,15 @@ base mixin ToolsSupport on MCPServer {
   /// The registered tools by name.
   final Map<String, Tool> _registeredTools = {};
 
+  /// The tools registered on this server, by name.
+  ///
+  /// [registerTool] and [unregisterTool] are what change this; the view
+  /// itself is read only. Reading it does not run [listTools], so a transport
+  /// can look a tool up without invoking an override.
+  late final Map<String, Tool> registeredTools = UnmodifiableMapView(
+    _registeredTools,
+  );
+
   /// The registered tool implementations by name.
   final Map<String, FutureOr<CallToolResult> Function(CallToolRequest)>
   _registeredToolImpls = {};

--- a/pkgs/dart_mcp/lib/src/utils/constants.dart
+++ b/pkgs/dart_mcp/lib/src/utils/constants.dart
@@ -175,4 +175,5 @@ extension Keys on Never {
   static const values = 'values';
   static const version = 'version';
   static const websiteUrl = 'websiteUrl';
+  static const xMcpHeader = 'x-mcp-header';
 }

--- a/pkgs/dart_mcp/lib/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/streamable_http.dart
@@ -85,8 +85,9 @@ import 'src/utils/json_rpc_2_object.dart';
 /// a non-`null` value. The registered tool is resolved before dispatch.
 /// Sentinel values are decoded, integers are compared numerically, and nested
 /// `properties` maps are followed. A validation failure returns header
-/// mismatch. Initialization notifications are buffered until validation
-/// succeeds.
+/// mismatch. Notifications the server emits before dispatch are held back, so
+/// a mismatch answers `400` rather than an event on a stream one of them
+/// already committed.
 ///
 /// Notifications the server produces while handling the request go out on an
 /// SSE response stream. The first one commits `text/event-stream`, and the
@@ -456,6 +457,16 @@ Future<void> handleStreamableHttpRequest(
     }
   }
 
+  /// Writes the notifications held back so far and stops holding any more.
+  void releasePendingNotifications() {
+    final pending = pendingNotifications;
+    if (pending == null) return;
+    pendingNotifications = null;
+    for (final notification in pending) {
+      writeNotification(notification);
+    }
+  }
+
   final Map<String, Object?>? result;
   try {
     result = await handleRequestScopedMessage(
@@ -476,11 +487,7 @@ Future<void> handleStreamableHttpRequest(
               ? (_, tool) {
                 final rejection = _checkMcpParamHeaders(request, params, tool);
                 if (rejection != null) return rejection;
-                final pending = pendingNotifications!;
-                pendingNotifications = null;
-                for (final notification in pending) {
-                  writeNotification(notification);
-                }
+                releasePendingNotifications();
                 return null;
               }
               : null,
@@ -488,10 +495,13 @@ Future<void> handleStreamableHttpRequest(
   } catch (_) {
     // The server could not be built for this request. Answer before the error
     // leaves this function, so an embedder which discards the returned future
-    // does not leave the connection open. A server that emitted a notification
-    // while initializing has already committed the stream, and headers cannot
-    // be set on it a second time. The answer goes out on the stream instead of
-    // starting a fresh response.
+    // does not leave the connection open. Notifications a server emitted while
+    // initializing are released first: they are what commits the stream, and
+    // once its headers are sent they cannot be set a second time, so the answer
+    // goes out on the stream instead of starting a fresh response. Holding them
+    // past this point would drop them and change the answer to a `tools/call`
+    // into a status no other method returns here.
+    releasePendingNotifications();
     await answer.finish(
       RpcException(
         error_code.INTERNAL_ERROR,
@@ -737,7 +747,7 @@ RpcException? _checkMcpParamHeaders(
 ) {
   if (tool == null) return null;
 
-  final properties = tool.inputSchema.properties;
+  final properties = _readableProperties(tool.inputSchema);
   if (properties == null) return null;
 
   final arguments = params[Keys.arguments];
@@ -752,22 +762,35 @@ RpcException? _checkMcpParamHeaders(
   );
 }
 
+/// The `properties` map of [schema], or `null` when [schema] does not carry one
+/// this check can read.
+///
+/// A subschema is a boolean wherever JSON Schema allows one, and `properties`
+/// holds whatever the server put there. Neither shape can name an
+/// `x-mcp-header`, so both read as nothing to check. Reading them as a map
+/// instead would fail a request over a part of the schema this has no
+/// annotation to find.
+Map<String, Object?>? _readableProperties(Object? schema) {
+  if (schema is! Map<String, Object?>) return null;
+  final properties = schema[Keys.properties];
+  return properties is Map<String, Object?> ? properties : null;
+}
+
 /// Validates [properties] and descends through each nested `properties` map.
 /// [pathPrefix] is the dotted argument path used in errors.
 RpcException? _checkMcpParamHeadersForProperties(
   HttpRequest request,
-  Map<String, Schema> properties,
+  Map<String, Object?> properties,
   Map<String, Object?> argumentMap,
   String pathPrefix,
 ) {
-  for (final MapEntry(key: property, value: schema) in properties.entries) {
+  for (final MapEntry(key: property, value: schemaMap) in properties.entries) {
+    if (schemaMap is! Map<String, Object?>) continue;
     final argumentValue = argumentMap[property];
     final hasValue = argumentMap.containsKey(property) && argumentValue != null;
     final propertyPath = '$pathPrefix$property';
-    final schemaMap = schema as Map<String, Object?>;
 
-    final nestedProperties =
-        (schemaMap[Keys.properties] as Map?)?.cast<String, Schema>();
+    final nestedProperties = _readableProperties(schemaMap);
     if (nestedProperties != null) {
       final nestedArguments =
           hasValue && argumentValue is Map<String, Object?>

--- a/pkgs/dart_mcp/lib/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/streamable_http.dart
@@ -82,14 +82,12 @@ import 'src/utils/json_rpc_2_object.dart';
 ///
 /// For `tools/call`, a string, integer, or boolean property annotated with
 /// `x-mcp-header` requires its `Mcp-Param-{Name}` header when the argument has
-/// a non-`null` value. The registered tool is resolved before dispatch.
-/// Sentinel values are decoded, integers are compared numerically, and nested
-/// `properties` maps are followed. An annotation on any other type is a bug in
-/// the server, not in the request, and asserts. A validation failure returns
-/// header mismatch. Notifications the server emits before dispatch are held
-/// back, so a mismatch answers `400` and not an event on a stream one of them
-/// already committed. A rejected call sends none of them: a `400` cannot be
-/// set on a committed stream, so the error is the whole response.
+/// a non-`null` value. An annotation on any other type is not recognized. The
+/// registered tool is resolved before dispatch, sentinel values are decoded,
+/// integers are compared numerically, and nested `properties` maps are
+/// followed. A validation failure answers `400` with a header mismatch and
+/// drops the notifications the server emitted before dispatch, since those are
+/// what would otherwise have committed the stream.
 ///
 /// Notifications the server produces while handling the request go out on an
 /// SSE response stream. The first one commits `text/event-stream`, and the
@@ -498,21 +496,18 @@ Future<void> handleStreamableHttpRequest(
               : null,
     );
   } catch (_) {
-    // Building the server, initializing it, and the pre-dispatch check all
-    // land here, so the message names none of them. Answer before the error
-    // leaves this function, so an embedder which discards the returned future
-    // does not leave the connection open. Notifications a server emitted while
-    // initializing are released first: they are what commits the stream, and
-    // once its headers are sent they cannot be set a second time, so the answer
-    // goes out on the stream instead of starting a fresh response. Holding them
-    // past this point would drop them and answer a `tools/call` with a fresh
-    // `500`, so the same failure would be reported one way for `tools/call`
-    // and another for every other method.
+    // The server could not be built for this request. Answer before the error
+    // leaves this function, so an embedder that discards the returned future
+    // does not leave the connection open. A server that emitted a notification
+    // while initializing has already committed the stream, and headers cannot
+    // be set on it a second time. The answer goes out on the stream instead of
+    // starting a fresh response, so a `tools/call` releases the notifications
+    // it was holding back before answering.
     releasePendingNotifications();
     await answer.finish(
       RpcException(
         error_code.INTERNAL_ERROR,
-        'The server failed to answer the request',
+        'The server failed to initialize',
       ).serialize(decoded),
     );
     rethrow;
@@ -673,7 +668,7 @@ bool _accepts(HttpRequest request, String mimeType) {
 ///
 /// Throws a [FormatException] if the sentinel payload is not valid base64.
 String _decodeSentinel(String value) =>
-    // The `=?base64?` prefix is 9 characters and the `?=` suffix is 2. Under
+    // The `=?base64?` prefix is 9 characters and the `?=` suffix is 2; under
     // 11 characters they overlap, so guard the length before slicing.
     value.length >= 11 && value.startsWith('=?base64?') && value.endsWith('?=')
         ? utf8.decode(base64.decode(value.substring(9, value.length - 2)))
@@ -800,22 +795,16 @@ RpcException? _checkMcpParamHeadersForProperties(
     final suffix = schemaMap[Keys.xMcpHeader];
     if (suffix is! String) continue;
 
-    // The annotation is read before the type so that one the specification
-    // does not allow is reported. Skipping it silently would leave the server
-    // believing a header is checked when nothing checks it, and the request
-    // would go through either way.
+    // The specification allows the annotation on a string, integer, or boolean
+    // property only, and it is the client that rejects a tool definition
+    // putting it anywhere else. An annotation on another type is one this does
+    // not recognize, so the header it names goes unread.
     final type = schemaMap[Keys.type];
-    final isPrimitive =
-        type == JsonType.string.typeName ||
-        type == JsonType.int.typeName ||
-        type == JsonType.bool.typeName;
-    assert(
-      isPrimitive,
-      'params.arguments.$propertyPath is annotated '
-      '${Keys.xMcpHeader}: $suffix, but the specification only allows the '
-      'annotation on a string, integer, or boolean property.',
-    );
-    if (!isPrimitive) continue;
+    if (type != JsonType.string.typeName &&
+        type != JsonType.int.typeName &&
+        type != JsonType.bool.typeName) {
+      continue;
+    }
 
     final headerName = '$_mcpParamHeaderPrefix$suffix';
     if (!hasValue) {

--- a/pkgs/dart_mcp/lib/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/streamable_http.dart
@@ -444,6 +444,9 @@ Future<void> handleStreamableHttpRequest(
   final answer = _Answer(response);
   var pendingNotifications =
       method == CallToolRequest.methodName ? <Map<String, Object?>>[] : null;
+
+  /// Writes [notification] to the response stream, skipping the ones an
+  /// embedder serves on a listen stream.
   void writeNotification(Map<String, Object?> notification) {
     if (!_listenStreamNotifications.contains(notification[Keys.method])) {
       answer.notify(notification);
@@ -753,7 +756,9 @@ RpcException? _checkMcpParamHeaders(
 ///
 /// A subschema is a boolean wherever JSON Schema allows one, and `properties`
 /// holds whatever the server put there. Neither shape can name an
-/// `x-mcp-header`, so both read as nothing to check.
+/// `x-mcp-header`, so both read as nothing to check. [schema] is [Object] here
+/// because `Tool.inputSchema` is an extension type over a map and does not
+/// implement `Map<String, Object?>`.
 Map<String, Object?>? _readableProperties(Object? schema) {
   if (schema is! Map<String, Object?>) return null;
   final properties = schema[Keys.properties];

--- a/pkgs/dart_mcp/lib/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/streamable_http.dart
@@ -498,7 +498,8 @@ Future<void> handleStreamableHttpRequest(
               : null,
     );
   } catch (_) {
-    // The server could not be built for this request. Answer before the error
+    // Building the server, initializing it, and the pre-dispatch check all
+    // land here, so the message names none of them. Answer before the error
     // leaves this function, so an embedder which discards the returned future
     // does not leave the connection open. Notifications a server emitted while
     // initializing are released first: they are what commits the stream, and
@@ -511,7 +512,7 @@ Future<void> handleStreamableHttpRequest(
     await answer.finish(
       RpcException(
         error_code.INTERNAL_ERROR,
-        'The server failed to initialize',
+        'The server failed to answer the request',
       ).serialize(decoded),
     );
     rethrow;
@@ -723,8 +724,8 @@ const _mcpParamHeaderPrefix = 'Mcp-Param-';
 
 /// Validates annotated primitive arguments in [params] against [request].
 ///
-/// A server which registers no tools, or which has none under the requested
-/// name, has no schema to read an annotation from and nothing to check.
+/// A server that registers no tools, or has none under the requested name,
+/// has no schema to read an annotation from and nothing to check.
 RpcException? _checkMcpParamHeaders(
   HttpRequest request,
   Map<String, Object?> params,

--- a/pkgs/dart_mcp/lib/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/streamable_http.dart
@@ -84,10 +84,12 @@ import 'src/utils/json_rpc_2_object.dart';
 /// `x-mcp-header` requires its `Mcp-Param-{Name}` header when the argument has
 /// a non-`null` value. The registered tool is resolved before dispatch.
 /// Sentinel values are decoded, integers are compared numerically, and nested
-/// `properties` maps are followed. A validation failure returns header
-/// mismatch. Notifications the server emits before dispatch are held back, so
-/// a mismatch answers `400` rather than an event on a stream one of them
-/// already committed.
+/// `properties` maps are followed. An annotation on any other type is a bug in
+/// the server, not in the request, and asserts. A validation failure returns
+/// header mismatch. Notifications the server emits before dispatch are held
+/// back, so a mismatch answers `400` and not an event on a stream one of them
+/// already committed. A rejected call sends none of them: a `400` cannot be
+/// set on a committed stream, so the error is the whole response.
 ///
 /// Notifications the server produces while handling the request go out on an
 /// SSE response stream. The first one commits `text/event-stream`, and the
@@ -424,13 +426,6 @@ Future<void> handleStreamableHttpRequest(
     }
   }
 
-  final initialization = MCPServerInitialization(
-    protocolVersion: protocolVersion,
-    clientCapabilities: ClientCapabilities.fromMap(capabilities),
-    clientInfo: clientInfo == null ? null : Implementation.fromMap(clientInfo),
-    logLevel: logLevel,
-  );
-
   if (!protocolVersion.methodIsValid(method) && _someRevisionDefines(method)) {
     // A method an earlier revision defined and this one took out is unknown
     // here, not a dispatcher error. A mixin or a capability registers handlers
@@ -471,7 +466,13 @@ Future<void> handleStreamableHttpRequest(
   try {
     result = await handleRequestScopedMessage(
       decoded,
-      initialization,
+      MCPServerInitialization(
+        protocolVersion: protocolVersion,
+        clientCapabilities: ClientCapabilities.fromMap(capabilities),
+        clientInfo:
+            clientInfo == null ? null : Implementation.fromMap(clientInfo),
+        logLevel: logLevel,
+      ),
       serverFactory,
       onNotification: (notification) {
         final pending = pendingNotifications;
@@ -484,8 +485,12 @@ Future<void> handleStreamableHttpRequest(
       },
       beforeDispatch:
           method == CallToolRequest.methodName
-              ? (_, tool) {
-                final rejection = _checkMcpParamHeaders(request, params, tool);
+              ? (server) {
+                final rejection = _checkMcpParamHeaders(
+                  request,
+                  params,
+                  server,
+                );
                 if (rejection != null) return rejection;
                 releasePendingNotifications();
                 return null;
@@ -499,8 +504,9 @@ Future<void> handleStreamableHttpRequest(
     // initializing are released first: they are what commits the stream, and
     // once its headers are sent they cannot be set a second time, so the answer
     // goes out on the stream instead of starting a fresh response. Holding them
-    // past this point would drop them and change the answer to a `tools/call`
-    // into a status no other method returns here.
+    // past this point would drop them and answer a `tools/call` with a fresh
+    // `500`, so the same failure would be reported one way for `tools/call`
+    // and another for every other method.
     releasePendingNotifications();
     await answer.finish(
       RpcException(
@@ -672,28 +678,6 @@ String _decodeSentinel(String value) =>
         ? utf8.decode(base64.decode(value.substring(9, value.length - 2)))
         : value;
 
-/// Decodes the sentinel encoding used by an `Mcp-Param` header.
-///
-/// Throws a [FormatException] if the payload is not standard base64.
-String _decodeMcpParamSentinel(String value) {
-  // The `=?base64?` prefix is 9 characters and the `?=` suffix is 2.
-  // Under 11 characters the markers overlap, so guard before slicing.
-  if (value.length < 11 ||
-      !value.startsWith('=?base64?') ||
-      !value.endsWith('?=')) {
-    return value;
-  }
-  final payload = value.substring(9, value.length - 2);
-  if (!_standardBase64.hasMatch(payload)) {
-    throw FormatException('Not standard base64', payload);
-  }
-  return utf8.decode(base64.decode(payload));
-}
-
-/// The standard base64 alphabet with its padding, which is what the
-/// `=?base64?...?=` sentinel carries.
-final _standardBase64 = RegExp(r'^[A-Za-z0-9+/]*={0,2}$');
-
 // Header field names are case insensitive, so these are used both to look
 // headers up and to name them in error messages, in the casing the
 // specification writes them in.
@@ -739,12 +723,18 @@ const _mcpParamHeaderPrefix = 'Mcp-Param-';
 
 /// Validates annotated primitive arguments in [params] against [request].
 ///
-/// [tool] is the registered tool named by the request, if one was found.
+/// A server which registers no tools, or which has none under the requested
+/// name, has no schema to read an annotation from and nothing to check.
 RpcException? _checkMcpParamHeaders(
   HttpRequest request,
   Map<String, Object?> params,
-  Tool? tool,
+  MCPServer server,
 ) {
+  if (server is! ToolsSupport) return null;
+  final toolName = params[Keys.name];
+  if (toolName is! String) return null;
+
+  final tool = server.registeredTools[toolName];
   if (tool == null) return null;
 
   final properties = _readableProperties(tool.inputSchema);
@@ -806,14 +796,25 @@ RpcException? _checkMcpParamHeadersForProperties(
       continue;
     }
 
-    final type = schemaMap[Keys.type];
-    if (type != JsonType.string.typeName &&
-        type != JsonType.int.typeName &&
-        type != JsonType.bool.typeName) {
-      continue;
-    }
     final suffix = schemaMap[Keys.xMcpHeader];
     if (suffix is! String) continue;
+
+    // The annotation is read before the type so that one the specification
+    // does not allow is reported. Skipping it silently would leave the server
+    // believing a header is checked when nothing checks it, and the request
+    // would go through either way.
+    final type = schemaMap[Keys.type];
+    final isPrimitive =
+        type == JsonType.string.typeName ||
+        type == JsonType.int.typeName ||
+        type == JsonType.bool.typeName;
+    assert(
+      isPrimitive,
+      'params.arguments.$propertyPath is annotated '
+      '${Keys.xMcpHeader}: $suffix, but the specification only allows the '
+      'annotation on a string, integer, or boolean property.',
+    );
+    if (!isPrimitive) continue;
 
     final headerName = '$_mcpParamHeaderPrefix$suffix';
     if (!hasValue) {
@@ -844,12 +845,12 @@ RpcException? _checkMcpParamHeadersForProperties(
     }
     final String decodedValue;
     try {
-      decodedValue = _decodeMcpParamSentinel(headerValue);
+      decodedValue = _decodeSentinel(headerValue);
     } on FormatException {
       return RpcException(
         McpErrorCodes.headerMismatch,
-        'The $headerName header ${jsonEncode(headerValue)} must use standard '
-        'base64 inside the =?base64?...?= sentinel',
+        'The $headerName header ${jsonEncode(headerValue)} is not valid base64 '
+        'inside the =?base64?...?= sentinel',
       );
     }
     final matches =

--- a/pkgs/dart_mcp/lib/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/streamable_http.dart
@@ -788,8 +788,14 @@ RpcException? _checkMcpParamHeadersForProperties(
 
     final nestedProperties = _readableProperties(schemaMap);
     if (nestedProperties != null) {
+      // Only `params.arguments` itself is typed by the protocol. What a tool
+      // takes under it belongs to the tool's own schema, and that schema
+      // validates the shape. An argument present but not an object holds no
+      // nested arguments to compare, and this leaves the subtree alone instead
+      // of reading them as absent.
+      if (hasValue && argumentValue is! Map<String, Object?>) continue;
       final nestedArguments =
-          hasValue && argumentValue is Map<String, Object?>
+          argumentValue is Map<String, Object?>
               ? argumentValue
               : const <String, Object?>{};
       final failure = _checkMcpParamHeadersForProperties(

--- a/pkgs/dart_mcp/lib/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/streamable_http.dart
@@ -753,9 +753,7 @@ RpcException? _checkMcpParamHeaders(
 ///
 /// A subschema is a boolean wherever JSON Schema allows one, and `properties`
 /// holds whatever the server put there. Neither shape can name an
-/// `x-mcp-header`, so both read as nothing to check. Reading them as a map
-/// instead would fail a request over a part of the schema this has no
-/// annotation to find.
+/// `x-mcp-header`, so both read as nothing to check.
 Map<String, Object?>? _readableProperties(Object? schema) {
   if (schema is! Map<String, Object?>) return null;
   final properties = schema[Keys.properties];

--- a/pkgs/dart_mcp/lib/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/streamable_http.dart
@@ -739,10 +739,9 @@ RpcException? _checkMcpParamHeaders(
   final properties = _readableProperties(tool.inputSchema);
   if (properties == null) return null;
 
-  // The protocol types `arguments` as an object. Reading a value of another
-  // shape as an empty map reports every annotated argument as absent, and
-  // answers a header naming one of them with a mismatch the client did not
-  // cause.
+  // The protocol types `arguments` as an object. Reading another shape as an
+  // empty map reports every annotated argument as absent, and blames a header
+  // naming one for what the body got wrong.
   final arguments = params[Keys.arguments];
   if (arguments is! Map<String, Object?>?) {
     return RpcException.invalidParams(
@@ -788,16 +787,11 @@ RpcException? _checkMcpParamHeadersForProperties(
 
     final nestedProperties = _readableProperties(schemaMap);
     if (nestedProperties != null) {
-      // Only `params.arguments` itself is typed by the protocol. What a tool
-      // takes under it belongs to the tool's own schema, and that schema
-      // validates the shape. An argument present but not an object holds no
-      // nested arguments to compare, and this leaves the subtree alone instead
-      // of reading them as absent.
-      if (hasValue && argumentValue is! Map<String, Object?>) continue;
-      final nestedArguments =
-          argumentValue is Map<String, Object?>
-              ? argumentValue
-              : const <String, Object?>{};
+      // Only `params.arguments` is typed by the protocol. What a tool takes
+      // under it belongs to the tool's own schema. A present non-object holds
+      // no nested arguments to compare, and this leaves the subtree unread.
+      final nestedArguments = argumentValue ?? const <String, Object?>{};
+      if (nestedArguments is! Map<String, Object?>) continue;
       final failure = _checkMcpParamHeadersForProperties(
         request,
         nestedProperties,

--- a/pkgs/dart_mcp/lib/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/streamable_http.dart
@@ -78,10 +78,15 @@ import 'src/utils/json_rpc_2_object.dart';
 ///
 /// `Mcp-Session-Id` and `Last-Event-ID` headers are ignored, and no session
 /// id is ever minted: sessions and resumable streams were removed in this
-/// revision. The `Mcp-Param-{Name}` headers this revision defines are not
-/// supported either: nothing here opts into `x-mcp-header`, so no such
-/// header is ever recognized, and it is ignored along with every other
-/// header this handler does not read.
+/// revision.
+///
+/// For `tools/call`, a string, integer, or boolean property annotated with
+/// `x-mcp-header` requires its `Mcp-Param-{Name}` header when the argument has
+/// a non-`null` value. The registered tool is resolved before dispatch.
+/// Sentinel values are decoded, integers are compared numerically, and nested
+/// `properties` maps are followed. A validation failure returns header
+/// mismatch. Initialization notifications are buffered until validation
+/// succeeds.
 ///
 /// Notifications the server produces while handling the request go out on an
 /// SSE response stream. The first one commits `text/event-stream`, and the
@@ -418,6 +423,13 @@ Future<void> handleStreamableHttpRequest(
     }
   }
 
+  final initialization = MCPServerInitialization(
+    protocolVersion: protocolVersion,
+    clientCapabilities: ClientCapabilities.fromMap(capabilities),
+    clientInfo: clientInfo == null ? null : Implementation.fromMap(clientInfo),
+    logLevel: logLevel,
+  );
+
   if (!protocolVersion.methodIsValid(method) && _someRevisionDefines(method)) {
     // A method an earlier revision defined and this one took out is unknown
     // here, not a dispatcher error. A mixin or a capability registers handlers
@@ -436,24 +448,42 @@ Future<void> handleStreamableHttpRequest(
   }
 
   final answer = _Answer(response);
+  var pendingNotifications =
+      method == CallToolRequest.methodName ? <Map<String, Object?>>[] : null;
+  void writeNotification(Map<String, Object?> notification) {
+    if (!_listenStreamNotifications.contains(notification[Keys.method])) {
+      answer.notify(notification);
+    }
+  }
+
   final Map<String, Object?>? result;
   try {
     result = await handleRequestScopedMessage(
       decoded,
-      MCPServerInitialization(
-        protocolVersion: protocolVersion,
-        clientCapabilities: ClientCapabilities.fromMap(capabilities),
-        clientInfo:
-            clientInfo == null ? null : Implementation.fromMap(clientInfo),
-        logLevel: logLevel,
-      ),
+      initialization,
       serverFactory,
       onNotification: (notification) {
-        if (!_listenStreamNotifications.contains(notification[Keys.method])) {
-          answer.notify(notification);
+        final pending = pendingNotifications;
+        if (pending == null) {
+          writeNotification(notification);
+        } else {
+          pending.add(notification);
         }
         onNotification?.call(notification);
       },
+      beforeDispatch:
+          method == CallToolRequest.methodName
+              ? (_, tool) {
+                final rejection = _checkMcpParamHeaders(request, params, tool);
+                if (rejection != null) return rejection;
+                final pending = pendingNotifications!;
+                pendingNotifications = null;
+                for (final notification in pending) {
+                  writeNotification(notification);
+                }
+                return null;
+              }
+              : null,
     );
   } catch (_) {
     // The server could not be built for this request. Answer before the error
@@ -626,11 +656,33 @@ bool _accepts(HttpRequest request, String mimeType) {
 ///
 /// Throws a [FormatException] if the sentinel payload is not valid base64.
 String _decodeSentinel(String value) =>
-    // The `=?base64?` prefix is 9 characters and the `?=` suffix is 2; under
+    // The `=?base64?` prefix is 9 characters and the `?=` suffix is 2. Under
     // 11 characters they overlap, so guard the length before slicing.
     value.length >= 11 && value.startsWith('=?base64?') && value.endsWith('?=')
         ? utf8.decode(base64.decode(value.substring(9, value.length - 2)))
         : value;
+
+/// Decodes the sentinel encoding used by an `Mcp-Param` header.
+///
+/// Throws a [FormatException] if the payload is not standard base64.
+String _decodeMcpParamSentinel(String value) {
+  // The `=?base64?` prefix is 9 characters and the `?=` suffix is 2.
+  // Under 11 characters the markers overlap, so guard before slicing.
+  if (value.length < 11 ||
+      !value.startsWith('=?base64?') ||
+      !value.endsWith('?=')) {
+    return value;
+  }
+  final payload = value.substring(9, value.length - 2);
+  if (!_standardBase64.hasMatch(payload)) {
+    throw FormatException('Not standard base64', payload);
+  }
+  return utf8.decode(base64.decode(payload));
+}
+
+/// The standard base64 alphabet with its padding, which is what the
+/// `=?base64?...?=` sentinel carries.
+final _standardBase64 = RegExp(r'^[A-Za-z0-9+/]*={0,2}$');
 
 // Header field names are case insensitive, so these are used both to look
 // headers up and to name them in error messages, in the casing the
@@ -664,3 +716,133 @@ const _mcpNameParams = {
   GetPromptRequest.methodName: Keys.name,
   ReadResourceRequest.methodName: Keys.uri,
 };
+
+/// A number with an optional minus sign and fractional part.
+///
+/// https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http
+final _decimal = RegExp(r'^-?\d+(\.\d+)?$');
+
+/// The prefix of the header a property's `x-mcp-header` annotation names, so
+/// a property annotated `x-mcp-header: "Region"` is mirrored on
+/// `Mcp-Param-Region`.
+const _mcpParamHeaderPrefix = 'Mcp-Param-';
+
+/// Validates annotated primitive arguments in [params] against [request].
+///
+/// [tool] is the registered tool named by the request, if one was found.
+RpcException? _checkMcpParamHeaders(
+  HttpRequest request,
+  Map<String, Object?> params,
+  Tool? tool,
+) {
+  if (tool == null) return null;
+
+  final properties = tool.inputSchema.properties;
+  if (properties == null) return null;
+
+  final arguments = params[Keys.arguments];
+  final argumentMap =
+      arguments is Map<String, Object?> ? arguments : const <String, Object?>{};
+
+  return _checkMcpParamHeadersForProperties(
+    request,
+    properties,
+    argumentMap,
+    '',
+  );
+}
+
+/// Validates [properties] and descends through each nested `properties` map.
+/// [pathPrefix] is the dotted argument path used in errors.
+RpcException? _checkMcpParamHeadersForProperties(
+  HttpRequest request,
+  Map<String, Schema> properties,
+  Map<String, Object?> argumentMap,
+  String pathPrefix,
+) {
+  for (final MapEntry(key: property, value: schema) in properties.entries) {
+    final argumentValue = argumentMap[property];
+    final hasValue = argumentMap.containsKey(property) && argumentValue != null;
+    final propertyPath = '$pathPrefix$property';
+    final schemaMap = schema as Map<String, Object?>;
+
+    final nestedProperties =
+        (schemaMap[Keys.properties] as Map?)?.cast<String, Schema>();
+    if (nestedProperties != null) {
+      final nestedArguments =
+          hasValue && argumentValue is Map<String, Object?>
+              ? argumentValue
+              : const <String, Object?>{};
+      final failure = _checkMcpParamHeadersForProperties(
+        request,
+        nestedProperties,
+        nestedArguments,
+        '$propertyPath.',
+      );
+      if (failure != null) return failure;
+      continue;
+    }
+
+    final type = schemaMap[Keys.type];
+    if (type != JsonType.string.typeName &&
+        type != JsonType.int.typeName &&
+        type != JsonType.bool.typeName) {
+      continue;
+    }
+    final suffix = schemaMap[Keys.xMcpHeader];
+    if (suffix is! String) continue;
+
+    final headerName = '$_mcpParamHeaderPrefix$suffix';
+    if (!hasValue) {
+      if (request.headers[headerName] == null) continue;
+      return RpcException(
+        McpErrorCodes.headerMismatch,
+        'Received a $headerName header for '
+        'params.arguments.$propertyPath. Expected no header because the '
+        'argument is absent or null',
+      );
+    }
+    final headerValue = _singleHeader(request, headerName);
+    if (headerValue == null) {
+      return RpcException(
+        McpErrorCodes.headerMismatch,
+        'Received no single $headerName header. Expected '
+        '${jsonEncode(argumentValue)} from params.arguments.$propertyPath',
+      );
+    }
+    if (headerValue.codeUnits.any(
+      (unit) => unit != 0x09 && (unit < 0x20 || unit > 0x7e),
+    )) {
+      return RpcException(
+        McpErrorCodes.headerMismatch,
+        'The $headerName header ${jsonEncode(headerValue)} must contain only '
+        'HTAB, space, or visible ASCII characters',
+      );
+    }
+    final String decodedValue;
+    try {
+      decodedValue = _decodeMcpParamSentinel(headerValue);
+    } on FormatException {
+      return RpcException(
+        McpErrorCodes.headerMismatch,
+        'The $headerName header ${jsonEncode(headerValue)} must use standard '
+        'base64 inside the =?base64?...?= sentinel',
+      );
+    }
+    final matches =
+        type == JsonType.int.typeName
+            ? argumentValue is num &&
+                _decimal.hasMatch(decodedValue) &&
+                num.tryParse(decodedValue) == argumentValue
+            : decodedValue == argumentValue.toString();
+    if (!matches) {
+      return RpcException(
+        McpErrorCodes.headerMismatch,
+        'The $headerName header ${jsonEncode(headerValue)} decodes to '
+        '${jsonEncode(decodedValue)}. Expected ${jsonEncode(argumentValue)} '
+        'from params.arguments.$propertyPath',
+      );
+    }
+  }
+  return null;
+}

--- a/pkgs/dart_mcp/lib/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/streamable_http.dart
@@ -739,14 +739,21 @@ RpcException? _checkMcpParamHeaders(
   final properties = _readableProperties(tool.inputSchema);
   if (properties == null) return null;
 
+  // The protocol types `arguments` as an object. Reading a value of another
+  // shape as an empty map reports every annotated argument as absent, and
+  // answers a header naming one of them with a mismatch the client did not
+  // cause.
   final arguments = params[Keys.arguments];
-  final argumentMap =
-      arguments is Map<String, Object?> ? arguments : const <String, Object?>{};
+  if (arguments is! Map<String, Object?>?) {
+    return RpcException.invalidParams(
+      'params.${Keys.arguments} must be an object',
+    );
+  }
 
   return _checkMcpParamHeadersForProperties(
     request,
     properties,
-    argumentMap,
+    arguments ?? const {},
     '',
   );
 }

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -53,7 +53,10 @@ void main() {
       expect(callbackServer, same(server));
       expect(callbackTool?.name, 'retained');
       expect(callbackReady, isTrue);
-      expect((response![Keys.error] as Map)[Keys.code], -32602);
+      expect(
+        (response![Keys.error] as Map)[Keys.code],
+        error_code.INVALID_PARAMS,
+      );
       expect(server.retainedResult, isNull);
       await server.done;
       expect(server.isActive, isFalse);

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -31,6 +31,68 @@ void main() {
       );
     });
 
+    test('returns a rejection before calling a registered tool', () async {
+      final harness = _DispatcherHarness();
+      MCPServer? callbackServer;
+      Tool? callbackTool;
+      bool? callbackReady;
+      final response = await harness.dispatch(
+        _callTool('retained'),
+        _initialization(),
+        beforeDispatch: (server, tool) {
+          callbackServer = server;
+          callbackTool = tool;
+          callbackReady = server.ready;
+          return RpcException.invalidParams('blocked before dispatch');
+        },
+      );
+
+      final server = harness.servers.single;
+      expect(callbackServer, same(server));
+      expect(callbackTool?.name, 'retained');
+      expect(callbackReady, isTrue);
+      expect((response![Keys.error] as Map)[Keys.code], -32602);
+      expect(server.retainedResult, isNull);
+      await server.done;
+      expect(server.isActive, isFalse);
+    });
+
+    test('drops a rejection for a notification', () async {
+      final harness = _DispatcherHarness();
+      final notification = _callTool('retained')..remove(Keys.id);
+      final response = await harness.dispatch(
+        notification,
+        _initialization(),
+        beforeDispatch: (_, tool) {
+          expect(tool?.name, 'retained');
+          return RpcException.invalidParams('blocked before dispatch');
+        },
+      );
+
+      final server = harness.servers.single;
+      expect(response, isNull);
+      expect(server.retainedResult, isNull);
+      await server.done;
+      expect(server.isActive, isFalse);
+    });
+
+    test('closes the server when beforeDispatch throws', () async {
+      final harness = _DispatcherHarness();
+      await expectLater(
+        harness.dispatch(
+          _callTool('retained'),
+          _initialization(),
+          beforeDispatch: (_, _) => throw StateError('callback failed'),
+        ),
+        throwsStateError,
+      );
+
+      final server = harness.servers.single;
+      expect(server.retainedResult, isNull);
+      await server.done;
+      expect(server.isActive, isFalse);
+    });
+
     test('records server info on the response', () async {
       final harness = _DispatcherHarness();
       final response = await harness.dispatch(
@@ -855,12 +917,20 @@ final class _DispatcherHarness {
     Map<String, Object?> message,
     MCPServerInitialization initialization, {
     void Function(Map<String, Object?> notification)? onNotification,
-  }) => handleRequestScopedMessage(message, initialization, (channel) {
-    final server = _DispatcherTestServer(channel);
-    if (pickedLogLevel != null) server.loggingLevel = pickedLogLevel;
-    servers.add(server);
-    return server;
-  }, onNotification: onNotification);
+    FutureOr<RpcException?> Function(MCPServer server, Tool? tool)?
+    beforeDispatch,
+  }) => handleRequestScopedMessage(
+    message,
+    initialization,
+    (channel) {
+      final server = _DispatcherTestServer(channel);
+      if (pickedLogLevel != null) server.loggingLevel = pickedLogLevel;
+      servers.add(server);
+      return server;
+    },
+    onNotification: onNotification,
+    beforeDispatch: beforeDispatch,
+  );
 }
 
 /// A server with tools which observe the request-scoped lifecycle.

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -39,9 +39,11 @@ void main() {
       final response = await harness.dispatch(
         _callTool('retained'),
         _initialization(),
-        beforeDispatch: (server, tool) {
+        beforeDispatch: (server) {
           callbackServer = server;
-          callbackTool = tool;
+          // The tools the server registers while initializing are already
+          // there, which is what lets a transport read one's schema here.
+          callbackTool = (server as ToolsSupport).registeredTools['retained'];
           callbackReady = server.ready;
           return RpcException.invalidParams('blocked before dispatch');
         },
@@ -63,8 +65,11 @@ void main() {
       final response = await harness.dispatch(
         notification,
         _initialization(),
-        beforeDispatch: (_, tool) {
-          expect(tool?.name, 'retained');
+        beforeDispatch: (server) {
+          expect(
+            (server as ToolsSupport).registeredTools['retained'],
+            isNotNull,
+          );
           return RpcException.invalidParams('blocked before dispatch');
         },
       );
@@ -82,7 +87,7 @@ void main() {
         harness.dispatch(
           _callTool('retained'),
           _initialization(),
-          beforeDispatch: (_, _) => throw StateError('callback failed'),
+          beforeDispatch: (_) => throw StateError('callback failed'),
         ),
         throwsStateError,
       );
@@ -917,8 +922,7 @@ final class _DispatcherHarness {
     Map<String, Object?> message,
     MCPServerInitialization initialization, {
     void Function(Map<String, Object?> notification)? onNotification,
-    FutureOr<RpcException?> Function(MCPServer server, Tool? tool)?
-    beforeDispatch,
+    FutureOr<RpcException?> Function(MCPServer server)? beforeDispatch,
   }) => handleRequestScopedMessage(
     message,
     initialization,

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -42,7 +42,7 @@ void main() {
         beforeDispatch: (server) {
           callbackServer = server;
           // The tools the server registers while initializing are already
-          // there, which is what lets a transport read one's schema here.
+          // there, so a transport can read one's schema here.
           callbackTool = (server as ToolsSupport).registeredTools['retained'];
           callbackReady = server.ready;
           return RpcException.invalidParams('blocked before dispatch');

--- a/pkgs/dart_mcp/test/server/tools_support_test.dart
+++ b/pkgs/dart_mcp/test/server/tools_support_test.dart
@@ -78,7 +78,7 @@ void main() {
     server.unregisterTool('echo');
     expect(server.registeredTools.keys, {'hello_world'});
 
-    // A caller which gets hold of the map must not be able to register or
+    // A caller that gets hold of the map must not be able to register or
     // drop a tool behind `registerTool`'s back.
     expect(
       () => server.registeredTools['echo'] = TestMCPServerWithTools.echo,

--- a/pkgs/dart_mcp/test/server/tools_support_test.dart
+++ b/pkgs/dart_mcp/test/server/tools_support_test.dart
@@ -58,6 +58,34 @@ void main() {
     );
   });
 
+  test('registeredTools tracks registration and is read only', () async {
+    final environment = TestEnvironment(
+      TestMCPClient(),
+      TestMCPServerWithTools.new,
+    );
+    await environment.initializeServer();
+
+    final server = environment.server;
+    expect(server.registeredTools.keys, {'hello_world', 'echo'});
+    expect(
+      server.registeredTools['echo'],
+      same(TestMCPServerWithTools.echo),
+      reason:
+          'the registered tool itself is what a transport reads a schema '
+          'from',
+    );
+
+    server.unregisterTool('echo');
+    expect(server.registeredTools.keys, {'hello_world'});
+
+    // A caller which gets hold of the map must not be able to register or
+    // drop a tool behind `registerTool`'s back.
+    expect(
+      () => server.registeredTools['echo'] = TestMCPServerWithTools.echo,
+      throwsUnsupportedError,
+    );
+  });
+
   test('client can list and invoke tools from the server', () async {
     final environment = TestEnvironment(
       TestMCPClient(),

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -688,6 +688,9 @@ void main() {
       final text = await utf8.decodeStream(response);
       expect(response.statusCode, 500);
       expect(errorCode(text), error_code.INTERNAL_ERROR);
+      // The server initialized. The annotation is what this could not get
+      // past, so the answer does not name initialization.
+      expect(errorMessage(text), 'The server failed to answer the request');
     }, testOn: '!exe');
 
     test(

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -723,6 +723,22 @@ void main() {
       expect(servers.single.listToolsCalls, 0);
     });
 
+    test('rejects arguments that are not an object', () async {
+      final (status, _, text) = await post(
+        headers: callWithHeaderParamHeaders({'Mcp-Param-Region': 'us-west1'}),
+        json: body(
+          callTool,
+          params: {
+            Keys.name: 'test/withHeaderParam',
+            Keys.arguments: 'us-west1',
+          },
+        ),
+      );
+      expect(status, 400);
+      expect(errorCode(text), error_code.INVALID_PARAMS);
+      expect(errorMessage(text), contains('params.arguments'));
+    });
+
     test('rejects a non-ASCII header field value', () async {
       final bodyBytes = utf8.encode(
         jsonEncode(callWithHeaderParam({'region': 'é'})),

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -1008,6 +1008,17 @@ void main() {
       expect(errorCode(text), isNull);
     });
 
+    test('rejects a header for an absent nested argument', () async {
+      final (status, _, text) = await post(
+        headers: callWithNestedHeaderParamHeaders({
+          'Mcp-Param-Region': 'us-west1',
+        }),
+        json: callWithNestedHeaderParam(const {}),
+      );
+      expect(status, 400);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
+    });
+
     test('does not require a header when the object carrying a nested '
         'property is absent', () async {
       final (status, _, text) = await post(

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -651,6 +651,69 @@ void main() {
       expect(errorCode(text), isNull);
     });
 
+    test('reports an annotation the specification does not allow', () async {
+      // Passing this over would leave the server believing `Mcp-Param-Label`
+      // is checked while the call goes through unchecked.
+      final failing = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => failing.close(force: true));
+      failing.listen(
+        (request) => handleStreamableHttpRequest(
+          request,
+          _HttpTestServer.new,
+        ).onError<Object>((_, _) {}),
+      );
+      final client = HttpClient();
+      addTearDown(client.close);
+      final request = await client.postUrl(
+        Uri.http('${failing.address.host}:${failing.port}', '/mcp'),
+      );
+      final sent = {
+        ...headers(callTool),
+        'Mcp-Name': 'test/badAnnotation',
+        'Mcp-Param-Label': 'wrong',
+      };
+      sent.forEach(request.headers.set);
+      request.write(
+        jsonEncode(
+          body(
+            callTool,
+            params: {
+              Keys.name: 'test/badAnnotation',
+              Keys.arguments: {'label': 'right'},
+            },
+          ),
+        ),
+      );
+      final response = await request.close();
+      final text = await utf8.decodeStream(response);
+      expect(response.statusCode, 500);
+      expect(errorCode(text), error_code.INTERNAL_ERROR);
+    }, testOn: '!exe');
+
+    test(
+      'ignores an Mcp-Param header for a tool which annotates none',
+      () async {
+        // `test/version` marks no property with `x-mcp-header`, so there is
+        // no argument to compare the header against, and it is ignored.
+        final (status, _, text) = await post(
+          headers: {
+            ...headers(callTool),
+            'Mcp-Name': 'test/version',
+            'Mcp-Param-Region': 'eu-west1',
+          },
+          json: body(
+            callTool,
+            params: {
+              Keys.name: 'test/version',
+              Keys.arguments: {'region': 'us-west1'},
+            },
+          ),
+        );
+        expect(status, 200);
+        expect(errorCode(text), isNull);
+      },
+    );
+
     test('skips a schema part which cannot carry an annotation', () async {
       final (status, _, text) = await post(
         headers: {...headers(callTool), 'Mcp-Name': 'test/booleanSubschema'},
@@ -707,7 +770,7 @@ void main() {
         bodyBytes,
       );
       expect(response, startsWith('HTTP/1.1 400'));
-      expect(errorCode(jsonBody(response)), -32020);
+      expect(errorCode(jsonBody(response)), McpErrorCodes.headerMismatch);
     });
 
     test('rejects a header value which does not match the body', () async {
@@ -716,7 +779,7 @@ void main() {
         json: callWithHeaderParam({'region': 'us-west1'}),
       );
       expect(status, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
       expect(errorMessage(text), contains('eu-west1'));
       expect(errorMessage(text), contains('us-west1'));
     });
@@ -727,7 +790,7 @@ void main() {
         json: callWithHeaderParam({'region': 'us-west1'}),
       );
       expect(status, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
       expect(errorMessage(text), contains('no single Mcp-Param-Region'));
       expect(errorMessage(text), contains('us-west1'));
     });
@@ -738,7 +801,7 @@ void main() {
         json: callWithHeaderParam(const {}),
       );
       expect(status, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
       expect(errorMessage(text), contains('Mcp-Param-Region'));
       expect(errorMessage(text), contains('params.arguments.region'));
     });
@@ -749,12 +812,15 @@ void main() {
         json: callWithHeaderParam({'region': null}),
       );
       expect(status, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
       expect(errorMessage(text), contains('Mcp-Param-Region'));
       expect(errorMessage(text), contains('params.arguments.region'));
     });
 
     test('rejects before an initialization notification commits', () async {
+      // Holding the notification back is what leaves the response headers
+      // free to carry a 400, and the price is that the rejected call sends
+      // none of them.
       final notifying = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
       addTearDown(() => notifying.close(force: true));
       notifying.listen(
@@ -773,7 +839,8 @@ void main() {
 
       expect(response.statusCode, 400);
       expect(response.headers.contentType?.mimeType, 'application/json');
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
+      expect(text, isNot(contains('while starting up')));
     });
 
     test(
@@ -800,17 +867,6 @@ void main() {
       expect(errorCode(text), isNull);
     });
 
-    test('rejects a url-safe base64-sentinel header value', () async {
-      final (status, _, text) = await post(
-        headers: callWithHeaderParamHeaders({
-          'Mcp-Param-Region': '=?base64?YWJ-eg==?=',
-        }),
-        json: callWithHeaderParam({'region': 'ab~z'}),
-      );
-      expect(status, 400);
-      expect(errorCode(text), -32020);
-    });
-
     test('rejects a base64-sentinel header value with bad padding', () async {
       final (status, _, text) = await post(
         // The base64 encoding of "us-west1" is "dXMtd2VzdDE=", with its
@@ -821,9 +877,9 @@ void main() {
         json: callWithHeaderParam({'region': 'us-west1'}),
       );
       expect(status, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
       expect(errorMessage(text), contains('=?base64?dXMtd2VzdDE?='));
-      expect(errorMessage(text), contains('standard base64'));
+      expect(errorMessage(text), contains('not valid base64'));
     });
 
     test(
@@ -836,7 +892,7 @@ void main() {
           json: callWithHeaderParam({'region': 'us-west1'}),
         );
         expect(status, 400);
-        expect(errorCode(text), -32020);
+        expect(errorCode(text), McpErrorCodes.headerMismatch);
       },
     );
 
@@ -900,7 +956,7 @@ void main() {
           json: callWithHeaderParam({'count': 42}),
         );
         expect(status, 400, reason: header);
-        expect(errorCode(text), -32020, reason: header);
+        expect(errorCode(text), McpErrorCodes.headerMismatch, reason: header);
       }
 
       final (status, _, text) = await post(
@@ -908,7 +964,7 @@ void main() {
         json: callWithHeaderParam({'count': 1000}),
       );
       expect(status, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
     });
 
     test('rejects a mismatched integer property', () async {
@@ -917,7 +973,7 @@ void main() {
         json: callWithHeaderParam({'count': 42}),
       );
       expect(status, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
     });
 
     test('compares a boolean property', () async {
@@ -935,7 +991,7 @@ void main() {
         json: callWithHeaderParam({'flag': true}),
       );
       expect(status, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
     });
   });
 
@@ -985,7 +1041,7 @@ void main() {
         }),
       );
       expect(status, 400);
-      expect(errorCode(text), -32020);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
     });
 
     test(
@@ -998,7 +1054,7 @@ void main() {
           }),
         );
         expect(status, 400);
-        expect(errorCode(text), -32020);
+        expect(errorCode(text), McpErrorCodes.headerMismatch);
       },
     );
 
@@ -1945,6 +2001,26 @@ base class _HttpTestServer extends MCPServer with LoggingSupport, ToolsSupport {
                 JsonType.string.typeName,
                 JsonType.nil.typeName,
               ],
+            }),
+          },
+        ),
+      ),
+      (_) => CallToolResult(content: [TextContent(text: 'ok')]),
+      validateArguments: false,
+    );
+    registerTool(
+      Tool(
+        name: 'test/badAnnotation',
+        inputSchema: ObjectSchema(
+          properties: {
+            // `x-mcp-header` is only allowed on a string, integer, or boolean
+            // property, so this annotation is one no server should write.
+            'label': Schema.fromMap({
+              Keys.type: <Object?>[
+                JsonType.string.typeName,
+                JsonType.nil.typeName,
+              ],
+              Keys.xMcpHeader: 'Label',
             }),
           },
         ),

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -997,6 +997,17 @@ void main() {
       },
     );
 
+    test('skips a subtree whose carrying argument is not an object', () async {
+      final (status, _, text) = await post(
+        headers: callWithNestedHeaderParamHeaders({
+          'Mcp-Param-Region': 'us-west1',
+        }),
+        json: callWithNestedHeaderParam({'location': 'us-west1'}),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
+
     test('does not require a header when the object carrying a nested '
         'property is absent', () async {
       final (status, _, text) = await post(

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -1930,8 +1930,7 @@ base class _HttpTestServer extends MCPServer with LoggingSupport, ToolsSupport {
         name: 'test/badAnnotation',
         inputSchema: ObjectSchema(
           properties: {
-            // `x-mcp-header` is only allowed on a string, integer, or boolean
-            // property, so this annotation is one no server should write.
+            // A non-primitive carrying the annotation.
             'label': Schema.fromMap({
               Keys.type: <Object?>[
                 JsonType.string.typeName,
@@ -1948,8 +1947,7 @@ base class _HttpTestServer extends MCPServer with LoggingSupport, ToolsSupport {
     registerTool(
       Tool(
         name: 'test/booleanSubschema',
-        // JSON Schema lets a subschema be a boolean, and `properties` holds
-        // whatever a server put there. Neither can name an `x-mcp-header`.
+        // A boolean subschema, and a nested `properties` that is a number.
         inputSchema: ObjectSchema.fromMap({
           Keys.type: JsonType.object.typeName,
           Keys.properties: {

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -651,50 +651,29 @@ void main() {
       expect(errorCode(text), isNull);
     });
 
-    test('reports an annotation the specification does not allow', () async {
-      // Passing this over would leave the server believing `Mcp-Param-Label`
-      // is checked while the call goes through unchecked.
-      final failing = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
-      addTearDown(() => failing.close(force: true));
-      failing.listen(
-        (request) => handleStreamableHttpRequest(
-          request,
-          _HttpTestServer.new,
-        ).onError<Object>((_, _) {}),
-      );
-      final client = HttpClient();
-      addTearDown(client.close);
-      final request = await client.postUrl(
-        Uri.http('${failing.address.host}:${failing.port}', '/mcp'),
-      );
-      final sent = {
-        ...headers(callTool),
-        'Mcp-Name': 'test/badAnnotation',
-        'Mcp-Param-Label': 'wrong',
-      };
-      sent.forEach(request.headers.set);
-      request.write(
-        jsonEncode(
-          body(
-            callTool,
-            params: {
-              Keys.name: 'test/badAnnotation',
-              Keys.arguments: {'label': 'right'},
-            },
-          ),
+    test('ignores an annotation the specification does not allow', () async {
+      // A tool definition annotating a non-primitive is one the client is
+      // told to reject, so nothing here reads `Mcp-Param-Label`.
+      final (status, _, text) = await post(
+        headers: {
+          ...headers(callTool),
+          'Mcp-Name': 'test/badAnnotation',
+          'Mcp-Param-Label': 'wrong',
+        },
+        json: body(
+          callTool,
+          params: {
+            Keys.name: 'test/badAnnotation',
+            Keys.arguments: {'label': 'right'},
+          },
         ),
       );
-      final response = await request.close();
-      final text = await utf8.decodeStream(response);
-      expect(response.statusCode, 500);
-      expect(errorCode(text), error_code.INTERNAL_ERROR);
-      // The server initialized. The annotation is what this could not get
-      // past, so the answer does not name initialization.
-      expect(errorMessage(text), 'The server failed to answer the request');
-    }, testOn: '!exe');
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
 
     test(
-      'ignores an Mcp-Param header for a tool which annotates none',
+      'ignores an Mcp-Param header for a tool that annotates none',
       () async {
         // `test/version` marks no property with `x-mcp-header`, so there is
         // no argument to compare the header against, and it is ignored.
@@ -717,7 +696,7 @@ void main() {
       },
     );
 
-    test('skips a schema part which cannot carry an annotation', () async {
+    test('skips a schema part that cannot carry an annotation', () async {
       final (status, _, text) = await post(
         headers: {...headers(callTool), 'Mcp-Name': 'test/booleanSubschema'},
         json: body(
@@ -776,7 +755,7 @@ void main() {
       expect(errorCode(jsonBody(response)), McpErrorCodes.headerMismatch);
     });
 
-    test('rejects a header value which does not match the body', () async {
+    test('rejects a header value that does not match the body', () async {
       final (status, _, text) = await post(
         headers: callWithHeaderParamHeaders({'Mcp-Param-Region': 'eu-west1'}),
         json: callWithHeaderParam({'region': 'us-west1'}),
@@ -885,55 +864,6 @@ void main() {
       expect(errorMessage(text), contains('not valid base64'));
     });
 
-    test(
-      'rejects a base64-sentinel header value with invalid characters',
-      () async {
-        final (status, _, text) = await post(
-          headers: callWithHeaderParamHeaders({
-            'Mcp-Param-Region': '=?base64?not!valid!base64?=',
-          }),
-          json: callWithHeaderParam({'region': 'us-west1'}),
-        );
-        expect(status, 400);
-        expect(errorCode(text), McpErrorCodes.headerMismatch);
-      },
-    );
-
-    test('treats a value missing the base64 prefix as a literal', () async {
-      // "dXMtd2VzdDE=" is valid base64, but without the `=?base64?` prefix
-      // it is compared to the body as-is instead of being decoded.
-      final (status, _, text) = await post(
-        headers: callWithHeaderParamHeaders({
-          'Mcp-Param-Region': 'dXMtd2VzdDE=',
-        }),
-        json: callWithHeaderParam({'region': 'dXMtd2VzdDE='}),
-      );
-      expect(status, 200);
-      expect(errorCode(text), isNull);
-    });
-
-    test('treats a value missing the base64 suffix as a literal', () async {
-      final (status, _, text) = await post(
-        headers: callWithHeaderParamHeaders({
-          'Mcp-Param-Region': '=?base64?dXMtd2VzdDE=',
-        }),
-        json: callWithHeaderParam({'region': '=?base64?dXMtd2VzdDE='}),
-      );
-      expect(status, 200);
-      expect(errorCode(text), isNull);
-    });
-
-    test('reads an overlapping sentinel as a literal', () async {
-      // '=?base64?=' is 10 characters: the prefix and suffix share a '?', so
-      // a naive slice throws a RangeError the handler would never answer.
-      final (status, _, text) = await post(
-        headers: callWithHeaderParamHeaders({'Mcp-Param-Region': '=?base64?='}),
-        json: callWithHeaderParam({'region': '=?base64?='}),
-      );
-      expect(status, 200);
-      expect(errorCode(text), isNull);
-    });
-
     test('compares an integer property numerically', () async {
       // The specification's own example of a numeric comparison: the header
       // spells the number differently and still matches.
@@ -947,7 +877,7 @@ void main() {
       }
     });
 
-    test('rejects an integer header which is not a decimal', () async {
+    test('rejects an integer header that is not a decimal', () async {
       // A client is told to send the decimal spelling, so anything else in the
       // header is a value some other component wrote. Letting `0x2a` match a
       // body of `42` would be the disagreement this check exists to catch.
@@ -1886,9 +1816,9 @@ void main() {
     });
 
     test('answers a failed tools/call on the stream too', () async {
-      // `tools/call` is the one method which holds notifications back until
+      // `tools/call` is the one method that holds notifications back until
       // the header check passes, so it is the one that could answer a server
-      // which failed after announcing itself with a fresh response instead.
+      // failing after it announced itself with a fresh response instead.
       final failing = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
       addTearDown(() => failing.close(force: true));
       failing.listen(
@@ -2184,7 +2114,7 @@ base class _HttpTestServer extends MCPServer with LoggingSupport, ToolsSupport {
   }
 }
 
-/// A server which emits a notification while a request is initializing.
+/// A server that emits a notification while a request is initializing.
 base class _NotifyingInitServer extends _HttpTestServer {
   _NotifyingInitServer(super.channel);
 

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -155,9 +155,13 @@ void main() {
   /// probe with and folds repeated header lines into one, so those requests
   /// have to go over a socket. The payload must ask for `Connection: close`
   /// or the read below never finishes.
-  Future<String> rawRequest(String payload) async {
+  Future<String> rawRequest(
+    String payload, [
+    List<int> bodyBytes = const [],
+  ]) async {
     final socket = await Socket.connect(httpServer.address, httpServer.port);
-    socket.write(payload);
+    socket.add(latin1.encode(payload));
+    socket.add(bodyBytes);
     await socket.flush();
     final response = utf8.decode(
       await socket.fold(<int>[], (bytes, chunk) => bytes..addAll(chunk)),
@@ -589,17 +593,6 @@ void main() {
       expect(errorCode(text), McpErrorCodes.headerMismatch);
     });
 
-    test('rejects an overlapping base64 sentinel without hanging', () async {
-      // '=?base64?=' is 10 characters: the prefix and suffix share a '?', so
-      // a naive slice throws a RangeError the handler would never answer.
-      final (status, _, text) = await post(
-        headers: {...headers(callTool), 'Mcp-Name': '=?base64?='},
-        json: body(callTool, params: {Keys.name: 'test/version'}),
-      );
-      expect(status, 400);
-      expect(errorCode(text), McpErrorCodes.headerMismatch);
-    });
-
     test('rejects a resources/read without an Mcp-Name header', () async {
       final (status, _, text) = await post(
         headers: headers(readResource),
@@ -620,6 +613,357 @@ void main() {
     });
   });
 
+  group('x-mcp-header custom headers', () {
+    /// A `tools/call` body for `test/withHeaderParam` with [arguments].
+    Map<String, Object?> callWithHeaderParam(Map<String, Object?> arguments) =>
+        body(
+          callTool,
+          params: {
+            Keys.name: 'test/withHeaderParam',
+            Keys.arguments: arguments,
+          },
+        );
+
+    /// The transport, `Mcp-Method`, and `Mcp-Name` headers for a
+    /// `test/withHeaderParam` call, plus any [extra] headers.
+    Map<String, String> callWithHeaderParamHeaders([
+      Map<String, String> extra = const {},
+    ]) => {...headers(callTool), 'Mcp-Name': 'test/withHeaderParam', ...extra};
+
+    test('ignores an unannotated property with an array type', () async {
+      // `label` permits a string or null and has no header annotation.
+      final (status, _, text) = await post(
+        headers: callWithHeaderParamHeaders({'Mcp-Param-Label': 'wrong'}),
+        json: callWithHeaderParam({'label': 'right'}),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
+
+    test('accepts a matching value without listing tools', () async {
+      final (status, _, text) = await post(
+        headers: callWithHeaderParamHeaders({'Mcp-Param-Region': 'us-west1'}),
+        json: callWithHeaderParam({'region': 'us-west1'}),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+      expect(servers.single.listToolsCalls, 0);
+    });
+
+    test('rejects a non-ASCII header field value', () async {
+      final bodyBytes = utf8.encode(
+        jsonEncode(callWithHeaderParam({'region': 'é'})),
+      );
+      final response = await rawRequest(
+        'POST /mcp HTTP/1.1\r\n'
+        'Host: ${httpServer.address.host}:${httpServer.port}\r\n'
+        'Content-Type: application/json\r\n'
+        'Accept: application/json, text/event-stream\r\n'
+        'Mcp-Protocol-Version: $version\r\n'
+        'Mcp-Method: $callTool\r\n'
+        'Mcp-Name: test/withHeaderParam\r\n'
+        'Mcp-Param-Region: é\r\n'
+        'Content-Length: ${bodyBytes.length}\r\n'
+        'Connection: close\r\n'
+        '\r\n',
+        bodyBytes,
+      );
+      expect(response, startsWith('HTTP/1.1 400'));
+      expect(errorCode(jsonBody(response)), -32020);
+    });
+
+    test('rejects a header value which does not match the body', () async {
+      final (status, _, text) = await post(
+        headers: callWithHeaderParamHeaders({'Mcp-Param-Region': 'eu-west1'}),
+        json: callWithHeaderParam({'region': 'us-west1'}),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32020);
+      expect(errorMessage(text), contains('eu-west1'));
+      expect(errorMessage(text), contains('us-west1'));
+    });
+
+    test('rejects a request missing a header its body requires', () async {
+      final (status, _, text) = await post(
+        headers: callWithHeaderParamHeaders(),
+        json: callWithHeaderParam({'region': 'us-west1'}),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32020);
+      expect(errorMessage(text), contains('no single Mcp-Param-Region'));
+      expect(errorMessage(text), contains('us-west1'));
+    });
+
+    test('rejects a header for an absent argument', () async {
+      final (status, _, text) = await post(
+        headers: callWithHeaderParamHeaders({'Mcp-Param-Region': 'us-west1'}),
+        json: callWithHeaderParam(const {}),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32020);
+      expect(errorMessage(text), contains('Mcp-Param-Region'));
+      expect(errorMessage(text), contains('params.arguments.region'));
+    });
+
+    test('rejects a header for a null argument', () async {
+      final (status, _, text) = await post(
+        headers: callWithHeaderParamHeaders({'Mcp-Param-Region': 'us-west1'}),
+        json: callWithHeaderParam({'region': null}),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32020);
+      expect(errorMessage(text), contains('Mcp-Param-Region'));
+      expect(errorMessage(text), contains('params.arguments.region'));
+    });
+
+    test('rejects before an initialization notification commits', () async {
+      final notifying = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => notifying.close(force: true));
+      notifying.listen(
+        (request) =>
+            handleStreamableHttpRequest(request, _NotifyingInitServer.new),
+      );
+      final client = HttpClient();
+      addTearDown(client.close);
+      final request = await client.postUrl(
+        Uri.http('${notifying.address.host}:${notifying.port}', '/mcp'),
+      );
+      callWithHeaderParamHeaders().forEach(request.headers.set);
+      request.write(jsonEncode(callWithHeaderParam({'region': 'us-west1'})));
+      final response = await request.close();
+      final text = await utf8.decodeStream(response);
+
+      expect(response.statusCode, 400);
+      expect(response.headers.contentType?.mimeType, 'application/json');
+      expect(errorCode(text), -32020);
+    });
+
+    test(
+      'does not require a header for an argument the body leaves null',
+      () async {
+        final (status, _, text) = await post(
+          headers: callWithHeaderParamHeaders(),
+          json: callWithHeaderParam({'region': null}),
+        );
+        expect(status, 200);
+        expect(errorCode(text), isNull);
+      },
+    );
+
+    test('decodes a base64-sentinel header value before comparing', () async {
+      final encoded = base64.encode(utf8.encode('us-west1'));
+      final (status, _, text) = await post(
+        headers: callWithHeaderParamHeaders({
+          'Mcp-Param-Region': '=?base64?$encoded?=',
+        }),
+        json: callWithHeaderParam({'region': 'us-west1'}),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
+
+    test('rejects a url-safe base64-sentinel header value', () async {
+      final (status, _, text) = await post(
+        headers: callWithHeaderParamHeaders({
+          'Mcp-Param-Region': '=?base64?YWJ-eg==?=',
+        }),
+        json: callWithHeaderParam({'region': 'ab~z'}),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32020);
+    });
+
+    test('rejects a base64-sentinel header value with bad padding', () async {
+      final (status, _, text) = await post(
+        // The base64 encoding of "us-west1" is "dXMtd2VzdDE=", with its
+        // required padding character stripped here.
+        headers: callWithHeaderParamHeaders({
+          'Mcp-Param-Region': '=?base64?dXMtd2VzdDE?=',
+        }),
+        json: callWithHeaderParam({'region': 'us-west1'}),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32020);
+      expect(errorMessage(text), contains('=?base64?dXMtd2VzdDE?='));
+      expect(errorMessage(text), contains('standard base64'));
+    });
+
+    test(
+      'rejects a base64-sentinel header value with invalid characters',
+      () async {
+        final (status, _, text) = await post(
+          headers: callWithHeaderParamHeaders({
+            'Mcp-Param-Region': '=?base64?not!valid!base64?=',
+          }),
+          json: callWithHeaderParam({'region': 'us-west1'}),
+        );
+        expect(status, 400);
+        expect(errorCode(text), -32020);
+      },
+    );
+
+    test('treats a value missing the base64 prefix as a literal', () async {
+      // "dXMtd2VzdDE=" is valid base64, but without the `=?base64?` prefix
+      // it is compared to the body as-is instead of being decoded.
+      final (status, _, text) = await post(
+        headers: callWithHeaderParamHeaders({
+          'Mcp-Param-Region': 'dXMtd2VzdDE=',
+        }),
+        json: callWithHeaderParam({'region': 'dXMtd2VzdDE='}),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
+
+    test('treats a value missing the base64 suffix as a literal', () async {
+      final (status, _, text) = await post(
+        headers: callWithHeaderParamHeaders({
+          'Mcp-Param-Region': '=?base64?dXMtd2VzdDE=',
+        }),
+        json: callWithHeaderParam({'region': '=?base64?dXMtd2VzdDE='}),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
+
+    test('compares an integer property numerically', () async {
+      // The specification's own example of a numeric comparison: the header
+      // spells the number differently and still matches.
+      for (final header in ['42', '42.0']) {
+        final (status, _, text) = await post(
+          headers: callWithHeaderParamHeaders({'Mcp-Param-Count': header}),
+          json: callWithHeaderParam({'count': 42}),
+        );
+        expect(status, 200, reason: header);
+        expect(errorCode(text), isNull, reason: header);
+      }
+    });
+
+    test('rejects an integer header which is not a decimal', () async {
+      // A client is told to send the decimal spelling, so anything else in the
+      // header is a value some other component wrote. Letting `0x2a` match a
+      // body of `42` would be the disagreement this check exists to catch.
+      // Leading whitespace never reaches here: the HTTP layer trims a header
+      // value before this sees it.
+      for (final header in ['0x2a', '0X2A', '+42', '42.']) {
+        final (status, _, text) = await post(
+          headers: callWithHeaderParamHeaders({'Mcp-Param-Count': header}),
+          json: callWithHeaderParam({'count': 42}),
+        );
+        expect(status, 400, reason: header);
+        expect(errorCode(text), -32020, reason: header);
+      }
+
+      final (status, _, text) = await post(
+        headers: callWithHeaderParamHeaders({'Mcp-Param-Count': '1e3'}),
+        json: callWithHeaderParam({'count': 1000}),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32020);
+    });
+
+    test('rejects a mismatched integer property', () async {
+      final (status, _, text) = await post(
+        headers: callWithHeaderParamHeaders({'Mcp-Param-Count': '7'}),
+        json: callWithHeaderParam({'count': 42}),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32020);
+    });
+
+    test('compares a boolean property', () async {
+      final (status, _, text) = await post(
+        headers: callWithHeaderParamHeaders({'Mcp-Param-Flag': 'true'}),
+        json: callWithHeaderParam({'flag': true}),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
+
+    test('rejects a mismatched boolean property', () async {
+      final (status, _, text) = await post(
+        headers: callWithHeaderParamHeaders({'Mcp-Param-Flag': 'false'}),
+        json: callWithHeaderParam({'flag': true}),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32020);
+    });
+  });
+
+  group('nested x-mcp-header custom headers', () {
+    /// A `tools/call` body for `test/withNestedHeaderParam` with
+    /// [arguments].
+    Map<String, Object?> callWithNestedHeaderParam(
+      Map<String, Object?> arguments,
+    ) => body(
+      callTool,
+      params: {
+        Keys.name: 'test/withNestedHeaderParam',
+        Keys.arguments: arguments,
+      },
+    );
+
+    /// The transport, `Mcp-Method`, and `Mcp-Name` headers for a
+    /// `test/withNestedHeaderParam` call, plus any [extra] headers.
+    Map<String, String> callWithNestedHeaderParamHeaders([
+      Map<String, String> extra = const {},
+    ]) => {
+      ...headers(callTool),
+      'Mcp-Name': 'test/withNestedHeaderParam',
+      ...extra,
+    };
+
+    test('accepts a header matching a nested property', () async {
+      final (status, _, text) = await post(
+        headers: callWithNestedHeaderParamHeaders({
+          'Mcp-Param-Region': 'us-west1',
+        }),
+        json: callWithNestedHeaderParam({
+          'location': {'region': 'us-west1'},
+        }),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
+
+    test('rejects a header that does not match a nested property', () async {
+      final (status, _, text) = await post(
+        headers: callWithNestedHeaderParamHeaders({
+          'Mcp-Param-Region': 'eu-west1',
+        }),
+        json: callWithNestedHeaderParam({
+          'location': {'region': 'us-west1'},
+        }),
+      );
+      expect(status, 400);
+      expect(errorCode(text), -32020);
+    });
+
+    test(
+      'rejects a request missing the header a nested property requires',
+      () async {
+        final (status, _, text) = await post(
+          headers: callWithNestedHeaderParamHeaders(),
+          json: callWithNestedHeaderParam({
+            'location': {'region': 'us-west1'},
+          }),
+        );
+        expect(status, 400);
+        expect(errorCode(text), -32020);
+      },
+    );
+
+    test('does not require a header when the object carrying a nested '
+        'property is absent', () async {
+      final (status, _, text) = await post(
+        headers: callWithNestedHeaderParamHeaders(),
+        json: callWithNestedHeaderParam(const {}),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
+  });
+
   group('removed 2025-11-25 mechanisms', () {
     test('ignores an Mcp-Session-Id header and mints none', () async {
       final (status, responseHeaders, text) = await post(
@@ -635,28 +979,6 @@ void main() {
       final (status, _, text) = await post(
         headers: {...headers(listTools), 'Last-Event-ID': '42'},
         json: body(listTools),
-      );
-      expect(status, 200);
-      expect(errorCode(text), isNull);
-    });
-
-    test('ignores an Mcp-Param header which contradicts the body', () async {
-      // Nothing here opts into `x-mcp-header`, so `Mcp-Param-*` is a header
-      // this handler does not recognize, and it is ignored rather than
-      // guessed at.
-      final (status, _, text) = await post(
-        headers: {
-          ...headers(callTool),
-          'Mcp-Name': 'test/version',
-          'Mcp-Param-Region': 'eu-west1',
-        },
-        json: body(
-          callTool,
-          params: {
-            Keys.name: 'test/version',
-            Keys.arguments: {'region': 'us-west1'},
-          },
-        ),
       );
       expect(status, 200);
       expect(errorCode(text), isNull);
@@ -1496,6 +1818,13 @@ Completer<void> releaseNotifyThenWait = Completer<void>();
 
 base class _HttpTestServer extends MCPServer with LoggingSupport, ToolsSupport {
   bool get _declaredSampling => clientCapabilities.sampling != null;
+  int listToolsCalls = 0;
+
+  @override
+  FutureOr<ListToolsResult> listTools([ListToolsRequest? request]) {
+    listToolsCalls++;
+    return super.listTools(request);
+  }
 
   _HttpTestServer(super.channel)
     : super.fromStreamChannel(
@@ -1507,6 +1836,56 @@ base class _HttpTestServer extends MCPServer with LoggingSupport, ToolsSupport {
     registerTool(
       Tool(name: 'test/version', inputSchema: ObjectSchema()),
       (_) => CallToolResult(content: [TextContent(text: '1.2.3')]),
+    );
+    registerTool(
+      Tool(
+        name: 'test/withHeaderParam',
+        inputSchema: ObjectSchema(
+          properties: {
+            // `x-mcp-header` is a schema extension the typed [Schema]
+            // factories do not have a parameter for, so these are built
+            // from a raw map instead.
+            'region': Schema.fromMap({
+              Keys.type: JsonType.string.typeName,
+              Keys.xMcpHeader: 'Region',
+            }),
+            'count': Schema.fromMap({
+              Keys.type: JsonType.int.typeName,
+              Keys.xMcpHeader: 'Count',
+            }),
+            'flag': Schema.fromMap({
+              Keys.type: JsonType.bool.typeName,
+              Keys.xMcpHeader: 'Flag',
+            }),
+            'label': Schema.fromMap({
+              Keys.type: <Object?>[
+                JsonType.string.typeName,
+                JsonType.nil.typeName,
+              ],
+            }),
+          },
+        ),
+      ),
+      (_) => CallToolResult(content: [TextContent(text: 'ok')]),
+      validateArguments: false,
+    );
+    registerTool(
+      Tool(
+        name: 'test/withNestedHeaderParam',
+        inputSchema: ObjectSchema(
+          properties: {
+            'location': Schema.fromMap({
+              Keys.properties: <String, Schema>{
+                'region': Schema.fromMap({
+                  Keys.type: JsonType.string.typeName,
+                  Keys.xMcpHeader: 'Region',
+                }),
+              },
+            }),
+          },
+        ),
+      ),
+      (_) => CallToolResult(content: [TextContent(text: 'ok')]),
     );
     registerTool(
       Tool(name: 'test/throw', inputSchema: ObjectSchema()),
@@ -1613,6 +1992,23 @@ base class _HttpTestServer extends MCPServer with LoggingSupport, ToolsSupport {
       log(LoggingLevel.error, 'from tool');
       return CallToolResult(content: [TextContent(text: 'logged')]);
     });
+  }
+}
+
+/// A server which emits a notification while a request is initializing.
+base class _NotifyingInitServer extends _HttpTestServer {
+  _NotifyingInitServer(super.channel);
+
+  @override
+  FutureOr<void> initialize(MCPServerInitialization initialization) async {
+    await super.initialize(initialization);
+    sendNotification(
+      LoggingMessageNotification.methodName,
+      LoggingMessageNotification(
+        level: LoggingLevel.error,
+        data: 'while starting up',
+      ),
+    );
   }
 }
 

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -593,6 +593,17 @@ void main() {
       expect(errorCode(text), McpErrorCodes.headerMismatch);
     });
 
+    test('rejects an overlapping base64 sentinel without hanging', () async {
+      // '=?base64?=' is 10 characters: the prefix and suffix share a '?', so
+      // a naive slice throws a RangeError the handler would never answer.
+      final (status, _, text) = await post(
+        headers: {...headers(callTool), 'Mcp-Name': '=?base64?='},
+        json: body(callTool, params: {Keys.name: 'test/version'}),
+      );
+      expect(status, 400);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
+    });
+
     test('rejects a resources/read without an Mcp-Name header', () async {
       final (status, _, text) = await post(
         headers: headers(readResource),
@@ -635,6 +646,33 @@ void main() {
       final (status, _, text) = await post(
         headers: callWithHeaderParamHeaders({'Mcp-Param-Label': 'wrong'}),
         json: callWithHeaderParam({'label': 'right'}),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
+
+    test('skips a schema part which cannot carry an annotation', () async {
+      final (status, _, text) = await post(
+        headers: {...headers(callTool), 'Mcp-Name': 'test/booleanSubschema'},
+        json: body(
+          callTool,
+          params: {
+            Keys.name: 'test/booleanSubschema',
+            Keys.arguments: {
+              'anything': 'x',
+              'nested': {'region': 'us-west1'},
+            },
+          },
+        ),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
+
+    test('skips a tool whose properties are not an object', () async {
+      final (status, _, text) = await post(
+        headers: {...headers(callTool), 'Mcp-Name': 'test/nonObjectProperties'},
+        json: body(callTool, params: {Keys.name: 'test/nonObjectProperties'}),
       );
       expect(status, 200);
       expect(errorCode(text), isNull);
@@ -821,6 +859,17 @@ void main() {
           'Mcp-Param-Region': '=?base64?dXMtd2VzdDE=',
         }),
         json: callWithHeaderParam({'region': '=?base64?dXMtd2VzdDE='}),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
+
+    test('reads an overlapping sentinel as a literal', () async {
+      // '=?base64?=' is 10 characters: the prefix and suffix share a '?', so
+      // a naive slice throws a RangeError the handler would never answer.
+      final (status, _, text) = await post(
+        headers: callWithHeaderParamHeaders({'Mcp-Param-Region': '=?base64?='}),
+        json: callWithHeaderParam({'region': '=?base64?='}),
       );
       expect(status, 200);
       expect(errorCode(text), isNull);
@@ -1777,6 +1826,40 @@ void main() {
       expect(await failure.future, isStateError);
     });
 
+    test('answers a failed tools/call on the stream too', () async {
+      // `tools/call` is the one method which holds notifications back until
+      // the header check passes, so it is the one that could answer a server
+      // which failed after announcing itself with a fresh response instead.
+      final failing = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => failing.close(force: true));
+      failing.listen(
+        (request) => handleStreamableHttpRequest(
+          request,
+          _NoisyFailingServer.new,
+        ).onError<Object>((_, _) {}),
+      );
+      final client = HttpClient();
+      addTearDown(client.close);
+      final request = await client.postUrl(
+        Uri.http('${failing.address.host}:${failing.port}', '/mcp'),
+      );
+      final callHeaders = {...headers(callTool), 'Mcp-Name': 'test/version'};
+      callHeaders.forEach(request.headers.set);
+      request.write(
+        jsonEncode(body(callTool, params: {Keys.name: 'test/version'})),
+      );
+      final response = await request.close();
+      final text = await utf8.decodeStream(response);
+      expect(response.statusCode, 200);
+      expect(response.headers.contentType?.mimeType, 'text/event-stream');
+      final messages = events(text);
+      expect(messages, hasLength(2));
+      expect(
+        (messages.last[Keys.error] as Map<String, Object?>)[Keys.code],
+        error_code.INTERNAL_ERROR,
+      );
+    });
+
     test('writes the event before the handler callback sees it', () async {
       final rude = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
       addTearDown(() => rude.close(force: true));
@@ -1865,6 +1948,33 @@ base class _HttpTestServer extends MCPServer with LoggingSupport, ToolsSupport {
             }),
           },
         ),
+      ),
+      (_) => CallToolResult(content: [TextContent(text: 'ok')]),
+      validateArguments: false,
+    );
+    registerTool(
+      Tool(
+        name: 'test/booleanSubschema',
+        // JSON Schema lets a subschema be a boolean, and `properties` holds
+        // whatever a server put there. Neither can name an `x-mcp-header`.
+        inputSchema: ObjectSchema.fromMap({
+          Keys.type: JsonType.object.typeName,
+          Keys.properties: {
+            'anything': true,
+            'nested': {Keys.properties: 5},
+          },
+        }),
+      ),
+      (_) => CallToolResult(content: [TextContent(text: 'ok')]),
+      validateArguments: false,
+    );
+    registerTool(
+      Tool(
+        name: 'test/nonObjectProperties',
+        inputSchema: ObjectSchema.fromMap({
+          Keys.type: JsonType.object.typeName,
+          Keys.properties: <Object>[1, 2],
+        }),
       ),
       (_) => CallToolResult(content: [TextContent(text: 'ok')]),
       validateArguments: false,

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -641,16 +641,6 @@ void main() {
       Map<String, String> extra = const {},
     ]) => {...headers(callTool), 'Mcp-Name': 'test/withHeaderParam', ...extra};
 
-    test('ignores an unannotated property with an array type', () async {
-      // `label` permits a string or null and has no header annotation.
-      final (status, _, text) = await post(
-        headers: callWithHeaderParamHeaders({'Mcp-Param-Label': 'wrong'}),
-        json: callWithHeaderParam({'label': 'right'}),
-      );
-      expect(status, 200);
-      expect(errorCode(text), isNull);
-    });
-
     test('ignores an annotation the specification does not allow', () async {
       // A tool definition annotating a non-primitive is one the client is
       // told to reject, so nothing here reads `Mcp-Param-Label`.
@@ -1928,12 +1918,6 @@ base class _HttpTestServer extends MCPServer with LoggingSupport, ToolsSupport {
             'flag': Schema.fromMap({
               Keys.type: JsonType.bool.typeName,
               Keys.xMcpHeader: 'Flag',
-            }),
-            'label': Schema.fromMap({
-              Keys.type: <Object?>[
-                JsonType.string.typeName,
-                JsonType.nil.typeName,
-              ],
             }),
           },
         ),


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

The server never read the `Mcp-Param-*` headers this revision defines. A header that contradicted the body was ignored. The spec asks for a 400 and -32020 there.

Validating one needs the tool's input schema, so I put a `beforeDispatch` hook on the request-scoped entry point and the transport hands it the initialized server. Reading a schema from there needed `ToolsSupport.registeredTools`, a read-only view. I did not want to run someone's `listTools` override on every call.

On #580 you preferred an error, or an assert if it had to be masked. Here the invalid thing is the tool definition, not the server: the 2026-07-28 page says clients "MUST reject tool definitions where any `x-mcp-header` value violates these constraints". An out-of-spec annotation goes unread instead.
