### PR TITLE
refuse input_required results a client cannot act on

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -114,6 +114,14 @@
   carry the `ttlMs` and `cacheScope` hints, which the handler may set itself.
   A server answering an earlier revision gets none of them. Does **not** add
   any transport.
+- Refuse an `input_required` result the client cannot act on in
+  `handleRequestScopedMessage`, see
+  https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr.
+  Answering a method outside the three the revision allows gets an internal
+  error back. Asking for an elicitation, sampling or roots the client left out
+  gets `McpErrorCodes.missingRequiredClientCapability` instead. An elicitation
+  is read down to its mode, so a client which declared only `elicitation.url`
+  does not get asked for a form.
 - Support a per-request log level on 2026-07-28, see
   https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/logging.
   The level goes in the `io.modelcontextprotocol/logLevel` metadata key, which

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -119,9 +119,11 @@
   https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr.
   Answering a method outside the three the revision allows gets an internal
   error back. Asking for an elicitation, sampling or roots the client left out
-  gets `McpErrorCodes.missingRequiredClientCapability` instead. An elicitation
-  is read down to its mode, so a client which declared only `elicitation.url`
-  does not get asked for a form.
+  gets `McpErrorCodes.missingRequiredClientCapability` instead. The error
+  carries every missing capability. An elicitation is read down to its mode,
+  so a client which declared only `elicitation.url` does not get asked for a
+  form. A sampling request with `tools` or `toolChoice` requires
+  `sampling.tools`.
 - Support a per-request log level on 2026-07-28, see
   https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/logging.
   The level goes in the `io.modelcontextprotocol/logLevel` metadata key, which

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -117,7 +117,7 @@
 - On protocol 2026-07-28, `handleRequestScopedMessage` now validates
   input-required results before forwarding them, see
   https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr.
-  An undeclared client capability answers
+  Asking for a client capability that was never declared answers
   `McpErrorCodes.missingRequiredClientCapability`, a malformed shape an
   internal error.
 - Support a per-request log level on 2026-07-28, see

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -114,16 +114,12 @@
   carry the `ttlMs` and `cacheScope` hints, which the handler may set itself.
   A server answering an earlier revision gets none of them. Does **not** add
   any transport.
-- Refuse an `input_required` result the client cannot act on in
-  `handleRequestScopedMessage`, see
+- On protocol 2026-07-28, `handleRequestScopedMessage` now validates
+  input-required results before forwarding them, see
   https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr.
-  Answering a method outside the three the revision allows gets an internal
-  error back, as does an invalid result or embedded request shape. Asking for
-  an elicitation, sampling or roots the client left out gets
-  `McpErrorCodes.missingRequiredClientCapability` instead. The error carries
-  every missing capability. An elicitation is read down to its mode, so a
-  client which declared only `elicitation.url` does not get asked for a form.
-  A sampling request with `tools` or `toolChoice` requires `sampling.tools`.
+  An undeclared client capability answers
+  `McpErrorCodes.missingRequiredClientCapability`, a malformed shape an
+  internal error.
 - Support a per-request log level on 2026-07-28, see
   https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/logging.
   The level goes in the `io.modelcontextprotocol/logLevel` metadata key, which

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -118,12 +118,12 @@
   `handleRequestScopedMessage`, see
   https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr.
   Answering a method outside the three the revision allows gets an internal
-  error back. Asking for an elicitation, sampling or roots the client left out
-  gets `McpErrorCodes.missingRequiredClientCapability` instead. The error
-  carries every missing capability. An elicitation is read down to its mode,
-  so a client which declared only `elicitation.url` does not get asked for a
-  form. A sampling request with `tools` or `toolChoice` requires
-  `sampling.tools`.
+  error back, as does an invalid result or embedded request shape. Asking for
+  an elicitation, sampling or roots the client left out gets
+  `McpErrorCodes.missingRequiredClientCapability` instead. The error carries
+  every missing capability. An elicitation is read down to its mode, so a
+  client which declared only `elicitation.url` does not get asked for a form.
+  A sampling request with `tools` or `toolChoice` requires `sampling.tools`.
 - Support a per-request log level on 2026-07-28, see
   https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/logging.
   The level goes in the `io.modelcontextprotocol/logLevel` metadata key, which

--- a/pkgs/dart_mcp/lib/src/api/input_required.dart
+++ b/pkgs/dart_mcp/lib/src/api/input_required.dart
@@ -14,6 +14,13 @@ part of 'api.dart';
 ///
 /// From the 2026-07-28 revision.
 extension type InputRequest._(Map<String, Object?> _value) {
+  /// The methods a request here may be made under.
+  static const methodNames = {
+    ElicitRequest.methodName,
+    CreateMessageRequest.methodName,
+    ListRootsRequest.methodName,
+  };
+
   factory InputRequest.fromMap(Map<String, Object?> value) {
     assert(value.containsKey(Keys.method));
     return InputRequest._(value);

--- a/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
@@ -11,8 +11,7 @@ base mixin ElicitationRequestSupport on LoggingSupport {
   ///
   /// Only safe to call after calling [initialize] on `super` since this
   /// is based on the client capabilities.
-  bool get supportsElicitation =>
-      (clientCapabilities as Map<String, Object?>)[Keys.elicitation] is Map;
+  bool get supportsElicitation => clientCapabilities.supportsElicitation;
 
   /// Whether or not the connected client supports [ElicitationMode.form]
   /// requests.
@@ -24,15 +23,14 @@ base mixin ElicitationRequestSupport on LoggingSupport {
   /// compatibility rule the 2025-11-25 revision added alongside the mode
   /// split. A client which named some other mode does not.
   bool get supportsFormElicitation =>
-      _supportsElicitationMode(clientCapabilities, ElicitationMode.form);
+      clientCapabilities.supportsFormElicitation;
 
   /// Whether or not the connected client supports [ElicitationMode.url]
   /// requests.
   ///
   /// Only safe to call after calling [initialize] on `super` since this
   /// is based on the client capabilities.
-  bool get supportsUrlElicitation =>
-      _supportsElicitationMode(clientCapabilities, ElicitationMode.url);
+  bool get supportsUrlElicitation => clientCapabilities.supportsUrlElicitation;
 
   @override
   FutureOr<void> initialize(MCPServerInitialization initialization) {
@@ -98,12 +96,18 @@ base mixin ElicitationRequestSupport on LoggingSupport {
   );
 }
 
-bool _supportsElicitationMode(
-  ClientCapabilities capabilities,
-  ElicitationMode mode,
-) {
-  final elicitation = (capabilities as Map<String, Object?>)[Keys.elicitation];
-  if (elicitation is! Map) return false;
-  return elicitation[mode.name] is Map ||
-      (mode == ElicitationMode.form && elicitation.isEmpty);
+extension on ClientCapabilities {
+  bool get supportsElicitation =>
+      (this as Map<String, Object?>)[Keys.elicitation] is Map;
+
+  bool get supportsFormElicitation {
+    final elicitation = (this as Map<String, Object?>)[Keys.elicitation];
+    return elicitation is Map &&
+        (elicitation[Keys.form] is Map || elicitation.isEmpty);
+  }
+
+  bool get supportsUrlElicitation {
+    final elicitation = (this as Map<String, Object?>)[Keys.elicitation];
+    return elicitation is Map && elicitation[Keys.url] is Map;
+  }
 }

--- a/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
@@ -95,16 +95,3 @@ base mixin ElicitationRequestSupport on LoggingSupport {
     notification,
   );
 }
-
-/// The mode reads [ElicitationRequestSupport] does, for
-/// [handleRequestScopedMessage], which has the capabilities but not the mixin.
-extension on ClientCapabilities {
-  bool get supportsFormElicitation {
-    final elicitation = this.elicitation;
-    if (elicitation == null) return false;
-    return elicitation.form != null ||
-        (elicitation as Map<String, Object?>).isEmpty;
-  }
-
-  bool get supportsUrlElicitation => elicitation?.url != null;
-}

--- a/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
@@ -11,7 +11,7 @@ base mixin ElicitationRequestSupport on LoggingSupport {
   ///
   /// Only safe to call after calling [initialize] on `super` since this
   /// is based on the client capabilities.
-  bool get supportsElicitation => clientCapabilities.supportsElicitation;
+  bool get supportsElicitation => clientCapabilities.elicitation != null;
 
   /// Whether or not the connected client supports [ElicitationMode.form]
   /// requests.
@@ -96,18 +96,15 @@ base mixin ElicitationRequestSupport on LoggingSupport {
   );
 }
 
+/// The mode reads [ElicitationRequestSupport] does, for
+/// [handleRequestScopedMessage], which has the capabilities but not the mixin.
 extension on ClientCapabilities {
-  bool get supportsElicitation =>
-      (this as Map<String, Object?>)[Keys.elicitation] is Map;
-
   bool get supportsFormElicitation {
-    final elicitation = (this as Map<String, Object?>)[Keys.elicitation];
-    return elicitation is Map &&
-        (elicitation[Keys.form] is Map || elicitation.isEmpty);
+    final elicitation = this.elicitation;
+    if (elicitation == null) return false;
+    return elicitation.form != null ||
+        (elicitation as Map<String, Object?>).isEmpty;
   }
 
-  bool get supportsUrlElicitation {
-    final elicitation = (this as Map<String, Object?>)[Keys.elicitation];
-    return elicitation is Map && elicitation[Keys.url] is Map;
-  }
+  bool get supportsUrlElicitation => elicitation?.url != null;
 }

--- a/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
@@ -71,17 +71,11 @@ base mixin ElicitationRequestSupport on LoggingSupport {
     switch (request.mode) {
       case ElicitationMode.url:
         if (!supportsUrlElicitation) {
-          throw _missingClientCapability(
-            'elicitation.url',
-            ClientCapabilities(elicitation: ElicitationCapability(url: {})),
-          );
+          throw _missingUrlElicitation;
         }
       case ElicitationMode.form:
         if (!supportsFormElicitation) {
-          throw _missingClientCapability(
-            'elicitation.form',
-            ClientCapabilities(elicitation: ElicitationCapability(form: {})),
-          );
+          throw _missingFormElicitation;
         }
     }
     return sendRequest(ElicitRequest.methodName, request);

--- a/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
@@ -11,7 +11,8 @@ base mixin ElicitationRequestSupport on LoggingSupport {
   ///
   /// Only safe to call after calling [initialize] on `super` since this
   /// is based on the client capabilities.
-  bool get supportsElicitation => clientCapabilities.elicitation != null;
+  bool get supportsElicitation =>
+      (clientCapabilities as Map<String, Object?>)[Keys.elicitation] is Map;
 
   /// Whether or not the connected client supports [ElicitationMode.form]
   /// requests.
@@ -22,12 +23,8 @@ base mixin ElicitationRequestSupport on LoggingSupport {
   /// An empty `elicitation` object counts as form support, the backwards
   /// compatibility rule the 2025-11-25 revision added alongside the mode
   /// split. A client which named some other mode does not.
-  bool get supportsFormElicitation {
-    final elicitation = clientCapabilities.elicitation;
-    if (elicitation == null) return false;
-    return elicitation.form != null ||
-        (elicitation as Map<String, Object?>).isEmpty;
-  }
+  bool get supportsFormElicitation =>
+      _supportsElicitationMode(clientCapabilities, ElicitationMode.form);
 
   /// Whether or not the connected client supports [ElicitationMode.url]
   /// requests.
@@ -35,7 +32,7 @@ base mixin ElicitationRequestSupport on LoggingSupport {
   /// Only safe to call after calling [initialize] on `super` since this
   /// is based on the client capabilities.
   bool get supportsUrlElicitation =>
-      clientCapabilities.elicitation?.url != null;
+      _supportsElicitationMode(clientCapabilities, ElicitationMode.url);
 
   @override
   FutureOr<void> initialize(MCPServerInitialization initialization) {
@@ -99,4 +96,14 @@ base mixin ElicitationRequestSupport on LoggingSupport {
     ElicitationCompleteNotification.methodName,
     notification,
   );
+}
+
+bool _supportsElicitationMode(
+  ClientCapabilities capabilities,
+  ElicitationMode mode,
+) {
+  final elicitation = (capabilities as Map<String, Object?>)[Keys.elicitation];
+  if (elicitation is! Map) return false;
+  return elicitation[mode.name] is Map ||
+      (mode == ElicitationMode.form && elicitation.isEmpty);
 }

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -50,6 +50,7 @@ typedef MCPServerFactory =
 /// before responding to a request, an internal-error response is returned
 /// instead. The server may still be processing a notification when the
 /// returned future completes.
+///
 /// The returned future completes once the server responds or the exchange
 /// closes; it does not time out on its own. A handler that never returns
 /// leaves it pending and the server alive. To bound execution, retain the

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -40,17 +40,16 @@ typedef MCPServerFactory =
 /// put a private answer in a cache shared across authorization contexts.
 /// A `ttlMs` below zero or a `cacheScope` outside `public` and `private` is a
 /// bug in the server: it asserts, and in a build with asserts disabled it is
-/// replaced the same way a field left `null` is. None of
-/// this reaches a result on an earlier revision, and every error response is
-/// returned unchanged. On 2026-07-28 an `input_required` result the client
-/// cannot act on is refused here instead of being sent on: one on a method the
-/// revision does not answer that way is an internal error, and one asking for
-/// a capability the client left out is
+/// replaced the same way a field left `null` is. None of this reaches a result
+/// on an earlier revision, and every error response is returned unchanged. On
+/// 2026-07-28 an `input_required` result the client cannot act on is refused
+/// here instead of being sent on: one on a method the revision does not answer
+/// that way asserts and returns an internal error, and one asking for a
+/// capability the client left out is
 /// [McpErrorCodes.missingRequiredClientCapability]. If the server closes
 /// before responding to a request, an internal-error response is returned
-/// instead. The server may still be
-/// processing a notification when the returned future completes.
-///
+/// instead. The server may still be processing a notification when the
+/// returned future completes.
 /// The returned future completes once the server responds or the exchange
 /// closes; it does not time out on its own. A handler that never returns
 /// leaves it pending and the server alive. To bound execution, retain the
@@ -174,6 +173,16 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
                     )
                     : _rpcErrorResponse(message[Keys.id], refusal),
               );
+              // A result the schema does not allow here is a bug in the
+              // server, so let it reach the zone the way a frame this
+              // dispatcher cannot process does. The client still gets the
+              // refusal above. Asking for a capability the client left out
+              // is not a bug: a server cannot know what the next client
+              // declares.
+              assert(
+                refusal == null || refusal.code != error_code.INTERNAL_ERROR,
+                refusal.message,
+              );
             }
         }
       } catch (_) {
@@ -295,10 +304,11 @@ RpcException? _inputRequiredRefusal(
     }
     final inputMethod = request[Keys.method];
     final params = request[Keys.params];
-    if (inputMethod is! String || !_clientInputMethods.contains(inputMethod)) {
+    if (inputMethod is! String ||
+        !InputRequest.methodNames.contains(inputMethod)) {
       return _malformedInputRequired(
         'containing an input request whose method was not one of '
-        '${_clientInputMethods.map((m) => '`$m`').join(', ')}.',
+        '${InputRequest.methodNames.map((m) => '`$m`').join(', ')}.',
       );
     }
     switch (inputMethod) {
@@ -357,8 +367,7 @@ RpcException? _inputRequiredRefusal(
   return null;
 }
 
-/// The internal error an `input_required` result which [detail] describes has
-/// to be refused with.
+/// The internal error refusing an `input_required` result [detail] describes.
 RpcException _malformedInputRequired(String detail) => RpcException(
   error_code.INTERNAL_ERROR,
   'The server answered with `${ResultTypes.inputRequired}` $detail',
@@ -371,6 +380,8 @@ RpcException _malformedInputRequired(String detail) => RpcException(
 /// Sampling that carries `tools` or `toolChoice` needs `sampling.tools`, and
 /// an elicitation needs the capability for the mode it asks for, so a client
 /// that declared only `elicitation.url` is never asked for a form.
+/// `sampling.context` is left alone: without it the schema only says a server
+/// SHOULD leave `includeContext` at `none`, so refusing would go past it.
 RpcException? _missingInputRequestCapability(
   String method,
   Object? params,
@@ -378,25 +389,24 @@ RpcException? _missingInputRequestCapability(
 ) {
   switch (method) {
     case ListRootsRequest.methodName:
-      if (capabilities.roots != null) return null;
+      if (capabilities.supportsRoots) return null;
       return _missingClientCapability(
         'roots',
         ClientCapabilities(roots: RootsCapabilities()),
       );
     case CreateMessageRequest.methodName:
-      final sampling = capabilities.sampling;
       final usesTools =
           params is Map &&
           (params.containsKey(Keys.tools) ||
               params.containsKey(Keys.toolChoice));
       if (!usesTools) {
-        if (sampling != null) return null;
+        if (capabilities.supportsSampling) return null;
         return _missingClientCapability(
           'sampling',
           ClientCapabilities(sampling: {}),
         );
       }
-      if (sampling?[Keys.tools] != null) return null;
+      if (capabilities.supportsSamplingTools) return null;
       return _missingClientCapability(
         'sampling.tools',
         ClientCapabilities(sampling: {Keys.tools: <String, Object?>{}}),
@@ -513,16 +523,6 @@ const _inputRequiredMethods = {
   CallToolRequest.methodName,
   GetPromptRequest.methodName,
   ReadResourceRequest.methodName,
-};
-
-/// The requests a server may ask the client to answer in an
-/// [InputRequiredResult].
-///
-/// https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr
-const _clientInputMethods = {
-  ElicitRequest.methodName,
-  CreateMessageRequest.methodName,
-  ListRootsRequest.methodName,
 };
 
 /// The requests whose results a server must send caching hints on.

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -43,8 +43,8 @@ typedef MCPServerFactory =
 /// replaced the same way a field left `null` is. None of this reaches a result
 /// on an earlier revision, and every error response is returned unchanged. On
 /// 2026-07-28 an `input_required` result the client cannot act on is refused
-/// here instead of being sent on: one on a method the revision does not answer
-/// that way asserts and returns an internal error, and one asking for a
+/// here, not sent on: one on a method the revision does not answer that way
+/// asserts and returns an internal error, and one asking for a
 /// capability the client left out is
 /// [McpErrorCodes.missingRequiredClientCapability]. If the server closes
 /// before responding to a request, an internal-error response is returned
@@ -377,9 +377,9 @@ RpcException _malformedInputRequired(String detail) => RpcException(
 /// has to be refused with, or `null` when [capabilities] declares what it
 /// needs.
 ///
-/// Sampling that carries `tools` or `toolChoice` needs `sampling.tools`, and
-/// an elicitation needs the capability for the mode it asks for, so a client
-/// that declared only `elicitation.url` is never asked for a form.
+/// Sampling that carries `tools` or `toolChoice` needs `sampling.tools`. An
+/// elicitation needs the capability for the mode it asks for. A client that
+/// declared only `elicitation.url` is never asked for a form.
 /// `sampling.context` is left alone: without it the schema only says a server
 /// SHOULD leave `includeContext` at `none`. Refusing would go past that.
 RpcException? _missingInputRequestCapability(

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -409,6 +409,10 @@ RpcException? _inputRequiredRefusal(
 /// The missing capability name and payload for an input request made under
 /// [method], or `null` when [capabilities] declares what it needs.
 ///
+/// Sampling that carries `tools` or `toolChoice` needs `sampling.tools`, and
+/// an elicitation needs the capability for the mode it asks for, so a client
+/// that declared only `elicitation.url` is never asked for a form.
+///
 (String, Map<String, Object?>)? _missingInputRequestCapability(
   String method,
   Object? params,

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -249,9 +249,8 @@ Map<String, Object?> _errorResponse(Object? id, String message) => {
 /// `package:dart_mcp/streamable_http.dart` maps that error to HTTP 400 while it
 /// can still send a JSON response.
 ///
-/// An entry naming a method outside [InputRequest] is left alone. The schema
-/// closes that set, so a server sending one has already left what any of this
-/// can check against.
+/// A malformed result or input request gets an internal error. The client
+/// capability check only runs after the wire shape has been validated.
 RpcException? _inputRequiredRefusal(
   Map<String, Object?> response,
   String method,
@@ -271,20 +270,121 @@ RpcException? _inputRequiredRefusal(
     );
   }
 
-  // Input requests and client capabilities are wire maps. Malformed requests
-  // are skipped, and malformed capability entries count as undeclared.
+  final hasInputRequests = result.containsKey(Keys.inputRequests);
+  final hasRequestState = result.containsKey(Keys.requestState);
+  if (!hasInputRequests && !hasRequestState) {
+    return RpcException(
+      error_code.INTERNAL_ERROR,
+      'The server answered with `${ResultTypes.inputRequired}` without '
+      '`${Keys.inputRequests}` or `${Keys.requestState}`.',
+    );
+  }
+  if (hasRequestState && result[Keys.requestState] is! String) {
+    return RpcException(
+      error_code.INTERNAL_ERROR,
+      'The server answered with `${ResultTypes.inputRequired}` whose '
+      '`${Keys.requestState}` was not a string.',
+    );
+  }
+  if (!hasInputRequests) return null;
+
   final requests = result[Keys.inputRequests];
-  if (requests is! Map) return null;
+  if (requests is! Map || requests.keys.any((key) => key is! String)) {
+    return RpcException(
+      error_code.INTERNAL_ERROR,
+      'The server answered with `${ResultTypes.inputRequired}` whose '
+      '`${Keys.inputRequests}` was not a string-keyed map.',
+    );
+  }
   final capabilities = initialization.clientCapabilities;
   final missing = <String>{};
   final required = <String, Object?>{};
   for (final request in requests.values) {
-    if (request is! Map) continue;
-    final method = request[Keys.method];
-    if (method is! String) continue;
+    if (request is! Map) {
+      return RpcException(
+        error_code.INTERNAL_ERROR,
+        'The server answered with `${ResultTypes.inputRequired}` whose '
+        '`${Keys.inputRequests}` contained a value that was not a map.',
+      );
+    }
+    final inputMethod = request[Keys.method];
+    final params = request[Keys.params];
+    if (inputMethod is! String) {
+      return RpcException(
+        error_code.INTERNAL_ERROR,
+        'The server answered with `${ResultTypes.inputRequired}` containing '
+        'an input request whose method was not one of '
+        '`${ElicitRequest.methodName}`, `${CreateMessageRequest.methodName}` '
+        'or `${ListRootsRequest.methodName}`.',
+      );
+    }
+    switch (inputMethod) {
+      case ListRootsRequest.methodName:
+        if (params != null && params is! Map) {
+          return RpcException(
+            error_code.INTERNAL_ERROR,
+            'The server answered with `${ResultTypes.inputRequired}` whose '
+            '`${ListRootsRequest.methodName}` params were not a map.',
+          );
+        }
+      case CreateMessageRequest.methodName:
+        if (params is! Map ||
+            params[Keys.messages] is! List ||
+            params[Keys.maxTokens] is! int) {
+          return RpcException(
+            error_code.INTERNAL_ERROR,
+            'The server answered with `${ResultTypes.inputRequired}` whose '
+            '`${CreateMessageRequest.methodName}` params did not contain a '
+            'messages list and integer maxTokens.',
+          );
+        }
+      case ElicitRequest.methodName:
+        if (params is! Map || params[Keys.message] is! String) {
+          return RpcException(
+            error_code.INTERNAL_ERROR,
+            'The server answered with `${ResultTypes.inputRequired}` whose '
+            '`${ElicitRequest.methodName}` params did not contain a message.',
+          );
+        }
+        final mode = params[Keys.mode];
+        if (mode == null || mode == ElicitationMode.form.name) {
+          final schema = params[Keys.requestedSchema];
+          if (schema is! Map ||
+              schema[Keys.type] != JsonType.object.typeName ||
+              schema[Keys.properties] is! Map) {
+            return RpcException(
+              error_code.INTERNAL_ERROR,
+              'The server answered with `${ResultTypes.inputRequired}` whose '
+              'form elicitation params did not contain an object schema.',
+            );
+          }
+        } else if (mode == ElicitationMode.url.name) {
+          if (params[Keys.url] is! String) {
+            return RpcException(
+              error_code.INTERNAL_ERROR,
+              'The server answered with `${ResultTypes.inputRequired}` whose '
+              'URL elicitation params did not contain a URL.',
+            );
+          }
+        } else {
+          return RpcException(
+            error_code.INTERNAL_ERROR,
+            'The server answered with `${ResultTypes.inputRequired}` whose '
+            'elicitation mode was not `form` or `url`.',
+          );
+        }
+      default:
+        return RpcException(
+          error_code.INTERNAL_ERROR,
+          'The server answered with `${ResultTypes.inputRequired}` containing '
+          'an input request whose method was not one of '
+          '`${ElicitRequest.methodName}`, `${CreateMessageRequest.methodName}` '
+          'or `${ListRootsRequest.methodName}`.',
+        );
+    }
     final requirement = _missingInputRequestCapability(
-      method,
-      request[Keys.params],
+      inputMethod,
+      params,
       capabilities,
     );
     if (requirement == null) continue;
@@ -316,7 +416,8 @@ RpcException? _inputRequiredRefusal(
 ) {
   switch (method) {
     case ListRootsRequest.methodName:
-      if (capabilities.roots != null) return null;
+      final roots = (capabilities as Map<String, Object?>)[Keys.roots];
+      if (roots is Map) return null;
       return (Keys.roots, {Keys.roots: <String, Object?>{}});
     case CreateMessageRequest.methodName:
       final sampling = (capabilities as Map<String, Object?>)[Keys.sampling];

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -42,8 +42,13 @@ typedef MCPServerFactory =
 /// bug in the server: it asserts, and in a build with asserts disabled it is
 /// replaced the same way a field left `null` is. None of
 /// this reaches a result on an earlier revision, and every error response is
-/// returned unchanged. If the server closes before responding to a request,
-/// an internal-error response is returned instead. The server may still be
+/// returned unchanged. On 2026-07-28 an `input_required` result the client
+/// cannot act on is refused here instead of being sent on: one on a method the
+/// revision does not answer that way is an internal error, and one asking for
+/// a capability the client left out is
+/// [McpErrorCodes.missingRequiredClientCapability]. If the server closes
+/// before responding to a request, an internal-error response is returned
+/// instead. The server may still be
 /// processing a notification when the returned future completes.
 ///
 /// The returned future completes once the server responds or the exchange
@@ -154,13 +159,20 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
             }
           case JsonRpc2Kind.response:
             if (!response.isCompleted) {
+              final refusal = _inputRequiredRefusal(
+                data,
+                method,
+                initialization,
+              );
               response.complete(
-                _withServerFields(
-                  data,
-                  server.implementation,
-                  method,
-                  initialization.protocolVersion,
-                ),
+                refusal == null
+                    ? _withServerFields(
+                      data,
+                      server.implementation,
+                      method,
+                      initialization.protocolVersion,
+                    )
+                    : _rpcErrorResponse(message[Keys.id], refusal),
               );
             }
         }
@@ -205,12 +217,143 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
   }
 }
 
+/// A JSON-RPC error response to the request with the given [id], carrying the
+/// code, message and data of [exception].
+Map<String, Object?> _rpcErrorResponse(Object? id, RpcException exception) => {
+  Keys.jsonrpc: '2.0',
+  Keys.id: id,
+  Keys.error: {
+    Keys.code: exception.code,
+    Keys.message: exception.message,
+    if (exception.data != null) Keys.data: exception.data,
+  },
+};
+
 /// A JSON-RPC internal-error response to the request with the given [id].
 Map<String, Object?> _errorResponse(Object? id, String message) => {
   Keys.jsonrpc: '2.0',
   Keys.id: id,
   Keys.error: {Keys.code: error_code.INTERNAL_ERROR, Keys.message: message},
 };
+
+/// The error [response] has to be answered with instead of itself, or `null`
+/// when it can go out as it stands.
+///
+/// The 2026-07-28 revision answers `input_required` on `tools/call`,
+/// `prompts/get` and `resources/read` and on no other request, and a server
+/// may not ask the client for input it never said it could give, see
+/// https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr.
+/// A result which breaks either rule asks the client for something it has no
+/// way to answer, so it is refused here and not sent on.
+///
+/// A missing capability is the error the revision names for it,
+/// [McpErrorCodes.missingRequiredClientCapability], carrying what the client
+/// left out under `data.requiredCapabilities`, which
+/// `handleStreamableHttpRequest` answers with `400`. Which capability an entry
+/// needs is read the way the request which sends it reads it, down to the
+/// elicitation mode: [ElicitationRequestSupport.elicit] separates
+/// `elicitation.form` from `elicitation.url`, and so does this.
+///
+/// An entry naming a method outside [InputRequest] is left alone. The schema
+/// closes that set, so a server sending one has already left what any of this
+/// can check against.
+RpcException? _inputRequiredRefusal(
+  Map<String, Object?> response,
+  String method,
+  MCPServerInitialization initialization,
+) {
+  if (initialization.protocolVersion < ProtocolVersion.v2026_07_28) return null;
+  final result = JsonRpc2Response.fromMap(response).result;
+  if (result is! Map<String, Object?>) return null;
+  if (result[Keys.resultType] != ResultTypes.inputRequired) return null;
+
+  if (!_inputRequiredMethods.contains(method)) {
+    return RpcException(
+      error_code.INTERNAL_ERROR,
+      'The server answered $method with `${ResultTypes.inputRequired}`, '
+      'which this revision allows only on '
+      '${_inputRequiredMethods.map((m) => '`$m`').join(', ')}.',
+    );
+  }
+
+  // Read the raw map, not the typed getters: a server may send anything here,
+  // and a cast throwing inside this check would reach the client as a frame it
+  // cannot read instead of the error naming what went wrong. An entry this
+  // cannot read is left to the dispatch which produced it.
+  final requests = result[Keys.inputRequests];
+  if (requests is! Map) return null;
+  for (final request in requests.values) {
+    if (request is! Map) continue;
+    final method = request[Keys.method];
+    if (method is! String) continue;
+    final missing = _missingInputRequestCapability(
+      method,
+      request[Keys.params],
+      initialization.clientCapabilities,
+    );
+    if (missing != null) return missing;
+  }
+  return null;
+}
+
+/// The capability error for an input request made under [method], or `null`
+/// when [capabilities] declares what it needs.
+///
+/// Reads each capability the way the request which sends it reads it:
+/// [MCPServer.listRoots], [MCPServer.createMessage] and
+/// [ElicitationRequestSupport.elicit]. A [method] outside those three needs
+/// nothing this can name.
+RpcException? _missingInputRequestCapability(
+  String method,
+  Object? params,
+  ClientCapabilities capabilities,
+) {
+  switch (method) {
+    case ListRootsRequest.methodName:
+      if (capabilities.roots != null) return null;
+      return _missingClientCapability(
+        'roots',
+        ClientCapabilities(roots: RootsCapabilities()),
+      );
+    case CreateMessageRequest.methodName:
+      if (capabilities.sampling != null) return null;
+      return _missingClientCapability(
+        'sampling',
+        ClientCapabilities(sampling: {}),
+      );
+    case ElicitRequest.methodName:
+      final url =
+          params is Map && params[Keys.mode] == ElicitationMode.url.name;
+      if (url) {
+        if (_supportsUrlElicitation(capabilities)) return null;
+        return _missingClientCapability(
+          'elicitation.url',
+          ClientCapabilities(elicitation: ElicitationCapability(url: {})),
+        );
+      }
+      if (_supportsFormElicitation(capabilities)) return null;
+      return _missingClientCapability(
+        'elicitation.form',
+        ClientCapabilities(elicitation: ElicitationCapability(form: {})),
+      );
+    default:
+      return null;
+  }
+}
+
+/// Whether [capabilities] declares form elicitation, on the same terms as
+/// [ElicitationRequestSupport.supportsFormElicitation].
+bool _supportsFormElicitation(ClientCapabilities capabilities) {
+  final elicitation = capabilities.elicitation;
+  if (elicitation == null) return false;
+  return elicitation.form != null ||
+      (elicitation as Map<String, Object?>).isEmpty;
+}
+
+/// Whether [capabilities] declares url elicitation, on the same terms as
+/// [ElicitationRequestSupport.supportsUrlElicitation].
+bool _supportsUrlElicitation(ClientCapabilities capabilities) =>
+    capabilities.elicitation?.url != null;
 
 /// Returns a copy of [response] with the fields a server on this protocol
 /// revision must send and the handler for [method] did not, as
@@ -298,6 +441,15 @@ Map<String, Object?> _withServerFields(
     },
   };
 }
+
+/// The requests a server may answer with an [InputRequiredResult].
+///
+/// https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr
+const _inputRequiredMethods = {
+  CallToolRequest.methodName,
+  GetPromptRequest.methodName,
+  ReadResourceRequest.methodName,
+};
 
 /// The requests whose results a server must send caching hints on.
 ///

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -175,11 +175,10 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
                     : _rpcErrorResponse(message[Keys.id], refusal),
               );
               // A result the schema does not allow here is a bug in the
-              // server, so let it reach the zone the way a frame this
-              // dispatcher cannot process does. The client still gets the
-              // refusal above. Asking for a capability the client left out
-              // is not a bug: a server cannot know what the next client
-              // declares.
+              // server. Let it reach the zone the way a frame this dispatcher
+              // cannot process does. The client still gets the refusal above.
+              // Asking for a capability the client left out is not a bug: a
+              // server cannot know what the next client declares.
               assert(
                 refusal == null || refusal.code != error_code.INTERNAL_ERROR,
                 refusal.message,
@@ -382,7 +381,7 @@ RpcException _malformedInputRequired(String detail) => RpcException(
 /// an elicitation needs the capability for the mode it asks for, so a client
 /// that declared only `elicitation.url` is never asked for a form.
 /// `sampling.context` is left alone: without it the schema only says a server
-/// SHOULD leave `includeContext` at `none`, so refusing would go past it.
+/// SHOULD leave `includeContext` at `none`. Refusing would go past that.
 RpcException? _missingInputRequestCapability(
   String method,
   Object? params,

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -236,23 +236,18 @@ Map<String, Object?> _errorResponse(Object? id, String message) => {
   Keys.error: {Keys.code: error_code.INTERNAL_ERROR, Keys.message: message},
 };
 
-/// The error [response] has to be answered with instead of itself, or `null`
-/// when it can go out as it stands.
+/// The error [response] has to be answered with, or `null` when the response
+/// can be sent unchanged.
 ///
-/// The 2026-07-28 revision answers `input_required` on `tools/call`,
-/// `prompts/get` and `resources/read` and on no other request, and a server
-/// may not ask the client for input it never said it could give, see
+/// The 2026-07-28 revision permits an input-required result on tools/call,
+/// prompts/get and resources/read. It also prohibits requests for client
+/// capabilities that were not declared. See
 /// https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr.
-/// A result which breaks either rule asks the client for something it has no
-/// way to answer, so it is refused here and not sent on.
 ///
-/// A missing capability is the error the revision names for it,
-/// [McpErrorCodes.missingRequiredClientCapability], carrying what the client
-/// left out under `data.requiredCapabilities`, which
-/// `handleStreamableHttpRequest` answers with `400`. Which capability an entry
-/// needs is read the way the request which sends it reads it, down to the
-/// elicitation mode: [ElicitationRequestSupport.elicit] separates
-/// `elicitation.form` from `elicitation.url`, and so does this.
+/// Missing capabilities are returned together under
+/// `data.requiredCapabilities`. `handleStreamableHttpRequest` in
+/// `package:dart_mcp/streamable_http.dart` maps that error to HTTP 400 while it
+/// can still send a JSON response.
 ///
 /// An entry naming a method outside [InputRequest] is left alone. The schema
 /// closes that set, so a server sending one has already left what any of this
@@ -276,34 +271,45 @@ RpcException? _inputRequiredRefusal(
     );
   }
 
-  // Read the raw map, not the typed getters: a server may send anything here,
-  // and a cast throwing inside this check would reach the client as a frame it
-  // cannot read instead of the error naming what went wrong. An entry this
-  // cannot read is left to the dispatch which produced it.
+  // Input requests and client capabilities are wire maps. Malformed requests
+  // are skipped, and malformed capability entries count as undeclared.
   final requests = result[Keys.inputRequests];
   if (requests is! Map) return null;
+  final capabilities = initialization.clientCapabilities;
+  final missing = <String>{};
+  final required = <String, Object?>{};
   for (final request in requests.values) {
     if (request is! Map) continue;
     final method = request[Keys.method];
     if (method is! String) continue;
-    final missing = _missingInputRequestCapability(
+    final requirement = _missingInputRequestCapability(
       method,
       request[Keys.params],
-      initialization.clientCapabilities,
+      capabilities,
     );
-    if (missing != null) return missing;
+    if (requirement == null) continue;
+    missing.add(requirement.$1);
+    for (final entry in requirement.$2.entries) {
+      final current = required[entry.key];
+      final addition = entry.value;
+      required[entry.key] =
+          current is Map<String, Object?> && addition is Map<String, Object?>
+              ? {...current, ...addition}
+              : addition;
+    }
   }
-  return null;
+  if (missing.isEmpty) return null;
+  return RpcException(
+    McpErrorCodes.missingRequiredClientCapability,
+    'The client did not declare these capabilities: ${missing.join(', ')}',
+    data: {Keys.requiredCapabilities: ClientCapabilities.fromMap(required)},
+  );
 }
 
-/// The capability error for an input request made under [method], or `null`
-/// when [capabilities] declares what it needs.
+/// The missing capability name and payload for an input request made under
+/// [method], or `null` when [capabilities] declares what it needs.
 ///
-/// Reads each capability the way the request which sends it reads it:
-/// [MCPServer.listRoots], [MCPServer.createMessage] and
-/// [ElicitationRequestSupport.elicit]. A [method] outside those three needs
-/// nothing this can name.
-RpcException? _missingInputRequestCapability(
+(String, Map<String, Object?>)? _missingInputRequestCapability(
   String method,
   Object? params,
   ClientCapabilities capabilities,
@@ -311,49 +317,51 @@ RpcException? _missingInputRequestCapability(
   switch (method) {
     case ListRootsRequest.methodName:
       if (capabilities.roots != null) return null;
-      return _missingClientCapability(
-        'roots',
-        ClientCapabilities(roots: RootsCapabilities()),
-      );
+      return (Keys.roots, {Keys.roots: <String, Object?>{}});
     case CreateMessageRequest.methodName:
-      if (capabilities.sampling != null) return null;
-      return _missingClientCapability(
-        'sampling',
-        ClientCapabilities(sampling: {}),
+      final sampling = (capabilities as Map<String, Object?>)[Keys.sampling];
+      final usesTools =
+          params is Map &&
+          (params.containsKey(Keys.tools) ||
+              params.containsKey(Keys.toolChoice));
+      if (sampling is Map && (!usesTools || sampling[Keys.tools] is Map)) {
+        return null;
+      }
+      return (
+        usesTools ? '${Keys.sampling}.${Keys.tools}' : Keys.sampling,
+        {
+          Keys.sampling: <String, Object?>{
+            if (usesTools) Keys.tools: <String, Object?>{},
+          },
+        },
       );
     case ElicitRequest.methodName:
       final url =
           params is Map && params[Keys.mode] == ElicitationMode.url.name;
       if (url) {
-        if (_supportsUrlElicitation(capabilities)) return null;
-        return _missingClientCapability(
-          'elicitation.url',
-          ClientCapabilities(elicitation: ElicitationCapability(url: {})),
+        if (_supportsElicitationMode(capabilities, ElicitationMode.url)) {
+          return null;
+        }
+        return (
+          '${Keys.elicitation}.${Keys.url}',
+          {
+            Keys.elicitation: <String, Object?>{Keys.url: <String, Object?>{}},
+          },
         );
       }
-      if (_supportsFormElicitation(capabilities)) return null;
-      return _missingClientCapability(
-        'elicitation.form',
-        ClientCapabilities(elicitation: ElicitationCapability(form: {})),
+      if (_supportsElicitationMode(capabilities, ElicitationMode.form)) {
+        return null;
+      }
+      return (
+        '${Keys.elicitation}.${Keys.form}',
+        {
+          Keys.elicitation: <String, Object?>{Keys.form: <String, Object?>{}},
+        },
       );
     default:
       return null;
   }
 }
-
-/// Whether [capabilities] declares form elicitation, on the same terms as
-/// [ElicitationRequestSupport.supportsFormElicitation].
-bool _supportsFormElicitation(ClientCapabilities capabilities) {
-  final elicitation = capabilities.elicitation;
-  if (elicitation == null) return false;
-  return elicitation.form != null ||
-      (elicitation as Map<String, Object?>).isEmpty;
-}
-
-/// Whether [capabilities] declares url elicitation, on the same terms as
-/// [ElicitationRequestSupport.supportsUrlElicitation].
-bool _supportsUrlElicitation(ClientCapabilities capabilities) =>
-    capabilities.elicitation?.url != null;
 
 /// Returns a copy of [response] with the fields a server on this protocol
 /// revision must send and the handler for [method] did not, as

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -230,11 +230,8 @@ Map<String, Object?> _rpcErrorResponse(Object? id, RpcException exception) => {
 };
 
 /// A JSON-RPC internal-error response to the request with the given [id].
-Map<String, Object?> _errorResponse(Object? id, String message) => {
-  Keys.jsonrpc: '2.0',
-  Keys.id: id,
-  Keys.error: {Keys.code: error_code.INTERNAL_ERROR, Keys.message: message},
-};
+Map<String, Object?> _errorResponse(Object? id, String message) =>
+    _rpcErrorResponse(id, RpcException(error_code.INTERNAL_ERROR, message));
 
 /// The error [response] has to be answered with, or `null` when the response
 /// can be sent unchanged.
@@ -244,10 +241,11 @@ Map<String, Object?> _errorResponse(Object? id, String message) => {
 /// capabilities that were not declared. See
 /// https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr.
 ///
-/// Missing capabilities are returned together under
-/// `data.requiredCapabilities`. `handleStreamableHttpRequest` in
-/// `package:dart_mcp/streamable_http.dart` maps that error to HTTP 400 while it
-/// can still send a JSON response.
+/// An undeclared capability is refused with [_missingClientCapability], the
+/// error [MCPServer.listRoots] and [ElicitationRequestSupport.elicit] raise for
+/// the same request on a connected transport, which
+/// `handleStreamableHttpRequest` in `package:dart_mcp/streamable_http.dart`
+/// maps to HTTP 400 while it can still send a JSON response.
 ///
 /// A malformed result or input request gets an internal error. The client
 /// capability check only runs after the wire shape has been validated.
@@ -262,10 +260,8 @@ RpcException? _inputRequiredRefusal(
   if (result[Keys.resultType] != ResultTypes.inputRequired) return null;
 
   if (!_inputRequiredMethods.contains(method)) {
-    return RpcException(
-      error_code.INTERNAL_ERROR,
-      'The server answered $method with `${ResultTypes.inputRequired}`, '
-      'which this revision allows only on '
+    return _malformedInputRequired(
+      'on $method, which this revision allows only on '
       '${_inputRequiredMethods.map((m) => '`$m`').join(', ')}.',
     );
   }
@@ -273,77 +269,59 @@ RpcException? _inputRequiredRefusal(
   final hasInputRequests = result.containsKey(Keys.inputRequests);
   final hasRequestState = result.containsKey(Keys.requestState);
   if (!hasInputRequests && !hasRequestState) {
-    return RpcException(
-      error_code.INTERNAL_ERROR,
-      'The server answered with `${ResultTypes.inputRequired}` without '
-      '`${Keys.inputRequests}` or `${Keys.requestState}`.',
+    return _malformedInputRequired(
+      'without `${Keys.inputRequests}` or `${Keys.requestState}`.',
     );
   }
   if (hasRequestState && result[Keys.requestState] is! String) {
-    return RpcException(
-      error_code.INTERNAL_ERROR,
-      'The server answered with `${ResultTypes.inputRequired}` whose '
-      '`${Keys.requestState}` was not a string.',
+    return _malformedInputRequired(
+      'whose `${Keys.requestState}` was not a string.',
     );
   }
   if (!hasInputRequests) return null;
 
   final requests = result[Keys.inputRequests];
   if (requests is! Map || requests.keys.any((key) => key is! String)) {
-    return RpcException(
-      error_code.INTERNAL_ERROR,
-      'The server answered with `${ResultTypes.inputRequired}` whose '
-      '`${Keys.inputRequests}` was not a string-keyed map.',
+    return _malformedInputRequired(
+      'whose `${Keys.inputRequests}` was not a string-keyed map.',
     );
   }
   final capabilities = initialization.clientCapabilities;
-  final missing = <String>{};
-  final required = <String, Object?>{};
   for (final request in requests.values) {
     if (request is! Map) {
-      return RpcException(
-        error_code.INTERNAL_ERROR,
-        'The server answered with `${ResultTypes.inputRequired}` whose '
-        '`${Keys.inputRequests}` contained a value that was not a map.',
+      return _malformedInputRequired(
+        'whose `${Keys.inputRequests}` contained a value that was not a map.',
       );
     }
     final inputMethod = request[Keys.method];
     final params = request[Keys.params];
-    if (inputMethod is! String) {
-      return RpcException(
-        error_code.INTERNAL_ERROR,
-        'The server answered with `${ResultTypes.inputRequired}` containing '
-        'an input request whose method was not one of '
-        '`${ElicitRequest.methodName}`, `${CreateMessageRequest.methodName}` '
-        'or `${ListRootsRequest.methodName}`.',
+    if (inputMethod is! String || !_inputRequestMethods.contains(inputMethod)) {
+      return _malformedInputRequired(
+        'containing an input request whose method was not one of '
+        '${_inputRequestMethods.map((m) => '`$m`').join(', ')}.',
       );
     }
     switch (inputMethod) {
       case ListRootsRequest.methodName:
         if (params != null && params is! Map) {
-          return RpcException(
-            error_code.INTERNAL_ERROR,
-            'The server answered with `${ResultTypes.inputRequired}` whose '
-            '`${ListRootsRequest.methodName}` params were not a map.',
+          return _malformedInputRequired(
+            'whose `${ListRootsRequest.methodName}` params were not a map.',
           );
         }
       case CreateMessageRequest.methodName:
         if (params is! Map ||
             params[Keys.messages] is! List ||
             params[Keys.maxTokens] is! int) {
-          return RpcException(
-            error_code.INTERNAL_ERROR,
-            'The server answered with `${ResultTypes.inputRequired}` whose '
-            '`${CreateMessageRequest.methodName}` params did not contain a '
-            'messages list and integer maxTokens.',
+          return _malformedInputRequired(
+            'whose `${CreateMessageRequest.methodName}` params did not contain '
+            'a messages list and integer maxTokens.',
           );
         }
       case ElicitRequest.methodName:
         if (params is! Map || params[Keys.message] is! String) {
-          return RpcException(
-            error_code.INTERNAL_ERROR,
-            'The server answered with `${ResultTypes.inputRequired}` whose '
-            '`${ElicitRequest.methodName}` params did not contain a message.',
+          return _malformedInputRequired(
+            'whose `${ElicitRequest.methodName}` params did not contain a '
+            'message.',
           );
         }
         final mode = params[Keys.mode];
@@ -352,112 +330,89 @@ RpcException? _inputRequiredRefusal(
           if (schema is! Map ||
               schema[Keys.type] != JsonType.object.typeName ||
               schema[Keys.properties] is! Map) {
-            return RpcException(
-              error_code.INTERNAL_ERROR,
-              'The server answered with `${ResultTypes.inputRequired}` whose '
-              'form elicitation params did not contain an object schema.',
+            return _malformedInputRequired(
+              'whose form elicitation params did not contain an object schema.',
             );
           }
         } else if (mode == ElicitationMode.url.name) {
           if (params[Keys.url] is! String) {
-            return RpcException(
-              error_code.INTERNAL_ERROR,
-              'The server answered with `${ResultTypes.inputRequired}` whose '
-              'URL elicitation params did not contain a URL.',
+            return _malformedInputRequired(
+              'whose URL elicitation params did not contain a URL.',
             );
           }
         } else {
-          return RpcException(
-            error_code.INTERNAL_ERROR,
-            'The server answered with `${ResultTypes.inputRequired}` whose '
-            'elicitation mode was not `form` or `url`.',
+          return _malformedInputRequired(
+            'whose elicitation mode was not '
+            '`${ElicitationMode.form.name}` or `${ElicitationMode.url.name}`.',
           );
         }
-      default:
-        return RpcException(
-          error_code.INTERNAL_ERROR,
-          'The server answered with `${ResultTypes.inputRequired}` containing '
-          'an input request whose method was not one of '
-          '`${ElicitRequest.methodName}`, `${CreateMessageRequest.methodName}` '
-          'or `${ListRootsRequest.methodName}`.',
-        );
     }
-    final requirement = _missingInputRequestCapability(
+    final missing = _missingInputRequestCapability(
       inputMethod,
       params,
       capabilities,
     );
-    if (requirement == null) continue;
-    missing.add(requirement.$1);
-    for (final entry in requirement.$2.entries) {
-      final current = required[entry.key];
-      final addition = entry.value;
-      required[entry.key] =
-          current is Map<String, Object?> && addition is Map<String, Object?>
-              ? {...current, ...addition}
-              : addition;
-    }
+    if (missing != null) return missing;
   }
-  if (missing.isEmpty) return null;
-  return RpcException(
-    McpErrorCodes.missingRequiredClientCapability,
-    'The client did not declare these capabilities: ${missing.join(', ')}',
-    data: {Keys.requiredCapabilities: ClientCapabilities.fromMap(required)},
-  );
+  return null;
 }
 
-/// The missing capability name and payload for an input request made under
-/// [method], or `null` when [capabilities] declares what it needs.
+/// The internal error an `input_required` result which [detail] describes has
+/// to be refused with.
+RpcException _malformedInputRequired(String detail) => RpcException(
+  error_code.INTERNAL_ERROR,
+  'The server answered with `${ResultTypes.inputRequired}` $detail',
+);
+
+/// The [_missingClientCapability] error an input request made under [method]
+/// has to be refused with, or `null` when [capabilities] declares what it
+/// needs.
 ///
 /// Sampling that carries `tools` or `toolChoice` needs `sampling.tools`, and
 /// an elicitation needs the capability for the mode it asks for, so a client
 /// that declared only `elicitation.url` is never asked for a form.
-///
-(String, Map<String, Object?>)? _missingInputRequestCapability(
+RpcException? _missingInputRequestCapability(
   String method,
   Object? params,
   ClientCapabilities capabilities,
 ) {
   switch (method) {
     case ListRootsRequest.methodName:
-      final roots = (capabilities as Map<String, Object?>)[Keys.roots];
-      if (roots is Map) return null;
-      return (Keys.roots, {Keys.roots: <String, Object?>{}});
+      if (capabilities.roots != null) return null;
+      return _missingClientCapability(
+        'roots',
+        ClientCapabilities(roots: RootsCapabilities()),
+      );
     case CreateMessageRequest.methodName:
-      final sampling = (capabilities as Map<String, Object?>)[Keys.sampling];
+      final sampling = capabilities.sampling;
       final usesTools =
           params is Map &&
           (params.containsKey(Keys.tools) ||
               params.containsKey(Keys.toolChoice));
-      if (sampling is Map && (!usesTools || sampling[Keys.tools] is Map)) {
-        return null;
+      if (!usesTools) {
+        if (sampling != null) return null;
+        return _missingClientCapability(
+          'sampling',
+          ClientCapabilities(sampling: {}),
+        );
       }
-      return (
-        usesTools ? '${Keys.sampling}.${Keys.tools}' : Keys.sampling,
-        {
-          Keys.sampling: <String, Object?>{
-            if (usesTools) Keys.tools: <String, Object?>{},
-          },
-        },
+      if (sampling?[Keys.tools] != null) return null;
+      return _missingClientCapability(
+        'sampling.tools',
+        ClientCapabilities(sampling: {Keys.tools: <String, Object?>{}}),
       );
     case ElicitRequest.methodName:
-      final url =
-          params is Map && params[Keys.mode] == ElicitationMode.url.name;
-      if (url) {
+      if (params is Map && params[Keys.mode] == ElicitationMode.url.name) {
         if (capabilities.supportsUrlElicitation) return null;
-        return (
-          '${Keys.elicitation}.${Keys.url}',
-          {
-            Keys.elicitation: <String, Object?>{Keys.url: <String, Object?>{}},
-          },
+        return _missingClientCapability(
+          'elicitation.url',
+          ClientCapabilities(elicitation: ElicitationCapability(url: {})),
         );
       }
       if (capabilities.supportsFormElicitation) return null;
-      return (
-        '${Keys.elicitation}.${Keys.form}',
-        {
-          Keys.elicitation: <String, Object?>{Keys.form: <String, Object?>{}},
-        },
+      return _missingClientCapability(
+        'elicitation.form',
+        ClientCapabilities(elicitation: ElicitationCapability(form: {})),
       );
     default:
       return null;
@@ -558,6 +513,16 @@ const _inputRequiredMethods = {
   CallToolRequest.methodName,
   GetPromptRequest.methodName,
   ReadResourceRequest.methodName,
+};
+
+/// The requests a server may ask the client to answer in an
+/// [InputRequiredResult].
+///
+/// https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr
+const _inputRequestMethods = {
+  ElicitRequest.methodName,
+  CreateMessageRequest.methodName,
+  ListRootsRequest.methodName,
 };
 
 /// The requests whose results a server must send caching hints on.

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -390,10 +390,7 @@ RpcException? _missingInputRequestCapability(
   switch (method) {
     case ListRootsRequest.methodName:
       if (capabilities.supportsRoots) return null;
-      return _missingClientCapability(
-        'roots',
-        ClientCapabilities(roots: RootsCapabilities()),
-      );
+      return _missingRoots;
     case CreateMessageRequest.methodName:
       final usesTools =
           params is Map &&
@@ -401,29 +398,17 @@ RpcException? _missingInputRequestCapability(
               params.containsKey(Keys.toolChoice));
       if (!usesTools) {
         if (capabilities.supportsSampling) return null;
-        return _missingClientCapability(
-          'sampling',
-          ClientCapabilities(sampling: {}),
-        );
+        return _missingSampling;
       }
       if (capabilities.supportsSamplingTools) return null;
-      return _missingClientCapability(
-        'sampling.tools',
-        ClientCapabilities(sampling: {Keys.tools: <String, Object?>{}}),
-      );
+      return _missingSamplingTools;
     case ElicitRequest.methodName:
       if (params is Map && params[Keys.mode] == ElicitationMode.url.name) {
         if (capabilities.supportsUrlElicitation) return null;
-        return _missingClientCapability(
-          'elicitation.url',
-          ClientCapabilities(elicitation: ElicitationCapability(url: {})),
-        );
+        return _missingUrlElicitation;
       }
       if (capabilities.supportsFormElicitation) return null;
-      return _missingClientCapability(
-        'elicitation.form',
-        ClientCapabilities(elicitation: ElicitationCapability(form: {})),
-      );
+      return _missingFormElicitation;
     default:
       return null;
   }

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -295,10 +295,10 @@ RpcException? _inputRequiredRefusal(
     }
     final inputMethod = request[Keys.method];
     final params = request[Keys.params];
-    if (inputMethod is! String || !_inputRequestMethods.contains(inputMethod)) {
+    if (inputMethod is! String || !_clientInputMethods.contains(inputMethod)) {
       return _malformedInputRequired(
         'containing an input request whose method was not one of '
-        '${_inputRequestMethods.map((m) => '`$m`').join(', ')}.',
+        '${_clientInputMethods.map((m) => '`$m`').join(', ')}.',
       );
     }
     switch (inputMethod) {
@@ -519,7 +519,7 @@ const _inputRequiredMethods = {
 /// [InputRequiredResult].
 ///
 /// https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr
-const _inputRequestMethods = {
+const _clientInputMethods = {
   ElicitRequest.methodName,
   CreateMessageRequest.methodName,
   ListRootsRequest.methodName,

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -339,9 +339,7 @@ RpcException? _inputRequiredRefusal(
       final url =
           params is Map && params[Keys.mode] == ElicitationMode.url.name;
       if (url) {
-        if (_supportsElicitationMode(capabilities, ElicitationMode.url)) {
-          return null;
-        }
+        if (capabilities.supportsUrlElicitation) return null;
         return (
           '${Keys.elicitation}.${Keys.url}',
           {
@@ -349,9 +347,7 @@ RpcException? _inputRequiredRefusal(
           },
         );
       }
-      if (_supportsElicitationMode(capabilities, ElicitationMode.form)) {
-        return null;
-      }
+      if (capabilities.supportsFormElicitation) return null;
       return (
         '${Keys.elicitation}.${Keys.form}',
         {

--- a/pkgs/dart_mcp/lib/src/server/roots_tracking_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/roots_tracking_support.dart
@@ -34,8 +34,10 @@ base mixin RootsTrackingSupport on LoggingSupport {
   ///
   /// Only safe to call after calling [initialize] on `super` since this
   /// is based on the client capabilities.
-  bool get supportsRootsChanged =>
-      clientCapabilities.roots?.listChanged == true;
+  bool get supportsRootsChanged {
+    final roots = (clientCapabilities as Map<String, Object?>)[Keys.roots];
+    return roots is Map && roots[Keys.listChanged] == true;
+  }
 
   @override
   FutureOr<void> initialize(MCPServerInitialization initialization) {

--- a/pkgs/dart_mcp/lib/src/server/roots_tracking_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/roots_tracking_support.dart
@@ -34,10 +34,8 @@ base mixin RootsTrackingSupport on LoggingSupport {
   ///
   /// Only safe to call after calling [initialize] on `super` since this
   /// is based on the client capabilities.
-  bool get supportsRootsChanged {
-    final roots = (clientCapabilities as Map<String, Object?>)[Keys.roots];
-    return roots is Map && roots[Keys.listChanged] == true;
-  }
+  bool get supportsRootsChanged =>
+      clientCapabilities.roots?.listChanged == true;
 
   @override
   FutureOr<void> initialize(MCPServerInitialization initialization) {

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -301,10 +301,7 @@ abstract base class MCPServer extends MCPBase {
   /// which the 2026-07-28 revision requires of that error.
   Future<ListRootsResult> listRoots([ListRootsRequest? request]) async {
     if (!supportsRoots) {
-      throw _missingClientCapability(
-        'roots',
-        ClientCapabilities(roots: RootsCapabilities()),
-      );
+      throw _missingRoots;
     }
     return sendRequest(ListRootsRequest.methodName, request);
   }
@@ -324,10 +321,7 @@ abstract base class MCPServer extends MCPBase {
     CreateMessageRequest request,
   ) async {
     if (!supportsSampling) {
-      throw _missingClientCapability(
-        'sampling',
-        ClientCapabilities(sampling: {}),
-      );
+      throw _missingSampling;
     }
     return sendRequest(CreateMessageRequest.methodName, request);
   }
@@ -343,6 +337,34 @@ RpcException _missingClientCapability(
   McpErrorCodes.missingRequiredClientCapability,
   'The client did not declare the $capability capability',
   data: {Keys.requiredCapabilities: required},
+);
+
+/// The refusal for a client that did not declare `roots`.
+RpcException get _missingRoots => _missingClientCapability(
+  'roots',
+  ClientCapabilities(roots: RootsCapabilities()),
+);
+
+/// The refusal for a client that did not declare `sampling`.
+RpcException get _missingSampling =>
+    _missingClientCapability('sampling', ClientCapabilities(sampling: {}));
+
+/// The refusal for a client whose `sampling` left out `tools`.
+RpcException get _missingSamplingTools => _missingClientCapability(
+  'sampling.tools',
+  ClientCapabilities(sampling: {Keys.tools: <String, Object?>{}}),
+);
+
+/// The refusal for a client that did not declare `elicitation.form`.
+RpcException get _missingFormElicitation => _missingClientCapability(
+  'elicitation.form',
+  ClientCapabilities(elicitation: ElicitationCapability(form: {})),
+);
+
+/// The refusal for a client that did not declare `elicitation.url`.
+RpcException get _missingUrlElicitation => _missingClientCapability(
+  'elicitation.url',
+  ClientCapabilities(elicitation: ElicitationCapability(url: {})),
 );
 
 /// The client capability reads a server makes, on the capabilities themselves

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -282,13 +282,13 @@ abstract base class MCPServer extends MCPBase {
   ///
   /// Only safe to call after calling [initialize] on `super` since this
   /// is based on the client capabilities.
-  bool get supportsRoots => clientCapabilities.roots != null;
+  bool get supportsRoots => clientCapabilities.supportsRoots;
 
   /// Whether or not the connected client supports [createMessage].
   ///
   /// Only safe to call after calling [initialize] on `super` since this
   /// is based on the client capabilities.
-  bool get supportsSampling => clientCapabilities.sampling != null;
+  bool get supportsSampling => clientCapabilities.supportsSampling;
 
   /// Lists all the root URIs from the client.
   ///
@@ -344,3 +344,28 @@ RpcException _missingClientCapability(
   'The client did not declare the $capability capability',
   data: {Keys.requiredCapabilities: required},
 );
+
+/// The client capability reads a server makes, on the capabilities themselves
+/// so that [handleRequestScopedMessage] can make them without a server.
+///
+/// [MCPServer] and [ElicitationRequestSupport] expose and document all of
+/// these but [supportsSamplingTools], which only the input request guard
+/// needs.
+extension on ClientCapabilities {
+  bool get supportsRoots => roots != null;
+
+  bool get supportsSampling => sampling != null;
+
+  /// Whether or not the client can answer a sampling request carrying `tools`
+  /// or `toolChoice`.
+  bool get supportsSamplingTools => sampling?[Keys.tools] != null;
+
+  bool get supportsFormElicitation {
+    final elicitation = this.elicitation;
+    if (elicitation == null) return false;
+    return elicitation.form != null ||
+        (elicitation as Map<String, Object?>).isEmpty;
+  }
+
+  bool get supportsUrlElicitation => elicitation?.url != null;
+}

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -153,7 +153,8 @@ abstract base class MCPServer extends MCPBase {
     protocolVersion = initialization.protocolVersion;
     clientCapabilities = initialization.clientCapabilities;
     clientInfo = initialization.clientInfo;
-    if (clientCapabilities.roots?.listChanged == true) {
+    final roots = (clientCapabilities as Map<String, Object?>)[Keys.roots];
+    if (roots is Map && roots[Keys.listChanged] == true) {
       _rootsListChangedController =
           StreamController<RootsListChangedNotification?>.broadcast();
       registerNotificationHandler(
@@ -282,7 +283,8 @@ abstract base class MCPServer extends MCPBase {
   ///
   /// Only safe to call after calling [initialize] on `super` since this
   /// is based on the client capabilities.
-  bool get supportsRoots => clientCapabilities.roots != null;
+  bool get supportsRoots =>
+      (clientCapabilities as Map<String, Object?>)[Keys.roots] is Map;
 
   /// Whether or not the connected client supports [createMessage].
   ///

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -153,8 +153,7 @@ abstract base class MCPServer extends MCPBase {
     protocolVersion = initialization.protocolVersion;
     clientCapabilities = initialization.clientCapabilities;
     clientInfo = initialization.clientInfo;
-    final roots = (clientCapabilities as Map<String, Object?>)[Keys.roots];
-    if (roots is Map && roots[Keys.listChanged] == true) {
+    if (clientCapabilities.roots?.listChanged == true) {
       _rootsListChangedController =
           StreamController<RootsListChangedNotification?>.broadcast();
       registerNotificationHandler(
@@ -283,8 +282,7 @@ abstract base class MCPServer extends MCPBase {
   ///
   /// Only safe to call after calling [initialize] on `super` since this
   /// is based on the client capabilities.
-  bool get supportsRoots =>
-      (clientCapabilities as Map<String, Object?>)[Keys.roots] is Map;
+  bool get supportsRoots => clientCapabilities.roots != null;
 
   /// Whether or not the connected client supports [createMessage].
   ///

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:dart_mcp/server.dart';
 import 'package:dart_mcp/src/utils/constants.dart';
@@ -463,64 +464,203 @@ void main() {
         _initialization(),
       );
 
-      final error = response![Keys.error] as Map<String, Object?>;
-      expect(error[Keys.code], error_code.INTERNAL_ERROR);
-      expect(error[Keys.message], contains(CompleteRequest.methodName));
-      expect(error[Keys.message], contains(CallToolRequest.methodName));
+      final wire = jsonDecode(jsonEncode(response)) as Map<String, Object?>;
+      final error = wire['error'] as Map<String, Object?>;
+      expect(error['code'], -32603);
+      expect(error['message'], contains(CompleteRequest.methodName));
+      expect(error['message'], contains(CallToolRequest.methodName));
     });
 
-    test('serves input_required on the three it is allowed on', () async {
+    test('serves input_required on allowed requests', () async {
       final harness = _DispatcherHarness();
-      for (final message in [
-        _callTool('interim'),
-        _getPrompt('interim'),
-        _readResource(),
+      for (final (method, response) in [
+        (
+          CallToolRequest.methodName,
+          await harness.dispatch(_callTool('interim'), _initialization()),
+        ),
+        (
+          GetPromptRequest.methodName,
+          await harness.dispatch(_getPrompt('interim'), _initialization()),
+        ),
+        (
+          ReadResourceRequest.methodName,
+          await _dispatchShapedRead(
+            (result) => {
+              ...result,
+              Keys.resultType: ResultTypes.inputRequired,
+              Keys.requestState: 'waiting',
+            },
+          ),
+        ),
       ]) {
-        final response = await harness.dispatch(message, _initialization());
-
+        final wire = jsonDecode(jsonEncode(response)) as Map<String, Object?>;
+        expect(wire['error'], isNull, reason: method);
         expect(
-          response![Keys.error],
-          isNull,
-          reason: '${message[Keys.method]}',
+          (wire['result'] as Map<String, Object?>)['resultType'],
+          'input_required',
+          reason: method,
         );
       }
-
-      // Only `tools/call` and `prompts/get` answer `input_required` here;
-      // `resources/read` answers a complete result, which is what makes the
-      // third method reachable at all.
-      final call = await harness.dispatch(
-        _callTool('interim'),
-        _initialization(),
-      );
-      expect(_result(call)[Keys.resultType], ResultTypes.inputRequired);
-      final prompt = await harness.dispatch(
-        _getPrompt('interim'),
-        _initialization(),
-      );
-      expect(_result(prompt)[Keys.resultType], ResultTypes.inputRequired);
     });
 
     test('refuses an input request the client cannot answer', () async {
       final harness = _DispatcherHarness();
-      for (final (tool, capability) in [
-        ('asks_to_elicit', 'elicitation.form'),
-        ('asks_to_sample', 'sampling'),
-        ('asks_for_roots', 'roots'),
+      for (final (tool, capability, required) in [
+        (
+          'asks_to_elicit',
+          'elicitation.form',
+          {
+            'elicitation': {'form': <String, Object?>{}},
+          },
+        ),
+        ('asks_to_sample', 'sampling', {'sampling': <String, Object?>{}}),
+        ('asks_for_roots', 'roots', {'roots': <String, Object?>{}}),
       ]) {
         final response = await harness.dispatch(
           _callTool(tool),
           _initialization(),
         );
 
-        final error = response![Keys.error] as Map<String, Object?>;
-        expect(
-          error[Keys.code],
-          McpErrorCodes.missingRequiredClientCapability,
-          reason: tool,
+        final wire = jsonDecode(jsonEncode(response)) as Map<String, Object?>;
+        final error = wire['error'] as Map<String, Object?>;
+        expect(error['code'], -32021, reason: tool);
+        expect(error['message'], contains(capability), reason: tool);
+        final data = error['data'] as Map<String, Object?>;
+        expect(data['requiredCapabilities'], required, reason: tool);
+      }
+    });
+
+    test('requires sampling.tools for tools and toolChoice', () async {
+      for (final field in [Keys.tools, Keys.toolChoice]) {
+        Map<String, Object?> shape(Map<String, Object?> result) => {
+          ...result,
+          Keys.resultType: ResultTypes.inputRequired,
+          Keys.inputRequests: {
+            CreateMessageRequest.methodName: InputRequest.sample(
+              CreateMessageRequest.fromMap({
+                Keys.messages: <Object?>[],
+                Keys.maxTokens: 1,
+                field:
+                    field == Keys.tools
+                        ? <Object?>[]
+                        : ToolChoice(mode: ToolChoiceMode.auto),
+              }),
+            ),
+          },
+        };
+
+        final refused = await _dispatchShapedRead(
+          shape,
+          capabilities: ClientCapabilities(sampling: {}),
         );
-        expect(error[Keys.message], contains(capability), reason: tool);
-        final data = error[Keys.data] as Map<String, Object?>;
-        expect(data, contains(Keys.requiredCapabilities), reason: tool);
+        final wire = jsonDecode(jsonEncode(refused)) as Map<String, Object?>;
+        final error = wire['error'] as Map<String, Object?>;
+        expect(error['code'], -32021, reason: field);
+        expect(error['message'], contains('sampling.tools'), reason: field);
+        final data = error['data'] as Map<String, Object?>;
+        expect(data['requiredCapabilities'], {
+          'sampling': {'tools': <String, Object?>{}},
+        }, reason: field);
+
+        final served = await _dispatchShapedRead(
+          shape,
+          capabilities: ClientCapabilities(
+            sampling: {Keys.tools: <String, Object?>{}},
+          ),
+        );
+        final servedWire =
+            jsonDecode(jsonEncode(served)) as Map<String, Object?>;
+        expect(servedWire['error'], isNull, reason: field);
+      }
+    });
+
+    test('reports all missing input request capabilities together', () async {
+      final response = await _dispatchShapedRead(
+        (result) => {
+          ...result,
+          Keys.resultType: ResultTypes.inputRequired,
+          Keys.inputRequests: {
+            ElicitRequest.methodName: InputRequest.elicit(
+              ElicitRequest.form(
+                message: 'Fill this in',
+                requestedSchema: ObjectSchema(),
+              ),
+            ),
+            CreateMessageRequest.methodName: InputRequest.sample(
+              CreateMessageRequest(messages: [], maxTokens: 1),
+            ),
+            ListRootsRequest.methodName: InputRequest.listRoots(
+              ListRootsRequest(),
+            ),
+          },
+        },
+      );
+
+      final wire = jsonDecode(jsonEncode(response)) as Map<String, Object?>;
+      final error = wire['error'] as Map<String, Object?>;
+      expect(error['code'], -32021);
+      for (final capability in ['elicitation.form', 'sampling', 'roots']) {
+        expect(error['message'], contains(capability));
+      }
+      final data = error['data'] as Map<String, Object?>;
+      expect(data['requiredCapabilities'], {
+        'elicitation': {'form': <String, Object?>{}},
+        'sampling': <String, Object?>{},
+        'roots': <String, Object?>{},
+      });
+    });
+
+    test('treats unreadable capability entries as absent', () async {
+      final harness = _DispatcherHarness();
+      for (final (tool, capabilities, required) in [
+        (
+          'asks_to_elicit',
+          ClientCapabilities.fromMap({Keys.elicitation: true}),
+          {
+            'elicitation': {'form': <String, Object?>{}},
+          },
+        ),
+        (
+          'asks_to_elicit',
+          ClientCapabilities.fromMap({Keys.elicitation: Keys.form}),
+          {
+            'elicitation': {'form': <String, Object?>{}},
+          },
+        ),
+        (
+          'asks_to_elicit',
+          ClientCapabilities.fromMap({
+            Keys.elicitation: {Keys.form: 1},
+          }),
+          {
+            'elicitation': {'form': <String, Object?>{}},
+          },
+        ),
+        (
+          'asks_to_sample',
+          ClientCapabilities.fromMap({Keys.sampling: 7}),
+          {'sampling': <String, Object?>{}},
+        ),
+        (
+          'asks_to_sample',
+          ClientCapabilities.fromMap({Keys.sampling: <Object?>[]}),
+          {'sampling': <String, Object?>{}},
+        ),
+      ]) {
+        final response = await harness.dispatch(
+          _callTool(tool),
+          _initialization(capabilities: capabilities),
+        );
+
+        final wire = jsonDecode(jsonEncode(response)) as Map<String, Object?>;
+        final error = wire['error'] as Map<String, Object?>;
+        expect(error['code'], -32021, reason: '$tool: $capabilities');
+        final data = error['data'] as Map<String, Object?>;
+        expect(
+          data['requiredCapabilities'],
+          required,
+          reason: '$tool: $capabilities',
+        );
       }
     });
 
@@ -554,9 +694,14 @@ void main() {
         urlOnly,
       );
 
-      final error = refused![Keys.error] as Map<String, Object?>;
-      expect(error[Keys.code], McpErrorCodes.missingRequiredClientCapability);
-      expect(error[Keys.message], contains('elicitation.form'));
+      final refusedWire =
+          jsonDecode(jsonEncode(refused)) as Map<String, Object?>;
+      final error = refusedWire['error'] as Map<String, Object?>;
+      expect(error['code'], -32021);
+      expect(error['message'], contains('elicitation.form'));
+      expect((error['data'] as Map)['requiredCapabilities'], {
+        'elicitation': {'form': <String, Object?>{}},
+      });
 
       // And the other way around: a client with only form support cannot
       // answer a url request.
@@ -570,12 +715,14 @@ void main() {
         formOnly,
       );
 
-      final urlError = urlRefused![Keys.error] as Map<String, Object?>;
-      expect(
-        urlError[Keys.code],
-        McpErrorCodes.missingRequiredClientCapability,
-      );
-      expect(urlError[Keys.message], contains('elicitation.url'));
+      final urlWire =
+          jsonDecode(jsonEncode(urlRefused)) as Map<String, Object?>;
+      final urlError = urlWire['error'] as Map<String, Object?>;
+      expect(urlError['code'], -32021);
+      expect(urlError['message'], contains('elicitation.url'));
+      expect((urlError['data'] as Map)['requiredCapabilities'], {
+        'elicitation': {'url': <String, Object?>{}},
+      });
 
       final urlServed = await harness.dispatch(
         _callTool('asks_to_elicit_by_url'),
@@ -594,6 +741,45 @@ void main() {
         ),
       );
       expect(bare![Keys.error], isNull);
+    });
+
+    test('treats a missing or unknown elicitation mode as form', () async {
+      for (final params in [
+        <String, Object?>{Keys.message: 'Fill this in'},
+        <String, Object?>{Keys.mode: 'voice', Keys.message: 'Fill this in'},
+      ]) {
+        Map<String, Object?> shape(Map<String, Object?> result) => {
+          ...result,
+          Keys.resultType: ResultTypes.inputRequired,
+          Keys.inputRequests: {
+            ElicitRequest.methodName: InputRequest.fromMap({
+              Keys.method: ElicitRequest.methodName,
+              Keys.params: params,
+            }),
+          },
+        };
+
+        final refused = await _dispatchShapedRead(
+          shape,
+          capabilities: ClientCapabilities(
+            elicitation: ElicitationCapability(url: {}),
+          ),
+        );
+        final wire = jsonDecode(jsonEncode(refused)) as Map<String, Object?>;
+        final error = wire['error'] as Map<String, Object?>;
+        expect(error['code'], -32021);
+        expect(error['message'], contains('elicitation.form'));
+
+        final served = await _dispatchShapedRead(
+          shape,
+          capabilities: ClientCapabilities(
+            elicitation: ElicitationCapability(form: {}),
+          ),
+        );
+        final servedWire =
+            jsonDecode(jsonEncode(served)) as Map<String, Object?>;
+        expect(servedWire['error'], isNull);
+      }
     });
 
     test('leaves a malformed inputRequests alone', () async {
@@ -1100,6 +1286,7 @@ final class _DispatcherTestServer extends TestMCPServer
       (_) => CallToolResult.fromMap({
         Keys.content: [TextContent(text: 'waiting')],
         Keys.resultType: ResultTypes.inputRequired,
+        Keys.requestState: 'waiting',
       }),
     );
     for (final entry
@@ -1150,6 +1337,7 @@ final class _DispatcherTestServer extends TestMCPServer
       (_) => GetPromptResult.fromMap({
         Keys.messages: <Object?>[],
         Keys.resultType: ResultTypes.inputRequired,
+        Keys.requestState: 'waiting',
       }),
     );
     registerTool(
@@ -1382,10 +1570,11 @@ Map<String, Object?> _result(Map<String, Object?>? response) =>
 /// Dispatches a `resources/read` to a server whose result is passed through
 /// [shape] first, so a test can say what the handler itself already set.
 Future<Map<String, Object?>?> _dispatchShapedRead(
-  Map<String, Object?> Function(Map<String, Object?> result) shape,
-) => handleRequestScopedMessage(
+  Map<String, Object?> Function(Map<String, Object?> result) shape, {
+  ClientCapabilities? capabilities,
+}) => handleRequestScopedMessage(
   _readResource(),
-  _initialization(),
+  _initialization(capabilities: capabilities),
   (channel) => _ShapedReadServer(channel, shape),
 );
 

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -214,9 +214,12 @@ void main() {
     test('records caching hints despite a result type the schema does not '
         'give the request', () async {
       // `tools/list` has no interim arm, so a non-complete type there does not
-      // make the result one the caching rules exempt.
+      // make the result one the caching rules exempt. The schema types
+      // `resultType` as a bare string, so a server may send one this package
+      // has no name for; `input_required` is not among the ones it may send
+      // here, and the dispatcher refuses that separately.
       final response = await _dispatchShapedList(
-        (result) => {...result, Keys.resultType: ResultTypes.inputRequired},
+        (result) => {...result, Keys.resultType: 'io.example/other'},
       );
 
       expect(_result(response), containsPair(Keys.ttlMs, 0));
@@ -451,6 +454,184 @@ void main() {
       final error = response![Keys.error] as Map<String, Object?>;
       expect(error[Keys.code], error_code.INTERNAL_ERROR);
       expect(error[Keys.message], contains('request-scoped transport'));
+    });
+
+    test('refuses input_required on a request it is not allowed on', () async {
+      final harness = _DispatcherHarness();
+      final response = await harness.dispatch(
+        _complete('input_required'),
+        _initialization(),
+      );
+
+      final error = response![Keys.error] as Map<String, Object?>;
+      expect(error[Keys.code], error_code.INTERNAL_ERROR);
+      expect(error[Keys.message], contains(CompleteRequest.methodName));
+      expect(error[Keys.message], contains(CallToolRequest.methodName));
+    });
+
+    test('serves input_required on the three it is allowed on', () async {
+      final harness = _DispatcherHarness();
+      for (final message in [
+        _callTool('interim'),
+        _getPrompt('interim'),
+        _readResource(),
+      ]) {
+        final response = await harness.dispatch(message, _initialization());
+
+        expect(
+          response![Keys.error],
+          isNull,
+          reason: '${message[Keys.method]}',
+        );
+      }
+
+      // Only `tools/call` and `prompts/get` answer `input_required` here;
+      // `resources/read` answers a complete result, which is what makes the
+      // third method reachable at all.
+      final call = await harness.dispatch(
+        _callTool('interim'),
+        _initialization(),
+      );
+      expect(_result(call)[Keys.resultType], ResultTypes.inputRequired);
+      final prompt = await harness.dispatch(
+        _getPrompt('interim'),
+        _initialization(),
+      );
+      expect(_result(prompt)[Keys.resultType], ResultTypes.inputRequired);
+    });
+
+    test('refuses an input request the client cannot answer', () async {
+      final harness = _DispatcherHarness();
+      for (final (tool, capability) in [
+        ('asks_to_elicit', 'elicitation.form'),
+        ('asks_to_sample', 'sampling'),
+        ('asks_for_roots', 'roots'),
+      ]) {
+        final response = await harness.dispatch(
+          _callTool(tool),
+          _initialization(),
+        );
+
+        final error = response![Keys.error] as Map<String, Object?>;
+        expect(
+          error[Keys.code],
+          McpErrorCodes.missingRequiredClientCapability,
+          reason: tool,
+        );
+        expect(error[Keys.message], contains(capability), reason: tool);
+        final data = error[Keys.data] as Map<String, Object?>;
+        expect(data, contains(Keys.requiredCapabilities), reason: tool);
+      }
+    });
+
+    test('serves an input request the client declared', () async {
+      final harness = _DispatcherHarness();
+      final response = await harness.dispatch(
+        _callTool('asks_to_elicit'),
+        _initialization(
+          capabilities: ClientCapabilities(
+            elicitation: ElicitationCapability(form: {}),
+          ),
+        ),
+      );
+
+      expect(response![Keys.error], isNull);
+      expect(_result(response)[Keys.inputRequests], isNotEmpty);
+    });
+
+    test('reads the elicitation mode the way the request does', () async {
+      // A client which declared only url elicitation cannot answer a form
+      // request, and `ElicitationRequestSupport.elicit` refuses the same
+      // request on a connected transport.
+      final harness = _DispatcherHarness();
+      final urlOnly = _initialization(
+        capabilities: ClientCapabilities(
+          elicitation: ElicitationCapability(url: {}),
+        ),
+      );
+      final refused = await harness.dispatch(
+        _callTool('asks_to_elicit'),
+        urlOnly,
+      );
+
+      final error = refused![Keys.error] as Map<String, Object?>;
+      expect(error[Keys.code], McpErrorCodes.missingRequiredClientCapability);
+      expect(error[Keys.message], contains('elicitation.form'));
+
+      // And the other way around: a client with only form support cannot
+      // answer a url request.
+      final formOnly = _initialization(
+        capabilities: ClientCapabilities(
+          elicitation: ElicitationCapability(form: {}),
+        ),
+      );
+      final urlRefused = await harness.dispatch(
+        _callTool('asks_to_elicit_by_url'),
+        formOnly,
+      );
+
+      final urlError = urlRefused![Keys.error] as Map<String, Object?>;
+      expect(
+        urlError[Keys.code],
+        McpErrorCodes.missingRequiredClientCapability,
+      );
+      expect(urlError[Keys.message], contains('elicitation.url'));
+
+      final urlServed = await harness.dispatch(
+        _callTool('asks_to_elicit_by_url'),
+        urlOnly,
+      );
+      expect(urlServed![Keys.error], isNull);
+
+      // An empty `elicitation` object still counts as form support, the
+      // backwards compatibility rule the mode split came with.
+      final bare = await harness.dispatch(
+        _callTool('asks_to_elicit'),
+        _initialization(
+          capabilities: ClientCapabilities(
+            elicitation: ElicitationCapability.fromMap({}),
+          ),
+        ),
+      );
+      expect(bare![Keys.error], isNull);
+    });
+
+    test('leaves a malformed inputRequests alone', () async {
+      final harness = _DispatcherHarness();
+      for (final tool in [
+        'bad_input_requests',
+        'bad_input_request_entry',
+        'input_request_without_a_method',
+      ]) {
+        final response = await harness.dispatch(
+          _callTool(tool),
+          _initialization(),
+        );
+
+        expect(response![Keys.error], isNull, reason: tool);
+      }
+    });
+
+    test('leaves an input request it has no capability for alone', () async {
+      final harness = _DispatcherHarness();
+      final response = await harness.dispatch(
+        _callTool('asks_for_something_else'),
+        _initialization(),
+      );
+
+      expect(response![Keys.error], isNull);
+      expect(_result(response)[Keys.inputRequests], isNotEmpty);
+    });
+
+    test('leaves input_required alone on an earlier revision', () async {
+      final harness = _DispatcherHarness();
+      final response = await harness.dispatch(
+        _callTool('asks_to_elicit'),
+        _initialization(protocolVersion: ProtocolVersion.v2025_11_25),
+      );
+
+      expect(response![Keys.error], isNull);
+      expect(_result(response)[Keys.inputRequests], isNotEmpty);
     });
 
     test('shuts the server down after a dispatch', () async {
@@ -872,7 +1053,12 @@ final class _DispatcherTestServer extends TestMCPServer
 
   @override
   CompleteResult handleComplete(CompleteRequest request) =>
-      CompleteResult(completion: Completion(values: const []));
+      request.argument.name == 'input_required'
+          ? CompleteResult.fromMap({
+            Keys.completion: Completion(values: const []),
+            Keys.resultType: ResultTypes.inputRequired,
+          })
+          : CompleteResult(completion: Completion(values: const []));
 
   /// How many [testNotification] notifications this server received.
   int testNotifications = 0;
@@ -914,6 +1100,92 @@ final class _DispatcherTestServer extends TestMCPServer
       (_) => CallToolResult.fromMap({
         Keys.content: [TextContent(text: 'waiting')],
         Keys.resultType: ResultTypes.inputRequired,
+      }),
+    );
+    for (final entry
+        in {
+          'asks_to_elicit': InputRequest.elicit(
+            ElicitRequest.form(
+              message: 'What is your name?',
+              requestedSchema: ObjectSchema(
+                properties: {'name': StringSchema()},
+              ),
+            ),
+          ),
+          'asks_to_sample': InputRequest.sample(
+            CreateMessageRequest(messages: [], maxTokens: 1),
+          ),
+          'asks_for_roots': InputRequest.listRoots(ListRootsRequest()),
+        }.entries) {
+      registerTool(
+        Tool(name: entry.key, inputSchema: ObjectSchema()),
+        (_) => CallToolResult.fromMap({
+          Keys.content: [TextContent(text: 'waiting')],
+          Keys.resultType: ResultTypes.inputRequired,
+          Keys.inputRequests: {'answer': entry.value},
+        }),
+      );
+    }
+    registerTool(
+      Tool(name: 'asks_to_elicit_by_url', inputSchema: ObjectSchema()),
+      (_) => CallToolResult.fromMap({
+        Keys.content: [TextContent(text: 'waiting')],
+        Keys.resultType: ResultTypes.inputRequired,
+        Keys.inputRequests: {
+          'answer': InputRequest.elicit(
+            ElicitRequest.url(
+              message: 'Sign in',
+              url: 'https://example.com/sign-in',
+              elicitationId: 'e1',
+            ),
+          ),
+        },
+      }),
+    );
+    // Registered directly instead of mixing in `PromptsSupport`: the guard
+    // dispatches on the method, and the mixin would also change what this
+    // server advertises, which other tests here assert on.
+    registerRequestHandler<GetPromptRequest, GetPromptResult>(
+      GetPromptRequest.methodName,
+      (_) => GetPromptResult.fromMap({
+        Keys.messages: <Object?>[],
+        Keys.resultType: ResultTypes.inputRequired,
+      }),
+    );
+    registerTool(
+      Tool(name: 'input_request_without_a_method', inputSchema: ObjectSchema()),
+      (_) => CallToolResult.fromMap({
+        Keys.content: [TextContent(text: 'waiting')],
+        Keys.resultType: ResultTypes.inputRequired,
+        Keys.inputRequests: {
+          'answer': {Keys.params: <String, Object?>{}},
+        },
+      }),
+    );
+    registerTool(
+      Tool(name: 'bad_input_requests', inputSchema: ObjectSchema()),
+      (_) => CallToolResult.fromMap({
+        Keys.content: [TextContent(text: 'waiting')],
+        Keys.resultType: ResultTypes.inputRequired,
+        Keys.inputRequests: 'not a map',
+      }),
+    );
+    registerTool(
+      Tool(name: 'bad_input_request_entry', inputSchema: ObjectSchema()),
+      (_) => CallToolResult.fromMap({
+        Keys.content: [TextContent(text: 'waiting')],
+        Keys.resultType: ResultTypes.inputRequired,
+        Keys.inputRequests: {'answer': 'not a map either'},
+      }),
+    );
+    registerTool(
+      Tool(name: 'asks_for_something_else', inputSchema: ObjectSchema()),
+      (_) => CallToolResult.fromMap({
+        Keys.content: [TextContent(text: 'waiting')],
+        Keys.resultType: ResultTypes.inputRequired,
+        Keys.inputRequests: {
+          'answer': {Keys.method: 'io.example/ask'},
+        },
       }),
     );
     registerTool(
@@ -1032,6 +1304,23 @@ final class _ShapedListServer extends TestMCPServer with ToolsSupport {
         shape(await super.listTools(request) as Map<String, Object?>),
       );
 }
+
+Map<String, Object?> _complete(String argumentName) => {
+  Keys.jsonrpc: '2.0',
+  Keys.id: 1,
+  Keys.method: CompleteRequest.methodName,
+  Keys.params: CompleteRequest(
+    ref: ResourceTemplateReference(uri: 'file:///{name}'),
+    argument: CompletionArgument(name: argumentName, value: ''),
+  ),
+};
+
+Map<String, Object?> _getPrompt(String name) => {
+  Keys.jsonrpc: '2.0',
+  Keys.id: 1,
+  Keys.method: GetPromptRequest.methodName,
+  Keys.params: {Keys.name: name},
+};
 
 Map<String, Object?> _callTool(
   String name, {

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -857,6 +857,38 @@ void main() {
           {Keys.message: 'Fill this in', Keys.requestedSchema: 'not a schema'},
         ),
         (ElicitRequest.methodName, {Keys.mode: 'url', Keys.message: 'Sign in'}),
+        (CreateMessageRequest.methodName, {Keys.maxTokens: 1}),
+        (
+          CreateMessageRequest.methodName,
+          {Keys.messages: <Object?>[], Keys.maxTokens: 'lots'},
+        ),
+        (
+          ElicitRequest.methodName,
+          {
+            Keys.message: 7,
+            Keys.requestedSchema: {
+              Keys.type: 'object',
+              Keys.properties: <String, Object?>{},
+            },
+          },
+        ),
+        (
+          ElicitRequest.methodName,
+          {
+            Keys.message: 'Fill this in',
+            Keys.requestedSchema: {
+              Keys.type: 'string',
+              Keys.properties: <String, Object?>{},
+            },
+          },
+        ),
+        (
+          ElicitRequest.methodName,
+          {
+            Keys.message: 'Fill this in',
+            Keys.requestedSchema: {Keys.type: 'object', Keys.properties: 'no'},
+          },
+        ),
       ]) {
         final (response, escaped) = await _dispatchRefusedRead(
           (result) => {

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -231,7 +231,11 @@ void main() {
       // The schema gives `resources/read` an interim arm; `tools/list` has
       // none, so a list result is never the one waiting on input.
       final response = await _dispatchShapedRead(
-        (result) => {...result, Keys.resultType: ResultTypes.inputRequired},
+        (result) => {
+          ...result,
+          Keys.resultType: ResultTypes.inputRequired,
+          Keys.requestState: 'waiting',
+        },
       );
 
       expect(_result(response), isNot(contains(Keys.ttlMs)));
@@ -646,6 +650,16 @@ void main() {
           ClientCapabilities.fromMap({Keys.sampling: <Object?>[]}),
           {'sampling': <String, Object?>{}},
         ),
+        (
+          'asks_for_roots',
+          ClientCapabilities.fromMap({Keys.roots: true}),
+          {'roots': <String, Object?>{}},
+        ),
+        (
+          'asks_for_roots',
+          ClientCapabilities.fromMap({Keys.roots: <Object?>[]}),
+          {'roots': <String, Object?>{}},
+        ),
       ]) {
         final response = await harness.dispatch(
           _callTool(tool),
@@ -743,46 +757,76 @@ void main() {
       expect(bare![Keys.error], isNull);
     });
 
-    test('treats a missing or unknown elicitation mode as form', () async {
-      for (final params in [
-        <String, Object?>{Keys.message: 'Fill this in'},
-        <String, Object?>{Keys.mode: 'voice', Keys.message: 'Fill this in'},
-      ]) {
+    test('treats a missing elicitation mode as form', () async {
+      final params = <String, Object?>{
+        Keys.message: 'Fill this in',
+        Keys.requestedSchema: {
+          Keys.type: JsonType.object.typeName,
+          Keys.properties: <String, Object?>{},
+        },
+      };
+      Map<String, Object?> shape(Map<String, Object?> result) => {
+        ...result,
+        Keys.resultType: ResultTypes.inputRequired,
+        Keys.inputRequests: {
+          ElicitRequest.methodName: InputRequest.fromMap({
+            Keys.method: ElicitRequest.methodName,
+            Keys.params: params,
+          }),
+        },
+      };
+
+      final refused = await _dispatchShapedRead(
+        shape,
+        capabilities: ClientCapabilities(
+          elicitation: ElicitationCapability(url: {}),
+        ),
+      );
+      final wire = jsonDecode(jsonEncode(refused)) as Map<String, Object?>;
+      final error = wire['error'] as Map<String, Object?>;
+      expect(error['code'], -32021);
+      expect(error['message'], contains('elicitation.form'));
+
+      final served = await _dispatchShapedRead(
+        shape,
+        capabilities: ClientCapabilities(
+          elicitation: ElicitationCapability(form: {}),
+        ),
+      );
+      final servedWire = jsonDecode(jsonEncode(served)) as Map<String, Object?>;
+      expect(servedWire['error'], isNull);
+    });
+
+    test('rejects unknown elicitation modes', () async {
+      for (final mode in ['voice', 1]) {
         Map<String, Object?> shape(Map<String, Object?> result) => {
           ...result,
           Keys.resultType: ResultTypes.inputRequired,
           Keys.inputRequests: {
             ElicitRequest.methodName: InputRequest.fromMap({
               Keys.method: ElicitRequest.methodName,
-              Keys.params: params,
+              Keys.params: {
+                Keys.mode: mode,
+                Keys.message: 'Fill this in',
+                Keys.requestedSchema: {
+                  Keys.type: JsonType.object.typeName,
+                  Keys.properties: <String, Object?>{},
+                },
+              },
             }),
           },
         };
 
-        final refused = await _dispatchShapedRead(
-          shape,
-          capabilities: ClientCapabilities(
-            elicitation: ElicitationCapability(url: {}),
-          ),
-        );
-        final wire = jsonDecode(jsonEncode(refused)) as Map<String, Object?>;
+        final response = await _dispatchShapedRead(shape);
+        final wire = jsonDecode(jsonEncode(response)) as Map<String, Object?>;
         final error = wire['error'] as Map<String, Object?>;
-        expect(error['code'], -32021);
-        expect(error['message'], contains('elicitation.form'));
-
-        final served = await _dispatchShapedRead(
-          shape,
-          capabilities: ClientCapabilities(
-            elicitation: ElicitationCapability(form: {}),
-          ),
-        );
-        final servedWire =
-            jsonDecode(jsonEncode(served)) as Map<String, Object?>;
-        expect(servedWire['error'], isNull);
+        expect(error['code'], -32603, reason: '$mode');
+        expect(error['message'], contains('form'), reason: '$mode');
+        expect(error['message'], contains('url'), reason: '$mode');
       }
     });
 
-    test('leaves a malformed inputRequests alone', () async {
+    test('rejects malformed inputRequests', () async {
       final harness = _DispatcherHarness();
       for (final tool in [
         'bad_input_requests',
@@ -794,19 +838,87 @@ void main() {
           _initialization(),
         );
 
-        expect(response![Keys.error], isNull, reason: tool);
+        final error = response![Keys.error] as Map<String, Object?>;
+        expect(error[Keys.code], error_code.INTERNAL_ERROR, reason: tool);
       }
     });
 
-    test('leaves an input request it has no capability for alone', () async {
+    test('rejects an input request with an unknown method', () async {
       final harness = _DispatcherHarness();
       final response = await harness.dispatch(
         _callTool('asks_for_something_else'),
         _initialization(),
       );
 
-      expect(response![Keys.error], isNull);
-      expect(_result(response)[Keys.inputRequests], isNotEmpty);
+      final error = response![Keys.error] as Map<String, Object?>;
+      expect(error[Keys.code], error_code.INTERNAL_ERROR);
+      expect(error[Keys.message], contains(ElicitRequest.methodName));
+      expect(error[Keys.message], contains(CreateMessageRequest.methodName));
+      expect(error[Keys.message], contains(ListRootsRequest.methodName));
+    });
+
+    test('rejects malformed input request params', () async {
+      for (final (method, params) in [
+        (ElicitRequest.methodName, null),
+        (ElicitRequest.methodName, <Object?>[]),
+        (CreateMessageRequest.methodName, null),
+        (CreateMessageRequest.methodName, <Object?>[]),
+        (ListRootsRequest.methodName, 'not a map'),
+      ]) {
+        final response = await _dispatchShapedRead(
+          (result) => {
+            ...result,
+            Keys.resultType: ResultTypes.inputRequired,
+            Keys.inputRequests: {
+              'answer': {
+                Keys.method: method,
+                if (params != null) Keys.params: params,
+              },
+            },
+          },
+        );
+
+        final wire = jsonDecode(jsonEncode(response)) as Map<String, Object?>;
+        final error = wire['error'] as Map<String, Object?>;
+        expect(error['code'], -32603, reason: '$method: $params');
+      }
+    });
+
+    test('rejects an input_required result with no work or state', () async {
+      for (final shape in [
+        <String, Object?>{},
+        <String, Object?>{Keys.requestState: 7},
+      ]) {
+        final response = await _dispatchShapedRead(
+          (result) => {
+            ...result,
+            Keys.resultType: ResultTypes.inputRequired,
+            ...shape,
+          },
+        );
+
+        final wire = jsonDecode(jsonEncode(response)) as Map<String, Object?>;
+        final error = wire['error'] as Map<String, Object?>;
+        expect(error['code'], -32603, reason: '$shape');
+      }
+    });
+
+    test('serves empty inputRequests and string requestState', () async {
+      for (final shape in [
+        <String, Object?>{Keys.inputRequests: <String, Object?>{}},
+        <String, Object?>{Keys.requestState: 'waiting'},
+      ]) {
+        final response = await _dispatchShapedRead(
+          (result) => {
+            ...result,
+            Keys.resultType: ResultTypes.inputRequired,
+            ...shape,
+          },
+        );
+
+        final wire = jsonDecode(jsonEncode(response)) as Map<String, Object?>;
+        expect(wire['error'], isNull, reason: '$shape');
+      }
     });
 
     test('leaves input_required alone on an earlier revision', () async {

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -558,7 +558,9 @@ void main() {
           capabilities: ClientCapabilities(sampling: {}),
         );
         final wire = jsonDecode(jsonEncode(refused)) as Map<String, Object?>;
-        final error = wire['error'] as Map<String, Object?>;
+        final rawError = wire['error'];
+        expect(rawError, isA<Map<String, Object?>>(), reason: field);
+        final error = rawError as Map<String, Object?>;
         expect(error['code'], -32021, reason: field);
         expect(error['message'], contains('sampling.tools'), reason: field);
         final data = error['data'] as Map<String, Object?>;
@@ -667,7 +669,13 @@ void main() {
         );
 
         final wire = jsonDecode(jsonEncode(response)) as Map<String, Object?>;
-        final error = wire['error'] as Map<String, Object?>;
+        final rawError = wire['error'];
+        expect(
+          rawError,
+          isA<Map<String, Object?>>(),
+          reason: '$tool: $capabilities',
+        );
+        final error = rawError as Map<String, Object?>;
         expect(error['code'], -32021, reason: '$tool: $capabilities');
         final data = error['data'] as Map<String, Object?>;
         expect(
@@ -819,7 +827,9 @@ void main() {
 
         final response = await _dispatchShapedRead(shape);
         final wire = jsonDecode(jsonEncode(response)) as Map<String, Object?>;
-        final error = wire['error'] as Map<String, Object?>;
+        final rawError = wire['error'];
+        expect(rawError, isA<Map<String, Object?>>(), reason: '$mode');
+        final error = rawError as Map<String, Object?>;
         expect(error['code'], -32603, reason: '$mode');
         expect(error['message'], contains('form'), reason: '$mode');
         expect(error['message'], contains('url'), reason: '$mode');
@@ -838,7 +848,9 @@ void main() {
           _initialization(),
         );
 
-        final error = response![Keys.error] as Map<String, Object?>;
+        final rawError = response![Keys.error];
+        expect(rawError, isA<Map<String, Object?>>(), reason: tool);
+        final error = rawError as Map<String, Object?>;
         expect(error[Keys.code], error_code.INTERNAL_ERROR, reason: tool);
       }
     });
@@ -850,7 +862,9 @@ void main() {
         _initialization(),
       );
 
-      final error = response![Keys.error] as Map<String, Object?>;
+      final rawError = response![Keys.error];
+      expect(rawError, isA<Map<String, Object?>>());
+      final error = rawError as Map<String, Object?>;
       expect(error[Keys.code], error_code.INTERNAL_ERROR);
       expect(error[Keys.message], contains(ElicitRequest.methodName));
       expect(error[Keys.message], contains(CreateMessageRequest.methodName));
@@ -879,7 +893,13 @@ void main() {
         );
 
         final wire = jsonDecode(jsonEncode(response)) as Map<String, Object?>;
-        final error = wire['error'] as Map<String, Object?>;
+        final rawError = wire['error'];
+        expect(
+          rawError,
+          isA<Map<String, Object?>>(),
+          reason: '$method: $params',
+        );
+        final error = rawError as Map<String, Object?>;
         expect(error['code'], -32603, reason: '$method: $params');
       }
     });
@@ -898,7 +918,9 @@ void main() {
         );
 
         final wire = jsonDecode(jsonEncode(response)) as Map<String, Object?>;
-        final error = wire['error'] as Map<String, Object?>;
+        final rawError = wire['error'];
+        expect(rawError, isA<Map<String, Object?>>(), reason: '$shape');
+        final error = rawError as Map<String, Object?>;
         expect(error['code'], -32603, reason: '$shape');
       }
     });

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -1664,8 +1664,8 @@ Future<Map<String, Object?>?> _dispatchShapedRead(
 /// Dispatches [shape] the way [_dispatchShapedRead] does, and returns the
 /// answer next to whatever the dispatcher let reach the zone.
 ///
-/// Refusing a result the schema does not allow asserts, so a test reading that
-/// answer has to collect the assertion rather than fail on it. A build with
+/// Refusing a result the schema does not allow asserts. A test reading that
+/// answer has to collect the assertion instead of failing on it. A build with
 /// asserts disabled collects nothing.
 Future<(Map<String, Object?>?, List<Object>)> _dispatchRefusedRead(
   Map<String, Object?> Function(Map<String, Object?> result) shape, {

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -580,7 +580,7 @@ void main() {
       }
     });
 
-    test('reports all missing input request capabilities together', () async {
+    test('checks every input request, not just the first', () async {
       final response = await _dispatchShapedRead(
         (result) => {
           ...result,
@@ -592,98 +592,22 @@ void main() {
                 requestedSchema: ObjectSchema(),
               ),
             ),
-            CreateMessageRequest.methodName: InputRequest.sample(
-              CreateMessageRequest(messages: [], maxTokens: 1),
-            ),
             ListRootsRequest.methodName: InputRequest.listRoots(
               ListRootsRequest(),
             ),
           },
         },
+        capabilities: ClientCapabilities(
+          elicitation: ElicitationCapability(form: {}),
+        ),
       );
 
       final wire = jsonDecode(jsonEncode(response)) as Map<String, Object?>;
       final error = wire['error'] as Map<String, Object?>;
       expect(error['code'], -32021);
-      for (final capability in ['elicitation.form', 'sampling', 'roots']) {
-        expect(error['message'], contains(capability));
-      }
+      expect(error['message'], contains('roots'));
       final data = error['data'] as Map<String, Object?>;
-      expect(data['requiredCapabilities'], {
-        'elicitation': {'form': <String, Object?>{}},
-        'sampling': <String, Object?>{},
-        'roots': <String, Object?>{},
-      });
-    });
-
-    test('treats unreadable capability entries as absent', () async {
-      final harness = _DispatcherHarness();
-      for (final (tool, capabilities, required) in [
-        (
-          'asks_to_elicit',
-          ClientCapabilities.fromMap({Keys.elicitation: true}),
-          {
-            'elicitation': {'form': <String, Object?>{}},
-          },
-        ),
-        (
-          'asks_to_elicit',
-          ClientCapabilities.fromMap({Keys.elicitation: Keys.form}),
-          {
-            'elicitation': {'form': <String, Object?>{}},
-          },
-        ),
-        (
-          'asks_to_elicit',
-          ClientCapabilities.fromMap({
-            Keys.elicitation: {Keys.form: 1},
-          }),
-          {
-            'elicitation': {'form': <String, Object?>{}},
-          },
-        ),
-        (
-          'asks_to_sample',
-          ClientCapabilities.fromMap({Keys.sampling: 7}),
-          {'sampling': <String, Object?>{}},
-        ),
-        (
-          'asks_to_sample',
-          ClientCapabilities.fromMap({Keys.sampling: <Object?>[]}),
-          {'sampling': <String, Object?>{}},
-        ),
-        (
-          'asks_for_roots',
-          ClientCapabilities.fromMap({Keys.roots: true}),
-          {'roots': <String, Object?>{}},
-        ),
-        (
-          'asks_for_roots',
-          ClientCapabilities.fromMap({Keys.roots: <Object?>[]}),
-          {'roots': <String, Object?>{}},
-        ),
-      ]) {
-        final response = await harness.dispatch(
-          _callTool(tool),
-          _initialization(capabilities: capabilities),
-        );
-
-        final wire = jsonDecode(jsonEncode(response)) as Map<String, Object?>;
-        final rawError = wire['error'];
-        expect(
-          rawError,
-          isA<Map<String, Object?>>(),
-          reason: '$tool: $capabilities',
-        );
-        final error = rawError as Map<String, Object?>;
-        expect(error['code'], -32021, reason: '$tool: $capabilities');
-        final data = error['data'] as Map<String, Object?>;
-        expect(
-          data['requiredCapabilities'],
-          required,
-          reason: '$tool: $capabilities',
-        );
-      }
+      expect(data['requiredCapabilities'], {'roots': <String, Object?>{}});
     });
 
     test('serves an input request the client declared', () async {
@@ -837,38 +761,55 @@ void main() {
     });
 
     test('rejects malformed inputRequests', () async {
-      final harness = _DispatcherHarness();
-      for (final tool in [
-        'bad_input_requests',
-        'bad_input_request_entry',
-        'input_request_without_a_method',
+      for (final requests in [
+        'not a map',
+        {'answer': 'not a map either'},
       ]) {
-        final response = await harness.dispatch(
-          _callTool(tool),
-          _initialization(),
+        final response = await _dispatchShapedRead(
+          (result) => {
+            ...result,
+            Keys.resultType: ResultTypes.inputRequired,
+            Keys.inputRequests: requests,
+          },
         );
 
         final rawError = response![Keys.error];
-        expect(rawError, isA<Map<String, Object?>>(), reason: tool);
+        expect(rawError, isA<Map<String, Object?>>(), reason: '$requests');
         final error = rawError as Map<String, Object?>;
-        expect(error[Keys.code], error_code.INTERNAL_ERROR, reason: tool);
+        expect(
+          error[Keys.code],
+          error_code.INTERNAL_ERROR,
+          reason: '$requests',
+        );
       }
     });
 
-    test('rejects an input request with an unknown method', () async {
-      final harness = _DispatcherHarness();
-      final response = await harness.dispatch(
-        _callTool('asks_for_something_else'),
-        _initialization(),
-      );
+    test('rejects an input request the revision has no arm for', () async {
+      // A request with no method at all lands here too.
+      for (final request in [
+        <String, Object?>{Keys.params: <String, Object?>{}},
+        <String, Object?>{Keys.method: 'io.example/ask'},
+      ]) {
+        final response = await _dispatchShapedRead(
+          (result) => {
+            ...result,
+            Keys.resultType: ResultTypes.inputRequired,
+            Keys.inputRequests: {'answer': request},
+          },
+        );
 
-      final rawError = response![Keys.error];
-      expect(rawError, isA<Map<String, Object?>>());
-      final error = rawError as Map<String, Object?>;
-      expect(error[Keys.code], error_code.INTERNAL_ERROR);
-      expect(error[Keys.message], contains(ElicitRequest.methodName));
-      expect(error[Keys.message], contains(CreateMessageRequest.methodName));
-      expect(error[Keys.message], contains(ListRootsRequest.methodName));
+        final rawError = response![Keys.error];
+        expect(rawError, isA<Map<String, Object?>>(), reason: '$request');
+        final error = rawError as Map<String, Object?>;
+        expect(error[Keys.code], error_code.INTERNAL_ERROR, reason: '$request');
+        for (final method in [
+          ElicitRequest.methodName,
+          CreateMessageRequest.methodName,
+          ListRootsRequest.methodName,
+        ]) {
+          expect(error[Keys.message], contains(method), reason: '$request');
+        }
+      }
     });
 
     test('rejects malformed input request params', () async {
@@ -1472,42 +1413,6 @@ final class _DispatcherTestServer extends TestMCPServer
         Keys.messages: <Object?>[],
         Keys.resultType: ResultTypes.inputRequired,
         Keys.requestState: 'waiting',
-      }),
-    );
-    registerTool(
-      Tool(name: 'input_request_without_a_method', inputSchema: ObjectSchema()),
-      (_) => CallToolResult.fromMap({
-        Keys.content: [TextContent(text: 'waiting')],
-        Keys.resultType: ResultTypes.inputRequired,
-        Keys.inputRequests: {
-          'answer': {Keys.params: <String, Object?>{}},
-        },
-      }),
-    );
-    registerTool(
-      Tool(name: 'bad_input_requests', inputSchema: ObjectSchema()),
-      (_) => CallToolResult.fromMap({
-        Keys.content: [TextContent(text: 'waiting')],
-        Keys.resultType: ResultTypes.inputRequired,
-        Keys.inputRequests: 'not a map',
-      }),
-    );
-    registerTool(
-      Tool(name: 'bad_input_request_entry', inputSchema: ObjectSchema()),
-      (_) => CallToolResult.fromMap({
-        Keys.content: [TextContent(text: 'waiting')],
-        Keys.resultType: ResultTypes.inputRequired,
-        Keys.inputRequests: {'answer': 'not a map either'},
-      }),
-    );
-    registerTool(
-      Tool(name: 'asks_for_something_else', inputSchema: ObjectSchema()),
-      (_) => CallToolResult.fromMap({
-        Keys.content: [TextContent(text: 'waiting')],
-        Keys.resultType: ResultTypes.inputRequired,
-        Keys.inputRequests: {
-          'answer': {Keys.method: 'io.example/ask'},
-        },
       }),
     );
     registerTool(

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -216,8 +216,8 @@ void main() {
         'give the request', () async {
       // `tools/list` has no interim arm, so a non-complete type there does not
       // make the result one the caching rules exempt. The schema types
-      // `resultType` as a bare string, so a server may send one this package
-      // has no name for; `input_required` is not among the ones it may send
+      // `resultType` as a bare string, and a server may send one this package
+      // has no name for. `input_required` is not among the ones it may send
       // here, and the dispatcher refuses that separately.
       final response = await _dispatchShapedList(
         (result) => {...result, Keys.resultType: 'io.example/other'},
@@ -1480,7 +1480,7 @@ final class _DispatcherTestServer extends TestMCPServer
         },
       }),
     );
-    // Registered directly instead of mixing in `PromptsSupport`: the guard
+    // Registered directly, not by mixing in `PromptsSupport`: the guard
     // dispatches on the method, and the mixin would also change what this
     // server advertises. Other tests here assert on those capabilities.
     registerRequestHandler<GetPromptRequest, GetPromptResult>(
@@ -1696,9 +1696,9 @@ Future<Map<String, Object?>?> _dispatchShapedRead(
 /// Dispatches [shape] the way [_dispatchShapedRead] does, and returns the
 /// answer next to whatever the dispatcher let reach the zone.
 ///
-/// Refusing a result the schema does not allow asserts. A test reading that
-/// answer has to collect the assertion instead of failing on it. A build with
-/// asserts disabled collects nothing.
+/// Refusing a result the schema does not allow asserts. Collecting it from
+/// the zone lets a test read the answer without that assertion failing it. A
+/// build with asserts disabled collects nothing.
 Future<(Map<String, Object?>?, List<Object>)> _dispatchRefusedRead(
   Map<String, Object?> Function(Map<String, Object?> result) shape, {
   ClientCapabilities? capabilities,

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -463,17 +463,38 @@ void main() {
 
     test('refuses input_required on a request it is not allowed on', () async {
       final harness = _DispatcherHarness();
-      final response = await harness.dispatch(
-        _complete('input_required'),
-        _initialization(),
-      );
+      final escaped = <Object>[];
+      Map<String, Object?>? response;
+      await runZonedGuarded(() async {
+        response = await harness.dispatch(
+          _complete('input_required'),
+          _initialization(),
+        );
+      }, (error, _) => escaped.add(error));
 
+      expect(escaped, everyElement(isA<AssertionError>()));
       final wire = jsonDecode(jsonEncode(response)) as Map<String, Object?>;
       final error = wire['error'] as Map<String, Object?>;
       expect(error['code'], -32603);
       expect(error['message'], contains(CompleteRequest.methodName));
       expect(error['message'], contains(CallToolRequest.methodName));
     });
+
+    test(
+      'reports a refused input_required result as a bug in the server',
+      () async {
+        // The refusal above answers the client, and this is the other half: the
+        // server that sent it still hears about it. A compiled executable has
+        // asserts stripped, so there is nothing to catch there.
+        final (_, escaped) = await _dispatchRefusedRead(
+          (result) => {...result, Keys.resultType: ResultTypes.inputRequired},
+        );
+
+        expect(escaped.single, isA<AssertionError>());
+        expect(escaped.single.toString(), contains(ResultTypes.inputRequired));
+      },
+      testOn: '!exe',
+    );
 
     test('serves input_required on allowed requests', () async {
       final harness = _DispatcherHarness();
@@ -626,7 +647,7 @@ void main() {
     });
 
     test('reads the elicitation mode the way the request does', () async {
-      // A client which declared only url elicitation cannot answer a form
+      // A client that declared only url elicitation cannot answer a form
       // request, and `ElicitationRequestSupport.elicit` refuses the same
       // request on a connected transport.
       final harness = _DispatcherHarness();
@@ -749,7 +770,8 @@ void main() {
           },
         };
 
-        final response = await _dispatchShapedRead(shape);
+        final (response, escaped) = await _dispatchRefusedRead(shape);
+        expect(escaped, everyElement(isA<AssertionError>()), reason: '$mode');
         final wire = jsonDecode(jsonEncode(response)) as Map<String, Object?>;
         final rawError = wire['error'];
         expect(rawError, isA<Map<String, Object?>>(), reason: '$mode');
@@ -766,7 +788,7 @@ void main() {
         {'answer': 'not a map either'},
         <int, Object?>{1: InputRequest.listRoots(ListRootsRequest())},
       ]) {
-        final response = await _dispatchShapedRead(
+        final (response, escaped) = await _dispatchRefusedRead(
           (result) => {
             ...result,
             Keys.resultType: ResultTypes.inputRequired,
@@ -774,6 +796,11 @@ void main() {
           },
         );
 
+        expect(
+          escaped,
+          everyElement(isA<AssertionError>()),
+          reason: '$requests',
+        );
         final rawError = response![Keys.error];
         expect(rawError, isA<Map<String, Object?>>(), reason: '$requests');
         final error = rawError as Map<String, Object?>;
@@ -791,7 +818,7 @@ void main() {
         <String, Object?>{Keys.params: <String, Object?>{}},
         <String, Object?>{Keys.method: 'io.example/ask'},
       ]) {
-        final response = await _dispatchShapedRead(
+        final (response, escaped) = await _dispatchRefusedRead(
           (result) => {
             ...result,
             Keys.resultType: ResultTypes.inputRequired,
@@ -799,6 +826,11 @@ void main() {
           },
         );
 
+        expect(
+          escaped,
+          everyElement(isA<AssertionError>()),
+          reason: '$request',
+        );
         final rawError = response![Keys.error];
         expect(rawError, isA<Map<String, Object?>>(), reason: '$request');
         final error = rawError as Map<String, Object?>;
@@ -826,7 +858,7 @@ void main() {
         ),
         (ElicitRequest.methodName, {Keys.mode: 'url', Keys.message: 'Sign in'}),
       ]) {
-        final response = await _dispatchShapedRead(
+        final (response, escaped) = await _dispatchRefusedRead(
           (result) => {
             ...result,
             Keys.resultType: ResultTypes.inputRequired,
@@ -839,6 +871,11 @@ void main() {
           },
         );
 
+        expect(
+          escaped,
+          everyElement(isA<AssertionError>()),
+          reason: '$method: $params',
+        );
         final wire = jsonDecode(jsonEncode(response)) as Map<String, Object?>;
         final rawError = wire['error'];
         expect(
@@ -856,7 +893,7 @@ void main() {
         <String, Object?>{},
         <String, Object?>{Keys.requestState: 7},
       ]) {
-        final response = await _dispatchShapedRead(
+        final (response, escaped) = await _dispatchRefusedRead(
           (result) => {
             ...result,
             Keys.resultType: ResultTypes.inputRequired,
@@ -864,6 +901,7 @@ void main() {
           },
         );
 
+        expect(escaped, everyElement(isA<AssertionError>()), reason: '$shape');
         final wire = jsonDecode(jsonEncode(response)) as Map<String, Object?>;
         final rawError = wire['error'];
         expect(rawError, isA<Map<String, Object?>>(), reason: '$shape');
@@ -1412,7 +1450,7 @@ final class _DispatcherTestServer extends TestMCPServer
     );
     // Registered directly instead of mixing in `PromptsSupport`: the guard
     // dispatches on the method, and the mixin would also change what this
-    // server advertises, which other tests here assert on.
+    // server advertises. Other tests here assert on those capabilities.
     registerRequestHandler<GetPromptRequest, GetPromptResult>(
       GetPromptRequest.methodName,
       (_) => GetPromptResult.fromMap({
@@ -1622,6 +1660,24 @@ Future<Map<String, Object?>?> _dispatchShapedRead(
   _initialization(capabilities: capabilities),
   (channel) => _ShapedReadServer(channel, shape),
 );
+
+/// Dispatches [shape] the way [_dispatchShapedRead] does, and returns the
+/// answer next to whatever the dispatcher let reach the zone.
+///
+/// Refusing a result the schema does not allow asserts, so a test reading that
+/// answer has to collect the assertion rather than fail on it. A build with
+/// asserts disabled collects nothing.
+Future<(Map<String, Object?>?, List<Object>)> _dispatchRefusedRead(
+  Map<String, Object?> Function(Map<String, Object?> result) shape, {
+  ClientCapabilities? capabilities,
+}) async {
+  final escaped = <Object>[];
+  Map<String, Object?>? response;
+  await runZonedGuarded(() async {
+    response = await _dispatchShapedRead(shape, capabilities: capabilities);
+  }, (error, _) => escaped.add(error));
+  return (response, escaped);
+}
 
 /// Dispatches a `tools/list` to a server whose result is passed through
 /// [shape] first, so a test can say what the handler itself already set.

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -648,8 +648,7 @@ void main() {
 
     test('reads the elicitation mode the way the request does', () async {
       // A client that declared only url elicitation cannot answer a form
-      // request, and `ElicitationRequestSupport.elicit` refuses the same
-      // request on a connected transport.
+      // request. `ElicitationRequestSupport.elicit` turns down that one too.
       final harness = _DispatcherHarness();
       final urlOnly = _initialization(
         capabilities: ClientCapabilities(

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -764,6 +764,7 @@ void main() {
       for (final requests in [
         'not a map',
         {'answer': 'not a map either'},
+        <int, Object?>{1: InputRequest.listRoots(ListRootsRequest())},
       ]) {
         final response = await _dispatchShapedRead(
           (result) => {

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -1696,9 +1696,9 @@ Future<Map<String, Object?>?> _dispatchShapedRead(
 /// Dispatches [shape] the way [_dispatchShapedRead] does, and returns the
 /// answer next to whatever the dispatcher let reach the zone.
 ///
-/// Refusing a result the schema does not allow asserts. Collecting it from
-/// the zone lets a test read the answer without that assertion failing it. A
-/// build with asserts disabled collects nothing.
+/// A malformed `input_required` asserts on its way out. Collecting that
+/// assertion lets a test read the answer without it failing the test. A build
+/// with asserts disabled collects nothing.
 Future<(Map<String, Object?>?, List<Object>)> _dispatchRefusedRead(
   Map<String, Object?> Function(Map<String, Object?> result) shape, {
   ClientCapabilities? capabilities,

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -820,6 +820,11 @@ void main() {
         (CreateMessageRequest.methodName, null),
         (CreateMessageRequest.methodName, <Object?>[]),
         (ListRootsRequest.methodName, 'not a map'),
+        (
+          ElicitRequest.methodName,
+          {Keys.message: 'Fill this in', Keys.requestedSchema: 'not a schema'},
+        ),
+        (ElicitRequest.methodName, {Keys.mode: 'url', Keys.message: 'Sign in'}),
       ]) {
         final response = await _dispatchShapedRead(
           (result) => {


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

The dispatcher passed an `input_required` result straight through. A server could answer tools/list that way, or ask for an elicitation the client never declared. 2026-07-28 allows neither.

Answering that way on a method outside prompts/get, resources/read and tools/call is now an internal error, as is a malformed input request. I send an undeclared capability through `_missingClientCapability`, just the -32021 a live connection raises. I pulled those refusals out for the dispatcher and the server methods to share. Tool use is the one check that goes further, needing `sampling.tools` where `createMessage` looks only for `sampling`.
