### PR TITLE
reject server-to-client requests the revision does not have

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -111,9 +111,8 @@
     `{"type": "integer", "minimum": 0.5}` sent something the getter threw on.
     `multipleOf` next to them already read `num`.
 - Add `supportsFormElicitation` and `supportsUrlElicitation` for a server to
-  ask before it sends, on a revision which has `elicitation/create` to send.
-  An empty `elicitation` object still means form, the way `elicitation` read
-  before the split.
+  ask before it sends. An empty `elicitation` object still means form, the way
+  `elicitation` read before the split.
 - Add `ElicitRequest.rawMode`, which carries the mode as it arrived. `mode`
   resolves it and throws on an unknown one.
 - Fix the `Meta` dartdoc, which still described the 2025-06-18 prefix rule, and

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -40,7 +40,7 @@
     - On the client, `MCPClient.capabilities` already worked this way.
   - Override `MCPServer.initializeLegacy` only to customize the legacy
     initialize response or version negotiation.
-  - On a revision which has `elicitation/create`,
+  - On revisions that have `elicitation/create`,
     `ElicitationRequestSupport.elicit` now throws an `RpcException` with
     `McpErrorCodes.missingRequiredClientCapability` instead of a `StateError`
     when the client did not declare the capability the request needs, naming
@@ -49,12 +49,11 @@
     reaches the client as that error rather than as a `CallToolResult` whose
     text is a Dart stack trace. A server catching the `StateError` needs to
     catch `RpcException` instead, which comes from `package:json_rpc_2`.
-  - On a revision which has `elicitation/create`,
-    `ElicitationRequestSupport.elicit` now checks which mode a request names. A
-    server that guarded on `supportsElicitation` should read
-    `supportsFormElicitation` or `supportsUrlElicitation`. A request naming an
-    unknown mode is answered with `-32602` (invalid params) instead of going out
-    with that mode still on it.
+  - `ElicitationRequestSupport.elicit` also checks which mode a request names
+    on those same revisions. A server that guarded on `supportsElicitation`
+    should read `supportsFormElicitation` or `supportsUrlElicitation`. A
+    request naming an unknown mode is answered with `-32602` (invalid params)
+    instead of going out with that mode still on it.
   - `ServerConnection` now answers an elicitation mode the client did not
     declare with `-32602` (invalid params), where it used to answer a `decline`,
     as if the user had sent it. An unrecognized one used to throw out of the
@@ -85,9 +84,9 @@
     `ProtocolVersion.v2026_07_28.removedMethods` now lists `roots/list`,
     `sampling/createMessage`, and `elicitation/create`, which that revision
     dropped along with the rest of the `ServerRequest` union, so
-    `ProtocolVersion.methodIsValid` is the single answer all three read. A
-    server on it asks the client for input with an `InputRequiredResult` on
-    `tools/call`, `prompts/get`, or `resources/read` instead, see
+    `ProtocolVersion.methodIsValid` answers for all three. A server on it asks
+    the client for input with an `InputRequiredResult` on `tools/call`,
+    `prompts/get`, or `resources/read` instead, see
     https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr.
     `elicit` also throws on 2024-11-05 and 2025-03-26, the two revisions before
     2025-06-18 added `elicitation/create`.

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -44,7 +44,8 @@
     `ElicitationRequestSupport.elicit` now throws an `RpcException` with
     `McpErrorCodes.missingRequiredClientCapability` instead of a `StateError`
     when the client did not declare the capability the request needs, naming
-    the missing capability under `data.requiredCapabilities`.
+    the missing capability under `data.requiredCapabilities`, which the
+    2026-07-28 revision requires of that error.
     `ToolsSupport.callTool` rethrows an `RpcException`, so a tool which elicits
     reaches the client as that error rather than as a `CallToolResult` whose
     text is a Dart stack trace. A server catching the `StateError` needs to

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -40,16 +40,17 @@
     - On the client, `MCPClient.capabilities` already worked this way.
   - Override `MCPServer.initializeLegacy` only to customize the legacy
     initialize response or version negotiation.
-  - `ElicitationRequestSupport.elicit` now throws an `RpcException` with
+  - On a revision which has `elicitation/create`,
+    `ElicitationRequestSupport.elicit` now throws an `RpcException` with
     `McpErrorCodes.missingRequiredClientCapability` instead of a `StateError`
-    when the client did not declare the capability the request needs, naming the
-    missing capability under `data.requiredCapabilities`, which the 2026-07-28
-    revision requires of that error. `ToolsSupport.callTool` rethrows an
-    `RpcException`, so a tool which elicits reaches the client as that error
-    rather than as a `CallToolResult` whose text is a Dart stack trace. A
-    server catching the `StateError` needs to catch `RpcException` instead,
-    which comes from `package:json_rpc_2`.
-  - `ElicitationRequestSupport.elicit` now checks which mode a request names. A
+    when the client did not declare the capability the request needs, naming
+    the missing capability under `data.requiredCapabilities`.
+    `ToolsSupport.callTool` rethrows an `RpcException`, so a tool which elicits
+    reaches the client as that error rather than as a `CallToolResult` whose
+    text is a Dart stack trace. A server catching the `StateError` needs to
+    catch `RpcException` instead, which comes from `package:json_rpc_2`.
+  - On a revision which has `elicitation/create`,
+    `ElicitationRequestSupport.elicit` now checks which mode a request names. A
     server that guarded on `supportsElicitation` should read
     `supportsFormElicitation` or `supportsUrlElicitation`. A request naming an
     unknown mode is answered with `-32602` (invalid params) instead of going out
@@ -77,14 +78,19 @@
     server to client request at all. A server which expects either of those
     codes for an undeclared capability should read `MCPServer.supportsRoots`
     or `MCPServer.supportsSampling` first.
-  - From protocol version 2026-07-28, `MCPServer.listRoots`,
-    `MCPServer.createMessage`, and `ElicitationRequestSupport.elicit` throw an
-    `RpcException` with `-32603` before checking the client capability, even
-    when it is declared. Direct `roots/list`, `sampling/createMessage`, and
-    `elicitation/create` requests are unavailable on that revision and later.
-    The protocol carries them in an `InputRequiredResult` response to
-    `tools/call`, `prompts/get`, or `resources/read`, see
+  - `MCPServer.listRoots`, `MCPServer.createMessage`, and
+    `ElicitationRequestSupport.elicit` now throw an `RpcException` with
+    `-32603` when the negotiated protocol version does not have the method,
+    before they read any client capability.
+    `ProtocolVersion.v2026_07_28.removedMethods` now lists `roots/list`,
+    `sampling/createMessage`, and `elicitation/create`, which that revision
+    dropped along with the rest of the `ServerRequest` union, so
+    `ProtocolVersion.methodIsValid` is the single answer all three read. A
+    server on it asks the client for input with an `InputRequiredResult` on
+    `tools/call`, `prompts/get`, or `resources/read` instead, see
     https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr.
+    `elicit` also throws on 2024-11-05 and 2025-03-26, the two revisions before
+    2025-06-18 added `elicitation/create`.
   - `ResourceLink.icons` is now `List<Icon>?` instead of `List<String>?`, and
     its factory takes the icons, the way the other five types carrying `icons`
     already do. The field has been an array of icons since 2025-11-25 added it,
@@ -105,8 +111,9 @@
     `{"type": "integer", "minimum": 0.5}` sent something the getter threw on.
     `multipleOf` next to them already read `num`.
 - Add `supportsFormElicitation` and `supportsUrlElicitation` for a server to
-  ask before it sends. An empty `elicitation` object still means form, the way
-  `elicitation` read before the split.
+  ask before it sends, on a revision which has `elicitation/create` to send.
+  An empty `elicitation` object still means form, the way `elicitation` read
+  before the split.
 - Add `ElicitRequest.rawMode`, which carries the mode as it arrived. `mode`
   resolves it and throws on an unknown one.
 - Fix the `Meta` dartdoc, which still described the 2025-06-18 prefix rule, and

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -66,18 +66,25 @@
     Dart stack trace attached. A server which overrides `readResource` and
     catches the `ArgumentError` its dartdoc used to promise needs to catch
     `RpcException` from `package:json_rpc_2` instead.
-  - `MCPServer.listRoots` and `MCPServer.createMessage` now throw an
-    `RpcException` with `McpErrorCodes.missingRequiredClientCapability` when
-    the client did not declare `roots` or `sampling`, naming the missing
-    capability under `data.requiredCapabilities`, the same way
-    `ElicitationRequestSupport.elicit` already did. The 2026-07-28 revision
-    requires a server not to send a request which relies on a capability the
-    client left out. Both used to send the request anyway, so what came back
+  - On revisions before 2026-07-28, `MCPServer.listRoots` and
+    `MCPServer.createMessage` now throw an `RpcException` with
+    `McpErrorCodes.missingRequiredClientCapability` when the client did not
+    declare `roots` or `sampling`, naming the missing capability under
+    `data.requiredCapabilities`, the same way `ElicitationRequestSupport.elicit`
+    already did. Both used to send the request anyway, so what came back
     depended on the peer: a client with no handler answered `-32601`, and a
     request-scoped transport answered `-32603` because it cannot carry a
     server to client request at all. A server which expects either of those
-    codes for an undeclared capability should read
-    `MCPServer.supportsRoots` or `MCPServer.supportsSampling` first.
+    codes for an undeclared capability should read `MCPServer.supportsRoots`
+    or `MCPServer.supportsSampling` first.
+  - From protocol version 2026-07-28, `MCPServer.listRoots`,
+    `MCPServer.createMessage`, and `ElicitationRequestSupport.elicit` throw an
+    `RpcException` with `-32603` before checking the client capability, even
+    when it is declared. Direct `roots/list`, `sampling/createMessage`, and
+    `elicitation/create` requests are unavailable on that revision and later.
+    The protocol carries them in an `InputRequiredResult` response to
+    `tools/call`, `prompts/get`, or `resources/read`, see
+    https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr.
   - `ResourceLink.icons` is now `List<Icon>?` instead of `List<String>?`, and
     its factory takes the icons, the way the other five types carrying `icons`
     already do. The field has been an array of icons since 2025-11-25 added it,

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -77,9 +77,6 @@ enum ProtocolVersion {
       DiscoverRequest.methodName,
       SubscriptionsListenRequest.methodName,
     },
-    // This revision dropped the `ServerRequest` union, so the three requests
-    // an `InputRequiredResult` carries are listed here too. Their types stay,
-    // because that result still carries them.
     removedMethods: {
       ElicitRequest.methodName,
       InitializeRequest.methodName,

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -77,7 +77,12 @@ enum ProtocolVersion {
       DiscoverRequest.methodName,
       SubscriptionsListenRequest.methodName,
     },
+    // This revision dropped the `ServerRequest` union, so the last three
+    // requests a server could make of a client are here with the rest of what
+    // it took out. Their types stay, because an `InputRequiredResult` carries
+    // them.
     removedMethods: {
+      ElicitRequest.methodName,
       InitializeRequest.methodName,
       SetLevelRequest.methodName,
       ElicitationCompleteNotification.methodName,
@@ -87,6 +92,8 @@ enum ProtocolVersion {
       PingRequest.methodName,
       SubscribeRequest.methodName,
       UnsubscribeRequest.methodName,
+      ListRootsRequest.methodName,
+      CreateMessageRequest.methodName,
       'tasks/cancel',
       'tasks/get',
       'tasks/list',

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -77,9 +77,9 @@ enum ProtocolVersion {
       DiscoverRequest.methodName,
       SubscriptionsListenRequest.methodName,
     },
-    // This revision dropped the `ServerRequest` union, so the last three
-    // requests a server could make of a client are listed here too. Their
-    // types stay, because an `InputRequiredResult` carries them.
+    // This revision dropped the `ServerRequest` union, so the three requests
+    // an `InputRequiredResult` carries are listed here too. Their types stay,
+    // because that result still carries them.
     removedMethods: {
       ElicitRequest.methodName,
       InitializeRequest.methodName,
@@ -109,14 +109,20 @@ enum ProtocolVersion {
   /// The methods this revision introduced.
   final Set<String> addedMethods;
 
-  /// The methods this revision took out.
+  /// The methods this revision stopped accepting.
+  ///
+  /// A method belongs here even when the revision kept its type, as long as it
+  /// took away the way to send it. 2026-07-28 keeps [ElicitRequest],
+  /// [ListRootsRequest] and [CreateMessageRequest] for the [InputRequest] an
+  /// [InputRequiredResult] carries, and none of the three can be sent on its
+  /// own there.
   final Set<String> removedMethods;
 
-  /// Whether [method] is part of this revision.
+  /// Whether [method] is one this revision accepts.
   ///
   /// Walks back from this revision to the first one, so a method holds until
-  /// some later revision removes it. A method no revision ever added is not
-  /// part of any of them.
+  /// some later revision lists it in [removedMethods]. A method no revision
+  /// ever added is not part of any of them.
   bool methodIsValid(String method) {
     for (var version = this; ; version = values[version.index - 1]) {
       if (version.removedMethods.contains(method)) return false;

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -78,9 +78,8 @@ enum ProtocolVersion {
       SubscriptionsListenRequest.methodName,
     },
     // This revision dropped the `ServerRequest` union, so the last three
-    // requests a server could make of a client are here with the rest of what
-    // it took out. Their types stay, because an `InputRequiredResult` carries
-    // them.
+    // requests a server could make of a client are listed here too. Their
+    // types stay, because an `InputRequiredResult` carries them.
     removedMethods: {
       ElicitRequest.methodName,
       InitializeRequest.methodName,

--- a/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
@@ -55,12 +55,11 @@ base mixin ElicitationRequestSupport on LoggingSupport {
   ///
   /// Throws an [RpcException] when [protocolVersion] does not have
   /// `elicitation/create`. 2026-07-28 took it out, and carries an
-  /// [ElicitRequest] in an [InputRequiredResult] instead. 2025-06-18 is the
-  /// revision which added it.
+  /// [ElicitRequest] in an [InputRequiredResult] instead. 2025-06-18 added it.
   ///
-  /// On a revision which has it, this only succeeds if the client has
-  /// advertised the mode the request asks for, as [supportsFormElicitation]
-  /// and [supportsUrlElicitation] read it, and throws an [RpcException] with
+  /// Otherwise this only succeeds if the client has advertised the mode the
+  /// request asks for, as [supportsFormElicitation] and
+  /// [supportsUrlElicitation] read it, and throws an [RpcException] with
   /// [McpErrorCodes.missingRequiredClientCapability] when the client has not,
   /// naming the capability it is missing under `data.requiredCapabilities`.
   ///

--- a/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
@@ -49,22 +49,32 @@ base mixin ElicitationRequestSupport on LoggingSupport {
 
   /// Sends an `elicitation/create` request to the client.
   ///
-  /// This method will only succeed if the client has advertised the mode the
-  /// request asks for, as [supportsFormElicitation] and
-  /// [supportsUrlElicitation] read it.
+  /// On revisions before 2026-07-28, this only succeeds if the client has
+  /// advertised the mode the request asks for, as [supportsFormElicitation]
+  /// and [supportsUrlElicitation] read it.
   ///
   /// Throws an [RpcException] with
   /// [McpErrorCodes.missingRequiredClientCapability] when the client has not,
-  /// naming the capability it is missing under `data.requiredCapabilities`,
-  /// which the 2026-07-28 revision requires of that error.
+  /// naming the capability it is missing under `data.requiredCapabilities`.
   ///
-  /// On 2026-07-28 and later, throws an [RpcException] directing the caller
-  /// to return this request in an [InputRequiredResult].
+  /// From 2026-07-28, throws an [RpcException] before checking that
+  /// capability. The protocol carries an [ElicitRequest] in an
+  /// [InputRequiredResult] on that revision.
   ///
   /// [ToolsSupport.callTool] rethrows an [RpcException] instead of folding it
   /// into a [CallToolResult], so a tool which elicits reaches the client as
   /// that error rather than as a result whose text is a Dart stack trace.
   Future<ElicitResult> elicit(ElicitRequest request) async {
+    if (protocolVersion >= ProtocolVersion.v2026_07_28) {
+      throw RpcException(
+        error_code.INTERNAL_ERROR,
+        'Direct ${ElicitRequest.methodName} requests are unavailable on '
+        'protocol version ${protocolVersion.versionString}. '
+        'InputRequiredResult responses are allowed for '
+        '${CallToolRequest.methodName}, ${GetPromptRequest.methodName}, and '
+        '${ReadResourceRequest.methodName}.',
+      );
+    }
     final raw = request.rawMode;
     if (raw != null && !ElicitationMode.values.any((m) => m.name == raw)) {
       throw RpcException.invalidParams(
@@ -87,16 +97,6 @@ base mixin ElicitationRequestSupport on LoggingSupport {
             ClientCapabilities(elicitation: ElicitationCapability(form: {})),
           );
         }
-    }
-    if (protocolVersion >= ProtocolVersion.v2026_07_28) {
-      throw RpcException(
-        error_code.INTERNAL_ERROR,
-        'The `${ElicitRequest.methodName}` request cannot be sent directly on '
-        'protocol version `${protocolVersion.versionString}` and must be '
-        'returned in an InputRequiredResult for a '
-        '`${CallToolRequest.methodName}`, `${GetPromptRequest.methodName}`, or '
-        '`${ReadResourceRequest.methodName}` request.',
-      );
     }
     return sendRequest(ElicitRequest.methodName, request);
   }

--- a/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
@@ -53,23 +53,22 @@ base mixin ElicitationRequestSupport on LoggingSupport {
 
   /// Sends an `elicitation/create` request to the client.
   ///
-  /// On revisions before 2026-07-28, this only succeeds if the client has
-  /// advertised the mode the request asks for, as [supportsFormElicitation]
-  /// and [supportsUrlElicitation] read it.
+  /// Throws an [RpcException] when [protocolVersion] does not have
+  /// `elicitation/create`. 2026-07-28 took it out, and carries an
+  /// [ElicitRequest] in an [InputRequiredResult] instead. 2025-06-18 is the
+  /// revision which added it.
   ///
-  /// Throws an [RpcException] with
+  /// On a revision which has it, this only succeeds if the client has
+  /// advertised the mode the request asks for, as [supportsFormElicitation]
+  /// and [supportsUrlElicitation] read it, and throws an [RpcException] with
   /// [McpErrorCodes.missingRequiredClientCapability] when the client has not,
   /// naming the capability it is missing under `data.requiredCapabilities`.
-  ///
-  /// From 2026-07-28, throws an [RpcException] before checking that
-  /// capability. The protocol carries an [ElicitRequest] in an
-  /// [InputRequiredResult] on that revision.
   ///
   /// [ToolsSupport.callTool] rethrows an [RpcException] instead of folding it
   /// into a [CallToolResult], so a tool which elicits reaches the client as
   /// that error rather than as a result whose text is a Dart stack trace.
   Future<ElicitResult> elicit(ElicitRequest request) async {
-    _rejectModernDirectRequest(ElicitRequest.methodName, protocolVersion);
+    _rejectRemovedMethod(ElicitRequest.methodName, protocolVersion);
     final raw = request.rawMode;
     if (raw != null && !ElicitationMode.values.any((m) => m.name == raw)) {
       throw RpcException.invalidParams(

--- a/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
@@ -69,16 +69,7 @@ base mixin ElicitationRequestSupport on LoggingSupport {
   /// into a [CallToolResult], so a tool which elicits reaches the client as
   /// that error rather than as a result whose text is a Dart stack trace.
   Future<ElicitResult> elicit(ElicitRequest request) async {
-    if (protocolVersion >= ProtocolVersion.v2026_07_28) {
-      throw RpcException(
-        error_code.INTERNAL_ERROR,
-        'Direct ${ElicitRequest.methodName} requests are unavailable on '
-        'protocol version ${protocolVersion.versionString}. '
-        'InputRequiredResult responses are allowed for '
-        '${CallToolRequest.methodName}, ${GetPromptRequest.methodName}, and '
-        '${ReadResourceRequest.methodName}.',
-      );
-    }
+    _rejectModernDirectRequest(ElicitRequest.methodName, protocolVersion);
     final raw = request.rawMode;
     if (raw != null && !ElicitationMode.values.any((m) => m.name == raw)) {
       throw RpcException.invalidParams(

--- a/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/elicitation_request_support.dart
@@ -58,6 +58,9 @@ base mixin ElicitationRequestSupport on LoggingSupport {
   /// naming the capability it is missing under `data.requiredCapabilities`,
   /// which the 2026-07-28 revision requires of that error.
   ///
+  /// On 2026-07-28 and later, throws an [RpcException] directing the caller
+  /// to return this request in an [InputRequiredResult].
+  ///
   /// [ToolsSupport.callTool] rethrows an [RpcException] instead of folding it
   /// into a [CallToolResult], so a tool which elicits reaches the client as
   /// that error rather than as a result whose text is a Dart stack trace.
@@ -84,6 +87,16 @@ base mixin ElicitationRequestSupport on LoggingSupport {
             ClientCapabilities(elicitation: ElicitationCapability(form: {})),
           );
         }
+    }
+    if (protocolVersion >= ProtocolVersion.v2026_07_28) {
+      throw RpcException(
+        error_code.INTERNAL_ERROR,
+        'The `${ElicitRequest.methodName}` request cannot be sent directly on '
+        'protocol version `${protocolVersion.versionString}` and must be '
+        'returned in an InputRequiredResult for a '
+        '`${CallToolRequest.methodName}`, `${GetPromptRequest.methodName}`, or '
+        '`${ReadResourceRequest.methodName}` request.',
+      );
     }
     return sendRequest(ElicitRequest.methodName, request);
   }

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -63,13 +63,13 @@ typedef MCPServerFactory =
 /// [onNotification] are reported as uncaught errors and do not fail the
 /// exchange.
 ///
-/// On revisions before 2026-07-28, server-to-client requests such as
-/// `roots/list` can reach this exchange but cannot be answered within it. They
-/// fail with an [RpcException] inside their handler, or with a [StateError] if
-/// the exchange has already been torn down. From 2026-07-28,
+/// A server-to-client request such as `roots/list` reaches this exchange on a
+/// revision which has it, and cannot be answered within it. It fails with an
+/// [RpcException] inside its handler, or with a [StateError] if the exchange
+/// has already been torn down. On a revision which does not have it,
 /// [MCPServer.listRoots], [MCPServer.createMessage], and
-/// [ElicitationRequestSupport.elicit] reject direct requests before reaching
-/// this exchange.
+/// [ElicitationRequestSupport.elicit] refuse it before it gets here, which is
+/// all three of them on 2026-07-28.
 ///
 /// Throws an [ArgumentError] if [message] is not a JSON-RPC request or
 /// notification (no string `method`, a `null` id, or a `result` or `error`

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -63,13 +63,13 @@ typedef MCPServerFactory =
 /// [onNotification] are reported as uncaught errors and do not fail the
 /// exchange.
 ///
-/// A server-to-client request such as `roots/list` reaches this exchange on a
-/// revision which has it, and cannot be answered within it. It fails with an
-/// [RpcException] inside its handler, or with a [StateError] if the exchange
-/// has already been torn down. On a revision which does not have it,
+/// Requests from the server back to the client, such as `roots/list`, cannot
+/// be answered within a single-message exchange: they fail with an
+/// [RpcException] inside their handler, or with a [StateError] if the exchange
+/// has already been torn down. When the negotiated revision does not have one,
 /// [MCPServer.listRoots], [MCPServer.createMessage], and
-/// [ElicitationRequestSupport.elicit] refuse it before it gets here, which is
-/// all three of them on 2026-07-28.
+/// [ElicitationRequestSupport.elicit] refuse it up front, so it never gets this
+/// far. 2026-07-28 has none of the three.
 ///
 /// Throws an [ArgumentError] if [message] is not a JSON-RPC request or
 /// notification (no string `method`, a `null` id, or a `result` or `error`

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -68,8 +68,9 @@ typedef MCPServerFactory =
 /// [RpcException] inside their handler, or with a [StateError] if the exchange
 /// has already been torn down. When the negotiated revision does not have one,
 /// [MCPServer.listRoots], [MCPServer.createMessage], and
-/// [ElicitationRequestSupport.elicit] refuse it up front, so it never gets this
-/// far. 2026-07-28 has none of the three.
+/// [ElicitationRequestSupport.elicit] refuse it before it gets this far.
+/// 2026-07-28 has none of the three. It dropped [MCPBase.ping] too, and that
+/// one is not gated, so a ping still fails inside its handler.
 ///
 /// Throws an [ArgumentError] if [message] is not a JSON-RPC request or
 /// notification (no string `method`, a `null` id, or a `result` or `error`

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -63,10 +63,13 @@ typedef MCPServerFactory =
 /// [onNotification] are reported as uncaught errors and do not fail the
 /// exchange.
 ///
-/// Requests from the server back to the client, such as `roots/list`, cannot
-/// be answered within a single-message exchange: they fail with an
-/// [RpcException] inside their handler, or with a [StateError] if the exchange
-/// has already been torn down.
+/// On revisions before 2026-07-28, server-to-client requests such as
+/// `roots/list` can reach this exchange but cannot be answered within it. They
+/// fail with an [RpcException] inside their handler, or with a [StateError] if
+/// the exchange has already been torn down. From 2026-07-28,
+/// [MCPServer.listRoots], [MCPServer.createMessage], and
+/// [ElicitationRequestSupport.elicit] reject direct requests before reaching
+/// this exchange.
 ///
 /// Throws an [ArgumentError] if [message] is not a JSON-RPC request or
 /// notification (no string `method`, a `null` id, or a `result` or `error`
@@ -75,6 +78,8 @@ typedef MCPServerFactory =
 /// request-scoped is the transport's job. Errors thrown by [serverFactory] or
 /// by [MCPServer.initialize] propagate to the caller; a server that was
 /// created is shut down first.
+// TODO: Route server-to-client requests on revisions before 2026-07-28.
+// https://github.com/dart-lang/ai/issues/162
 Future<Map<String, Object?>?> handleRequestScopedMessage(
   Map<String, Object?> message,
   MCPServerInitialization initialization,

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -75,8 +75,6 @@ typedef MCPServerFactory =
 /// request-scoped is the transport's job. Errors thrown by [serverFactory] or
 /// by [MCPServer.initialize] propagate to the caller; a server that was
 /// created is shut down first.
-// TODO: Support server-to-client requests once a transport can route them.
-// https://github.com/dart-lang/ai/issues/162
 Future<Map<String, Object?>?> handleRequestScopedMessage(
   Map<String, Object?> message,
   MCPServerInitialization initialization,

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -69,8 +69,9 @@ typedef MCPServerFactory =
 /// has already been torn down. When the negotiated revision does not have one,
 /// [MCPServer.listRoots], [MCPServer.createMessage], and
 /// [ElicitationRequestSupport.elicit] refuse it before it gets this far.
-/// 2026-07-28 has none of the three. It dropped [MCPBase.ping] too, and that
-/// one is not gated, so a ping still fails inside its handler.
+/// 2026-07-28 has none of the three. It dropped `ping` as well, and
+/// [MCPBase.ping] does not read the revision, so a ping still fails inside its
+/// handler.
 ///
 /// Throws an [ArgumentError] if [message] is not a JSON-RPC request or
 /// notification (no string `method`, a `null` id, or a `result` or `error`

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -344,12 +344,19 @@ abstract base class MCPServer extends MCPBase {
 /// server can make of a client end up here on that revision.
 void _rejectRemovedMethod(String method, ProtocolVersion protocolVersion) {
   if (protocolVersion.methodIsValid(method)) return;
+  // Only a revision which has `InputRequiredResult` can be pointed at it, and
+  // `elicit` also lands here on the revisions before 2025-06-18 added
+  // `elicitation/create`.
+  final replacement =
+      protocolVersion >= ProtocolVersion.v2026_07_28
+          ? ' Ask the client for input with an InputRequiredResult on '
+              '${CallToolRequest.methodName}, ${GetPromptRequest.methodName}, '
+              'or ${ReadResourceRequest.methodName} instead.'
+          : '';
   throw RpcException(
     error_code.INTERNAL_ERROR,
-    'Protocol version ${protocolVersion.versionString} does not have $method. '
-    'From 2026-07-28 a server asks the client for input with an '
-    'InputRequiredResult on ${CallToolRequest.methodName}, '
-    '${GetPromptRequest.methodName}, or ${ReadResourceRequest.methodName}.',
+    'Protocol version ${protocolVersion.versionString} does not have '
+    '$method.$replacement',
   );
 }
 

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -340,8 +340,8 @@ abstract base class MCPServer extends MCPBase {
 /// Refuses to send [method] when [ProtocolVersion.methodIsValid] says
 /// [protocolVersion] does not have it.
 ///
-/// 2026-07-28 dropped the `ServerRequest` union, so the three requests an
-/// [InputRequiredResult] carries end up here on that revision.
+/// Each sender calls this first, so a method the revision does not have fails
+/// for that reason instead of for a missing client capability.
 void _rejectRemovedMethod(String method, ProtocolVersion protocolVersion) {
   if (protocolVersion.methodIsValid(method)) return;
   // Only a revision with an `InputRequiredResult` can be pointed at it, and

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -296,8 +296,8 @@ abstract base class MCPServer extends MCPBase {
   /// `roots/list`. 2026-07-28 took it out, and carries a [ListRootsRequest]
   /// in an [InputRequiredResult] instead.
   ///
-  /// On a revision which has it, this only succeeds if the client has
-  /// advertised the `roots` capability, and throws an [RpcException] with
+  /// Otherwise this only succeeds if the client has advertised the `roots`
+  /// capability, and throws an [RpcException] with
   /// [McpErrorCodes.missingRequiredClientCapability] when it has not, naming
   /// the capability the client is missing under `data.requiredCapabilities`.
   Future<ListRootsResult> listRoots([ListRootsRequest? request]) async {
@@ -319,8 +319,8 @@ abstract base class MCPServer extends MCPBase {
   /// `sampling/createMessage`. 2026-07-28 took it out, and carries a
   /// [CreateMessageRequest] in an [InputRequiredResult] instead.
   ///
-  /// On a revision which has it, this only succeeds if the client has
-  /// advertised the `sampling` capability, and throws an [RpcException] with
+  /// Otherwise this only succeeds if the client has advertised the `sampling`
+  /// capability, and throws an [RpcException] with
   /// [McpErrorCodes.missingRequiredClientCapability] when it has not, naming
   /// the capability the client is missing under `data.requiredCapabilities`.
   Future<CreateMessageResult> createMessage(
@@ -337,12 +337,11 @@ abstract base class MCPServer extends MCPBase {
   }
 }
 
-/// Refuses to send [method] when [protocolVersion] does not have it, which
-/// [ProtocolVersion.methodIsValid] answers.
+/// Refuses to send [method] when [ProtocolVersion.methodIsValid] says
+/// [protocolVersion] does not have it.
 ///
-/// 2026-07-28 took the three requests a server can make of a client out with
-/// the rest of the `ServerRequest` union, so on that revision all three end up
-/// here.
+/// 2026-07-28 dropped the `ServerRequest` union, so all three requests a
+/// server can make of a client end up here on that revision.
 void _rejectRemovedMethod(String method, ProtocolVersion protocolVersion) {
   if (protocolVersion.methodIsValid(method)) return;
   throw RpcException(

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -340,8 +340,8 @@ abstract base class MCPServer extends MCPBase {
 /// Refuses to send [method] when [ProtocolVersion.methodIsValid] says
 /// [protocolVersion] does not have it.
 ///
-/// 2026-07-28 dropped the `ServerRequest` union, so all three requests a
-/// server can make of a client end up here on that revision.
+/// 2026-07-28 dropped the `ServerRequest` union, so the three requests an
+/// [InputRequiredResult] carries end up here on that revision.
 void _rejectRemovedMethod(String method, ProtocolVersion protocolVersion) {
   if (protocolVersion.methodIsValid(method)) return;
   // Only a revision with an `InputRequiredResult` can be pointed at it, and

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -292,18 +292,16 @@ abstract base class MCPServer extends MCPBase {
 
   /// Lists all the root URIs from the client.
   ///
-  /// On revisions before 2026-07-28, this only succeeds if the client has
-  /// advertised the `roots` capability.
+  /// Throws an [RpcException] when [protocolVersion] does not have
+  /// `roots/list`. 2026-07-28 took it out, and carries a [ListRootsRequest]
+  /// in an [InputRequiredResult] instead.
   ///
-  /// Throws an [RpcException] with
+  /// On a revision which has it, this only succeeds if the client has
+  /// advertised the `roots` capability, and throws an [RpcException] with
   /// [McpErrorCodes.missingRequiredClientCapability] when it has not, naming
   /// the capability the client is missing under `data.requiredCapabilities`.
-  ///
-  /// From 2026-07-28, throws an [RpcException] before checking that
-  /// capability. The protocol carries a [ListRootsRequest] in an
-  /// [InputRequiredResult] on that revision.
   Future<ListRootsResult> listRoots([ListRootsRequest? request]) async {
-    _rejectModernDirectRequest(ListRootsRequest.methodName, protocolVersion);
+    _rejectRemovedMethod(ListRootsRequest.methodName, protocolVersion);
     if (!supportsRoots) {
       throw _missingClientCapability(
         'roots',
@@ -317,23 +315,18 @@ abstract base class MCPServer extends MCPBase {
   ///
   /// See https://modelcontextprotocol.io/specification/2026-07-28/client/sampling/.
   ///
-  /// On revisions before 2026-07-28, this only succeeds if the client has
-  /// advertised the `sampling` capability.
+  /// Throws an [RpcException] when [protocolVersion] does not have
+  /// `sampling/createMessage`. 2026-07-28 took it out, and carries a
+  /// [CreateMessageRequest] in an [InputRequiredResult] instead.
   ///
-  /// Throws an [RpcException] with
+  /// On a revision which has it, this only succeeds if the client has
+  /// advertised the `sampling` capability, and throws an [RpcException] with
   /// [McpErrorCodes.missingRequiredClientCapability] when it has not, naming
   /// the capability the client is missing under `data.requiredCapabilities`.
-  ///
-  /// From 2026-07-28, throws an [RpcException] before checking that
-  /// capability. The protocol carries a [CreateMessageRequest] in an
-  /// [InputRequiredResult] on that revision.
   Future<CreateMessageResult> createMessage(
     CreateMessageRequest request,
   ) async {
-    _rejectModernDirectRequest(
-      CreateMessageRequest.methodName,
-      protocolVersion,
-    );
+    _rejectRemovedMethod(CreateMessageRequest.methodName, protocolVersion);
     if (!supportsSampling) {
       throw _missingClientCapability(
         'sampling',
@@ -344,17 +337,20 @@ abstract base class MCPServer extends MCPBase {
   }
 }
 
-void _rejectModernDirectRequest(
-  String method,
-  ProtocolVersion protocolVersion,
-) {
-  if (protocolVersion < ProtocolVersion.v2026_07_28) return;
+/// Refuses to send [method] when [protocolVersion] does not have it, which
+/// [ProtocolVersion.methodIsValid] answers.
+///
+/// 2026-07-28 took the three requests a server can make of a client out with
+/// the rest of the `ServerRequest` union, so on that revision all three end up
+/// here.
+void _rejectRemovedMethod(String method, ProtocolVersion protocolVersion) {
+  if (protocolVersion.methodIsValid(method)) return;
   throw RpcException(
     error_code.INTERNAL_ERROR,
-    'Direct $method requests are unavailable on protocol version '
-    '${protocolVersion.versionString}. InputRequiredResult responses are '
-    'allowed for ${CallToolRequest.methodName}, '
-    '${GetPromptRequest.methodName}, and ${ReadResourceRequest.methodName}.',
+    'Protocol version ${protocolVersion.versionString} does not have $method. '
+    'From 2026-07-28 a server asks the client for input with an '
+    'InputRequiredResult on ${CallToolRequest.methodName}, '
+    '${GetPromptRequest.methodName}, or ${ReadResourceRequest.methodName}.',
   );
 }
 

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -299,11 +299,24 @@ abstract base class MCPServer extends MCPBase {
   /// [McpErrorCodes.missingRequiredClientCapability] when it has not, naming
   /// the capability the client is missing under `data.requiredCapabilities`,
   /// which the 2026-07-28 revision requires of that error.
+  ///
+  /// On 2026-07-28 and later, throws an [RpcException] directing the caller
+  /// to return this request in an [InputRequiredResult].
   Future<ListRootsResult> listRoots([ListRootsRequest? request]) async {
     if (!supportsRoots) {
       throw _missingClientCapability(
         'roots',
         ClientCapabilities(roots: RootsCapabilities()),
+      );
+    }
+    if (protocolVersion >= ProtocolVersion.v2026_07_28) {
+      throw RpcException(
+        error_code.INTERNAL_ERROR,
+        'The `${ListRootsRequest.methodName}` request cannot be sent directly '
+        'on protocol version `${protocolVersion.versionString}` and must be '
+        'returned in an InputRequiredResult for a '
+        '`${CallToolRequest.methodName}`, `${GetPromptRequest.methodName}`, or '
+        '`${ReadResourceRequest.methodName}` request.',
       );
     }
     return sendRequest(ListRootsRequest.methodName, request);
@@ -320,6 +333,9 @@ abstract base class MCPServer extends MCPBase {
   /// [McpErrorCodes.missingRequiredClientCapability] when it has not, naming
   /// the capability the client is missing under `data.requiredCapabilities`,
   /// which the 2026-07-28 revision requires of that error.
+  ///
+  /// On 2026-07-28 and later, throws an [RpcException] directing the caller
+  /// to return this request in an [InputRequiredResult].
   Future<CreateMessageResult> createMessage(
     CreateMessageRequest request,
   ) async {
@@ -327,6 +343,16 @@ abstract base class MCPServer extends MCPBase {
       throw _missingClientCapability(
         'sampling',
         ClientCapabilities(sampling: {}),
+      );
+    }
+    if (protocolVersion >= ProtocolVersion.v2026_07_28) {
+      throw RpcException(
+        error_code.INTERNAL_ERROR,
+        'The `${CreateMessageRequest.methodName}` request cannot be sent '
+        'directly on protocol version `${protocolVersion.versionString}` and '
+        'must be returned in an InputRequiredResult for a '
+        '`${CallToolRequest.methodName}`, `${GetPromptRequest.methodName}`, or '
+        '`${ReadResourceRequest.methodName}` request.',
       );
     }
     return sendRequest(CreateMessageRequest.methodName, request);

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -344,7 +344,7 @@ abstract base class MCPServer extends MCPBase {
 /// server can make of a client end up here on that revision.
 void _rejectRemovedMethod(String method, ProtocolVersion protocolVersion) {
   if (protocolVersion.methodIsValid(method)) return;
-  // Only a revision which has `InputRequiredResult` can be pointed at it, and
+  // Only a revision with an `InputRequiredResult` can be pointed at it, and
   // `elicit` also lands here on the revisions before 2025-06-18 added
   // `elicitation/create`.
   final replacement =

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -292,31 +292,31 @@ abstract base class MCPServer extends MCPBase {
 
   /// Lists all the root URIs from the client.
   ///
-  /// This method will only succeed if the client has advertised the `roots`
-  /// capability.
+  /// On revisions before 2026-07-28, this only succeeds if the client has
+  /// advertised the `roots` capability.
   ///
   /// Throws an [RpcException] with
   /// [McpErrorCodes.missingRequiredClientCapability] when it has not, naming
-  /// the capability the client is missing under `data.requiredCapabilities`,
-  /// which the 2026-07-28 revision requires of that error.
+  /// the capability the client is missing under `data.requiredCapabilities`.
   ///
-  /// On 2026-07-28 and later, throws an [RpcException] directing the caller
-  /// to return this request in an [InputRequiredResult].
+  /// From 2026-07-28, throws an [RpcException] before checking that
+  /// capability. The protocol carries a [ListRootsRequest] in an
+  /// [InputRequiredResult] on that revision.
   Future<ListRootsResult> listRoots([ListRootsRequest? request]) async {
+    if (protocolVersion >= ProtocolVersion.v2026_07_28) {
+      throw RpcException(
+        error_code.INTERNAL_ERROR,
+        'Direct ${ListRootsRequest.methodName} requests are unavailable on '
+        'protocol version ${protocolVersion.versionString}. '
+        'InputRequiredResult responses are allowed for '
+        '${CallToolRequest.methodName}, ${GetPromptRequest.methodName}, and '
+        '${ReadResourceRequest.methodName}.',
+      );
+    }
     if (!supportsRoots) {
       throw _missingClientCapability(
         'roots',
         ClientCapabilities(roots: RootsCapabilities()),
-      );
-    }
-    if (protocolVersion >= ProtocolVersion.v2026_07_28) {
-      throw RpcException(
-        error_code.INTERNAL_ERROR,
-        'The `${ListRootsRequest.methodName}` request cannot be sent directly '
-        'on protocol version `${protocolVersion.versionString}` and must be '
-        'returned in an InputRequiredResult for a '
-        '`${CallToolRequest.methodName}`, `${GetPromptRequest.methodName}`, or '
-        '`${ReadResourceRequest.methodName}` request.',
       );
     }
     return sendRequest(ListRootsRequest.methodName, request);
@@ -324,35 +324,35 @@ abstract base class MCPServer extends MCPBase {
 
   /// A request to prompt the LLM owned by the client with a message.
   ///
-  /// See https://modelcontextprotocol.io/specification/2025-11-25/client/sampling/.
+  /// See https://modelcontextprotocol.io/specification/2026-07-28/client/sampling/.
   ///
-  /// This method will only succeed if the client has advertised the `sampling`
-  /// capability.
+  /// On revisions before 2026-07-28, this only succeeds if the client has
+  /// advertised the `sampling` capability.
   ///
   /// Throws an [RpcException] with
   /// [McpErrorCodes.missingRequiredClientCapability] when it has not, naming
-  /// the capability the client is missing under `data.requiredCapabilities`,
-  /// which the 2026-07-28 revision requires of that error.
+  /// the capability the client is missing under `data.requiredCapabilities`.
   ///
-  /// On 2026-07-28 and later, throws an [RpcException] directing the caller
-  /// to return this request in an [InputRequiredResult].
+  /// From 2026-07-28, throws an [RpcException] before checking that
+  /// capability. The protocol carries a [CreateMessageRequest] in an
+  /// [InputRequiredResult] on that revision.
   Future<CreateMessageResult> createMessage(
     CreateMessageRequest request,
   ) async {
+    if (protocolVersion >= ProtocolVersion.v2026_07_28) {
+      throw RpcException(
+        error_code.INTERNAL_ERROR,
+        'Direct ${CreateMessageRequest.methodName} requests are unavailable '
+        'on protocol version ${protocolVersion.versionString}. '
+        'InputRequiredResult responses are allowed for '
+        '${CallToolRequest.methodName}, ${GetPromptRequest.methodName}, and '
+        '${ReadResourceRequest.methodName}.',
+      );
+    }
     if (!supportsSampling) {
       throw _missingClientCapability(
         'sampling',
         ClientCapabilities(sampling: {}),
-      );
-    }
-    if (protocolVersion >= ProtocolVersion.v2026_07_28) {
-      throw RpcException(
-        error_code.INTERNAL_ERROR,
-        'The `${CreateMessageRequest.methodName}` request cannot be sent '
-        'directly on protocol version `${protocolVersion.versionString}` and '
-        'must be returned in an InputRequiredResult for a '
-        '`${CallToolRequest.methodName}`, `${GetPromptRequest.methodName}`, or '
-        '`${ReadResourceRequest.methodName}` request.',
       );
     }
     return sendRequest(CreateMessageRequest.methodName, request);

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -303,16 +303,7 @@ abstract base class MCPServer extends MCPBase {
   /// capability. The protocol carries a [ListRootsRequest] in an
   /// [InputRequiredResult] on that revision.
   Future<ListRootsResult> listRoots([ListRootsRequest? request]) async {
-    if (protocolVersion >= ProtocolVersion.v2026_07_28) {
-      throw RpcException(
-        error_code.INTERNAL_ERROR,
-        'Direct ${ListRootsRequest.methodName} requests are unavailable on '
-        'protocol version ${protocolVersion.versionString}. '
-        'InputRequiredResult responses are allowed for '
-        '${CallToolRequest.methodName}, ${GetPromptRequest.methodName}, and '
-        '${ReadResourceRequest.methodName}.',
-      );
-    }
+    _rejectModernDirectRequest(ListRootsRequest.methodName, protocolVersion);
     if (!supportsRoots) {
       throw _missingClientCapability(
         'roots',
@@ -339,16 +330,10 @@ abstract base class MCPServer extends MCPBase {
   Future<CreateMessageResult> createMessage(
     CreateMessageRequest request,
   ) async {
-    if (protocolVersion >= ProtocolVersion.v2026_07_28) {
-      throw RpcException(
-        error_code.INTERNAL_ERROR,
-        'Direct ${CreateMessageRequest.methodName} requests are unavailable '
-        'on protocol version ${protocolVersion.versionString}. '
-        'InputRequiredResult responses are allowed for '
-        '${CallToolRequest.methodName}, ${GetPromptRequest.methodName}, and '
-        '${ReadResourceRequest.methodName}.',
-      );
-    }
+    _rejectModernDirectRequest(
+      CreateMessageRequest.methodName,
+      protocolVersion,
+    );
     if (!supportsSampling) {
       throw _missingClientCapability(
         'sampling',
@@ -357,6 +342,20 @@ abstract base class MCPServer extends MCPBase {
     }
     return sendRequest(CreateMessageRequest.methodName, request);
   }
+}
+
+void _rejectModernDirectRequest(
+  String method,
+  ProtocolVersion protocolVersion,
+) {
+  if (protocolVersion < ProtocolVersion.v2026_07_28) return;
+  throw RpcException(
+    error_code.INTERNAL_ERROR,
+    'Direct $method requests are unavailable on protocol version '
+    '${protocolVersion.versionString}. InputRequiredResult responses are '
+    'allowed for ${CallToolRequest.methodName}, '
+    '${GetPromptRequest.methodName}, and ${ReadResourceRequest.methodName}.',
+  );
 }
 
 /// The error a server must return when handling a request needs [capability],

--- a/pkgs/dart_mcp/test/api/api_test.dart
+++ b/pkgs/dart_mcp/test/api/api_test.dart
@@ -99,7 +99,7 @@ void main() {
     expect(ProtocolVersion.v2026_07_28.methodIsValid('server/discover'), true);
   });
 
-  test('the 2026-07-28 revision removes the methods it stopped accepting', () {
+  test('the 2026-07-28 removal set is pinned', () {
     // Pinned so an entry cannot fall out of the set unnoticed. The walk test
     // below reads the set and would follow it. `elicitation/create`,
     // `roots/list`, and `sampling/createMessage` are in here with their types

--- a/pkgs/dart_mcp/test/api/api_test.dart
+++ b/pkgs/dart_mcp/test/api/api_test.dart
@@ -103,6 +103,7 @@ void main() {
     // Pinned against the schema so an entry cannot fall out of the set
     // unnoticed; the walk test below reads the set and would follow it.
     expect(ProtocolVersion.v2026_07_28.removedMethods, {
+      'elicitation/create',
       'initialize',
       'logging/setLevel',
       'notifications/elicitation/complete',
@@ -112,6 +113,8 @@ void main() {
       'ping',
       'resources/subscribe',
       'resources/unsubscribe',
+      'roots/list',
+      'sampling/createMessage',
       'tasks/cancel',
       'tasks/get',
       'tasks/list',

--- a/pkgs/dart_mcp/test/api/api_test.dart
+++ b/pkgs/dart_mcp/test/api/api_test.dart
@@ -99,12 +99,12 @@ void main() {
     expect(ProtocolVersion.v2026_07_28.methodIsValid('server/discover'), true);
   });
 
-  test('the 2026-07-28 revision removes more than its schema does', () {
-    // Pinned so an entry cannot fall out of the set unnoticed; the walk test
+  test('the 2026-07-28 revision removes the methods it stopped accepting', () {
+    // Pinned so an entry cannot fall out of the set unnoticed. The walk test
     // below reads the set and would follow it. `elicitation/create`,
-    // `roots/list`, and `sampling/createMessage` are in it because that
-    // revision dropped the `ServerRequest` union that carried them, not
-    // because their types went: those stay, for `InputRequiredResult`.
+    // `roots/list`, and `sampling/createMessage` are in here with their types
+    // intact, because that revision left them only as an `InputRequest`
+    // inside an `InputRequiredResult`.
     expect(ProtocolVersion.v2026_07_28.removedMethods, {
       'elicitation/create',
       'initialize',

--- a/pkgs/dart_mcp/test/api/api_test.dart
+++ b/pkgs/dart_mcp/test/api/api_test.dart
@@ -99,9 +99,12 @@ void main() {
     expect(ProtocolVersion.v2026_07_28.methodIsValid('server/discover'), true);
   });
 
-  test('the 2026-07-28 revision removes what its schema removed', () {
-    // Pinned against the schema so an entry cannot fall out of the set
-    // unnoticed; the walk test below reads the set and would follow it.
+  test('the 2026-07-28 revision removes more than its schema does', () {
+    // Pinned so an entry cannot fall out of the set unnoticed; the walk test
+    // below reads the set and would follow it. `elicitation/create`,
+    // `roots/list`, and `sampling/createMessage` are in it because that
+    // revision dropped the `ServerRequest` union that carried them, not
+    // because their types went: those stay, for `InputRequiredResult`.
     expect(ProtocolVersion.v2026_07_28.removedMethods, {
       'elicitation/create',
       'initialize',

--- a/pkgs/dart_mcp/test/api/api_test.dart
+++ b/pkgs/dart_mcp/test/api/api_test.dart
@@ -101,10 +101,7 @@ void main() {
 
   test('the 2026-07-28 removal set is pinned', () {
     // Pinned so an entry cannot fall out of the set unnoticed. The walk test
-    // below reads the set and would follow it. `elicitation/create`,
-    // `roots/list`, and `sampling/createMessage` are in here with their types
-    // intact, because that revision left them only as an `InputRequest`
-    // inside an `InputRequiredResult`.
+    // below reads the set and would follow it.
     expect(ProtocolVersion.v2026_07_28.removedMethods, {
       'elicitation/create',
       'initialize',

--- a/pkgs/dart_mcp/test/server/client_capability_guard_test.dart
+++ b/pkgs/dart_mcp/test/server/client_capability_guard_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:dart_mcp/server.dart';
 import 'package:dart_mcp/src/utils/constants.dart';
+import 'package:json_rpc_2/error_code.dart' as error_code;
 import 'package:test/test.dart';
 
 final class _RequestingServer extends MCPServer
@@ -73,20 +74,36 @@ void main() {
     },
   );
 
-  test('a declared capability reaches the transport instead', () async {
-    // The request-scoped transport cannot carry a server to client request, so
-    // it answers with its own error. Reaching that error is what shows the
-    // guard let the request through.
+  test('declared sampling stops before the request-scoped transport', () async {
     final result = await _callTool(
       'test/sample',
       ClientCapabilities(sampling: {}),
     );
 
     final error = result![Keys.error] as Map<String, Object?>;
+    expect(error[Keys.code], error_code.INTERNAL_ERROR);
     expect(
-      error[Keys.code],
-      isNot(McpErrorCodes.missingRequiredClientCapability),
+      error[Keys.message],
+      'The `sampling/createMessage` request cannot be sent directly on '
+      'protocol version `2026-07-28` and must be returned in an '
+      'InputRequiredResult for a `tools/call`, `prompts/get`, or '
+      '`resources/read` request.',
     );
-    expect(error[Keys.message], contains('request-scoped transport'));
+  });
+
+  test('declared roots stop before the request-scoped transport', () async {
+    final result = await _callTool(
+      'test/roots',
+      ClientCapabilities(roots: RootsCapabilities()),
+    );
+
+    final error = result![Keys.error] as Map<String, Object?>;
+    expect(error[Keys.code], error_code.INTERNAL_ERROR);
+    expect(
+      error[Keys.message],
+      'The `roots/list` request cannot be sent directly on protocol version '
+      '`2026-07-28` and must be returned in an InputRequiredResult for a '
+      '`tools/call`, `prompts/get`, or `resources/read` request.',
+    );
   });
 }

--- a/pkgs/dart_mcp/test/server/client_capability_guard_test.dart
+++ b/pkgs/dart_mcp/test/server/client_capability_guard_test.dart
@@ -30,8 +30,9 @@ final class _RequestingServer extends MCPServer
 
 Future<Map<String, Object?>?> _callTool(
   String name,
-  ClientCapabilities capabilities,
-) => handleRequestScopedMessage(
+  ClientCapabilities capabilities, {
+  ProtocolVersion protocolVersion = ProtocolVersion.v2025_11_25,
+}) => handleRequestScopedMessage(
   {
     Keys.jsonrpc: '2.0',
     Keys.id: 1,
@@ -39,7 +40,7 @@ Future<Map<String, Object?>?> _callTool(
     Keys.params: {Keys.name: name},
   },
   MCPServerInitialization(
-    protocolVersion: ProtocolVersion.v2026_07_28,
+    protocolVersion: protocolVersion,
     clientCapabilities: capabilities,
   ),
   _RequestingServer.new,
@@ -74,36 +75,47 @@ void main() {
     },
   );
 
-  test('declared sampling stops before the request-scoped transport', () async {
-    final result = await _callTool(
-      'test/sample',
+  test('2026-07-28 rejects sampling before capability checks', () async {
+    for (final capabilities in [
+      ClientCapabilities(),
       ClientCapabilities(sampling: {}),
-    );
+    ]) {
+      final result = await _callTool(
+        'test/sample',
+        capabilities,
+        protocolVersion: ProtocolVersion.v2026_07_28,
+      );
 
-    final error = result![Keys.error] as Map<String, Object?>;
-    expect(error[Keys.code], error_code.INTERNAL_ERROR);
-    expect(
-      error[Keys.message],
-      'The `sampling/createMessage` request cannot be sent directly on '
-      'protocol version `2026-07-28` and must be returned in an '
-      'InputRequiredResult for a `tools/call`, `prompts/get`, or '
-      '`resources/read` request.',
-    );
+      final error = result![Keys.error] as Map<String, Object?>;
+      expect(error[Keys.code], error_code.INTERNAL_ERROR);
+      expect(
+        error[Keys.message],
+        'Direct sampling/createMessage requests are unavailable on protocol '
+        'version 2026-07-28. InputRequiredResult responses are allowed for '
+        'tools/call, prompts/get, and resources/read.',
+      );
+    }
   });
 
-  test('declared roots stop before the request-scoped transport', () async {
-    final result = await _callTool(
-      'test/roots',
+  test('2026-07-28 rejects roots before capability checks', () async {
+    for (final capabilities in [
+      ClientCapabilities(),
       ClientCapabilities(roots: RootsCapabilities()),
-    );
+    ]) {
+      final result = await _callTool(
+        'test/roots',
+        capabilities,
+        protocolVersion: ProtocolVersion.v2026_07_28,
+      );
 
-    final error = result![Keys.error] as Map<String, Object?>;
-    expect(error[Keys.code], error_code.INTERNAL_ERROR);
-    expect(
-      error[Keys.message],
-      'The `roots/list` request cannot be sent directly on protocol version '
-      '`2026-07-28` and must be returned in an InputRequiredResult for a '
-      '`tools/call`, `prompts/get`, or `resources/read` request.',
-    );
+      final error = result![Keys.error] as Map<String, Object?>;
+      expect(error[Keys.code], error_code.INTERNAL_ERROR);
+      expect(
+        error[Keys.message],
+        'Direct roots/list requests are unavailable on protocol version '
+        '2026-07-28. InputRequiredResult responses are allowed for '
+        'tools/call, prompts/get, and resources/read.',
+      );
+    }
   });
 }

--- a/pkgs/dart_mcp/test/server/client_capability_guard_test.dart
+++ b/pkgs/dart_mcp/test/server/client_capability_guard_test.dart
@@ -90,9 +90,7 @@ void main() {
       expect(error[Keys.code], error_code.INTERNAL_ERROR);
       expect(
         error[Keys.message],
-        'Protocol version 2026-07-28 does not have sampling/createMessage. '
-        'From 2026-07-28 a server asks the client for input with an '
-        'InputRequiredResult on tools/call, prompts/get, or resources/read.',
+        contains('2026-07-28 does not have sampling/createMessage'),
       );
     }
   });
@@ -112,9 +110,7 @@ void main() {
       expect(error[Keys.code], error_code.INTERNAL_ERROR);
       expect(
         error[Keys.message],
-        'Protocol version 2026-07-28 does not have roots/list. From '
-        '2026-07-28 a server asks the client for input with an '
-        'InputRequiredResult on tools/call, prompts/get, or resources/read.',
+        contains('2026-07-28 does not have roots/list'),
       );
     }
   });

--- a/pkgs/dart_mcp/test/server/client_capability_guard_test.dart
+++ b/pkgs/dart_mcp/test/server/client_capability_guard_test.dart
@@ -90,9 +90,9 @@ void main() {
       expect(error[Keys.code], error_code.INTERNAL_ERROR);
       expect(
         error[Keys.message],
-        'Direct sampling/createMessage requests are unavailable on protocol '
-        'version 2026-07-28. InputRequiredResult responses are allowed for '
-        'tools/call, prompts/get, and resources/read.',
+        'Protocol version 2026-07-28 does not have sampling/createMessage. '
+        'From 2026-07-28 a server asks the client for input with an '
+        'InputRequiredResult on tools/call, prompts/get, or resources/read.',
       );
     }
   });
@@ -112,9 +112,9 @@ void main() {
       expect(error[Keys.code], error_code.INTERNAL_ERROR);
       expect(
         error[Keys.message],
-        'Direct roots/list requests are unavailable on protocol version '
-        '2026-07-28. InputRequiredResult responses are allowed for '
-        'tools/call, prompts/get, and resources/read.',
+        'Protocol version 2026-07-28 does not have roots/list. From '
+        '2026-07-28 a server asks the client for input with an '
+        'InputRequiredResult on tools/call, prompts/get, or resources/read.',
       );
     }
   });

--- a/pkgs/dart_mcp/test/server/client_capability_guard_test.dart
+++ b/pkgs/dart_mcp/test/server/client_capability_guard_test.dart
@@ -28,6 +28,9 @@ final class _RequestingServer extends MCPServer
   }
 }
 
+/// Calls [name] on [protocolVersion]. It defaults to a revision with the
+/// requests these tools send, so a capability test reaches the capability
+/// check.
 Future<Map<String, Object?>?> _callTool(
   String name,
   ClientCapabilities capabilities, {
@@ -90,7 +93,10 @@ void main() {
       expect(error[Keys.code], error_code.INTERNAL_ERROR);
       expect(
         error[Keys.message],
-        contains('2026-07-28 does not have sampling/createMessage'),
+        contains(
+          '2026-07-28 does not have '
+          '${CreateMessageRequest.methodName}',
+        ),
       );
     }
   });
@@ -110,7 +116,7 @@ void main() {
       expect(error[Keys.code], error_code.INTERNAL_ERROR);
       expect(
         error[Keys.message],
-        contains('2026-07-28 does not have roots/list'),
+        contains('2026-07-28 does not have ${ListRootsRequest.methodName}'),
       );
     }
   });

--- a/pkgs/dart_mcp/test/server/elicitation_request_support_test.dart
+++ b/pkgs/dart_mcp/test/server/elicitation_request_support_test.dart
@@ -124,13 +124,19 @@ void main() {
     );
   });
 
-  test('a declared mode clears the capability check', () async {
+  test('a declared mode stops before the request-scoped transport', () async {
     final result = await _call(
       'test/send',
       ClientCapabilities(elicitation: ElicitationCapability(url: {})),
     );
 
-    expect(_errorCode(result!), _clearedTheCheck);
+    expect(_errorCode(result!), error_code.INTERNAL_ERROR);
+    expect(
+      (result[Keys.error] as Map<String, Object?>)[Keys.message],
+      'The `elicitation/create` request cannot be sent directly on protocol '
+      'version `2026-07-28` and must be returned in an InputRequiredResult '
+      'for a `tools/call`, `prompts/get`, or `resources/read` request.',
+    );
   });
 
   test('naming one mode does not sign a client up for the other', () async {

--- a/pkgs/dart_mcp/test/server/elicitation_request_support_test.dart
+++ b/pkgs/dart_mcp/test/server/elicitation_request_support_test.dart
@@ -148,7 +148,10 @@ void main() {
       expect(_errorCode(result!), error_code.INTERNAL_ERROR);
       expect(
         (result[Keys.error] as Map<String, Object?>)[Keys.message],
-        contains('2026-07-28 does not have elicitation/create'),
+        allOf(
+          contains('2026-07-28 does not have elicitation/create'),
+          contains('InputRequiredResult'),
+        ),
       );
     }
   });
@@ -169,8 +172,13 @@ void main() {
       expect(_errorCode(result!), error_code.INTERNAL_ERROR);
       expect(
         (result[Keys.error] as Map<String, Object?>)[Keys.message],
-        contains(
-          '${protocolVersion.versionString} does not have elicitation/create',
+        allOf(
+          contains(
+            '${protocolVersion.versionString} does not have elicitation/create',
+          ),
+          // Neither revision has an `InputRequiredResult` to send instead, so
+          // the error must not send the caller after one.
+          isNot(contains('InputRequiredResult')),
         ),
       );
     }

--- a/pkgs/dart_mcp/test/server/elicitation_request_support_test.dart
+++ b/pkgs/dart_mcp/test/server/elicitation_request_support_test.dart
@@ -63,8 +63,9 @@ final class _ElicitingServer extends MCPServer
 
 Future<Map<String, Object?>?> _call(
   String tool,
-  ClientCapabilities capabilities,
-) => handleRequestScopedMessage(
+  ClientCapabilities capabilities, {
+  ProtocolVersion protocolVersion = ProtocolVersion.v2025_11_25,
+}) => handleRequestScopedMessage(
   {
     Keys.jsonrpc: '2.0',
     Keys.id: 1,
@@ -72,7 +73,7 @@ Future<Map<String, Object?>?> _call(
     Keys.params: {Keys.name: tool},
   },
   MCPServerInitialization(
-    protocolVersion: ProtocolVersion.v2026_07_28,
+    protocolVersion: protocolVersion,
     clientCapabilities: capabilities,
   ),
   _ElicitingServer.new,
@@ -83,9 +84,8 @@ const _missingCapability = McpErrorCodes.missingRequiredClientCapability;
 Object? _errorCode(Map<String, Object?> result) =>
     (result[Keys.error] as Map<String, Object?>)[Keys.code];
 
-/// The request-scoped transport cannot route a request back to the client, so
-/// a call that clears the capability check still fails. These assert that it
-/// got that far.
+/// On 2025-11-25, a call which passes the capability check reaches the
+/// request-scoped transport and fails there.
 final _clearedTheCheck = isNot(_missingCapability);
 
 Object? _requiredCapabilities(Map<String, Object?> result) {
@@ -124,19 +124,33 @@ void main() {
     );
   });
 
-  test('a declared mode stops before the request-scoped transport', () async {
-    final result = await _call(
-      'test/send',
-      ClientCapabilities(elicitation: ElicitationCapability(url: {})),
-    );
+  test('2026-07-28 rejects both modes before capability checks', () async {
+    for (final (tool, capabilities) in [
+      ('test/ask', ClientCapabilities()),
+      (
+        'test/ask',
+        ClientCapabilities(elicitation: ElicitationCapability(form: {})),
+      ),
+      ('test/send', ClientCapabilities()),
+      (
+        'test/send',
+        ClientCapabilities(elicitation: ElicitationCapability(url: {})),
+      ),
+    ]) {
+      final result = await _call(
+        tool,
+        capabilities,
+        protocolVersion: ProtocolVersion.v2026_07_28,
+      );
 
-    expect(_errorCode(result!), error_code.INTERNAL_ERROR);
-    expect(
-      (result[Keys.error] as Map<String, Object?>)[Keys.message],
-      'The `elicitation/create` request cannot be sent directly on protocol '
-      'version `2026-07-28` and must be returned in an InputRequiredResult '
-      'for a `tools/call`, `prompts/get`, or `resources/read` request.',
-    );
+      expect(_errorCode(result!), error_code.INTERNAL_ERROR);
+      expect(
+        (result[Keys.error] as Map<String, Object?>)[Keys.message],
+        'Direct elicitation/create requests are unavailable on protocol '
+        'version 2026-07-28. InputRequiredResult responses are allowed for '
+        'tools/call, prompts/get, and resources/read.',
+      );
+    }
   });
 
   test('naming one mode does not sign a client up for the other', () async {

--- a/pkgs/dart_mcp/test/server/elicitation_request_support_test.dart
+++ b/pkgs/dart_mcp/test/server/elicitation_request_support_test.dart
@@ -84,7 +84,7 @@ const _missingCapability = McpErrorCodes.missingRequiredClientCapability;
 Object? _errorCode(Map<String, Object?> result) =>
     (result[Keys.error] as Map<String, Object?>)[Keys.code];
 
-/// On 2025-11-25, a call which passes the capability check reaches the
+/// On 2025-11-25, a call that clears the capability check reaches the
 /// request-scoped transport and fails there.
 final _clearedTheCheck = isNot(_missingCapability);
 
@@ -158,8 +158,8 @@ void main() {
       ProtocolVersion.v2024_11_05,
       ProtocolVersion.v2025_03_26,
     ]) {
-      // The capability is declared, so reaching the version error is what
-      // shows the check runs first on a revision which never had the method.
+      // The capability is declared, so reaching the version error shows the
+      // version check runs before it on these revisions too.
       final result = await _call(
         'test/ask',
         ClientCapabilities(elicitation: ElicitationCapability(form: {})),

--- a/pkgs/dart_mcp/test/server/elicitation_request_support_test.dart
+++ b/pkgs/dart_mcp/test/server/elicitation_request_support_test.dart
@@ -145,12 +145,33 @@ void main() {
         protocolVersion: ProtocolVersion.v2026_07_28,
       );
 
-      expect(_errorCode(result!), -32603);
+      expect(_errorCode(result!), error_code.INTERNAL_ERROR);
       expect(
         (result[Keys.error] as Map<String, Object?>)[Keys.message],
-        'Protocol version 2026-07-28 does not have elicitation/create. From '
-        '2026-07-28 a server asks the client for input with an '
-        'InputRequiredResult on tools/call, prompts/get, or resources/read.',
+        contains('2026-07-28 does not have elicitation/create'),
+      );
+    }
+  });
+
+  test('a revision before 2025-06-18 rejects elicitation too', () async {
+    for (final protocolVersion in [
+      ProtocolVersion.v2024_11_05,
+      ProtocolVersion.v2025_03_26,
+    ]) {
+      // The capability is declared, so reaching the version error is what
+      // shows the check runs first on a revision which never had the method.
+      final result = await _call(
+        'test/ask',
+        ClientCapabilities(elicitation: ElicitationCapability(form: {})),
+        protocolVersion: protocolVersion,
+      );
+
+      expect(_errorCode(result!), error_code.INTERNAL_ERROR);
+      expect(
+        (result[Keys.error] as Map<String, Object?>)[Keys.message],
+        contains(
+          '${protocolVersion.versionString} does not have elicitation/create',
+        ),
       );
     }
   });

--- a/pkgs/dart_mcp/test/server/elicitation_request_support_test.dart
+++ b/pkgs/dart_mcp/test/server/elicitation_request_support_test.dart
@@ -136,6 +136,8 @@ void main() {
         'test/send',
         ClientCapabilities(elicitation: ElicitationCapability(url: {})),
       ),
+      ('test/no-mode', ClientCapabilities()),
+      ('test/unknown', ClientCapabilities()),
     ]) {
       final result = await _call(
         tool,
@@ -143,7 +145,7 @@ void main() {
         protocolVersion: ProtocolVersion.v2026_07_28,
       );
 
-      expect(_errorCode(result!), error_code.INTERNAL_ERROR);
+      expect(_errorCode(result!), -32603);
       expect(
         (result[Keys.error] as Map<String, Object?>)[Keys.message],
         'Direct elicitation/create requests are unavailable on protocol '

--- a/pkgs/dart_mcp/test/server/elicitation_request_support_test.dart
+++ b/pkgs/dart_mcp/test/server/elicitation_request_support_test.dart
@@ -148,9 +148,9 @@ void main() {
       expect(_errorCode(result!), -32603);
       expect(
         (result[Keys.error] as Map<String, Object?>)[Keys.message],
-        'Direct elicitation/create requests are unavailable on protocol '
-        'version 2026-07-28. InputRequiredResult responses are allowed for '
-        'tools/call, prompts/get, and resources/read.',
+        'Protocol version 2026-07-28 does not have elicitation/create. From '
+        '2026-07-28 a server asks the client for input with an '
+        'InputRequiredResult on tools/call, prompts/get, or resources/read.',
       );
     }
   });

--- a/pkgs/dart_mcp/test/server/elicitation_request_support_test.dart
+++ b/pkgs/dart_mcp/test/server/elicitation_request_support_test.dart
@@ -149,7 +149,10 @@ void main() {
       expect(
         (result[Keys.error] as Map<String, Object?>)[Keys.message],
         allOf(
-          contains('2026-07-28 does not have elicitation/create'),
+          contains(
+            '2026-07-28 does not have '
+            '${ElicitRequest.methodName}',
+          ),
           contains('InputRequiredResult'),
         ),
       );
@@ -174,7 +177,8 @@ void main() {
         (result[Keys.error] as Map<String, Object?>)[Keys.message],
         allOf(
           contains(
-            '${protocolVersion.versionString} does not have elicitation/create',
+            '${protocolVersion.versionString} does not have '
+            '${ElicitRequest.methodName}',
           ),
           // Neither revision has an `InputRequiredResult` to send instead, so
           // the error must not send the caller after one.

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -437,15 +437,11 @@ void main() {
       expect(legacy![Keys.result], isNotNull);
     });
 
-    test('fails server to client requests instead of hanging', () async {
+    test('fails a server ping instead of hanging', () async {
       final harness = _DispatcherHarness();
-      // The client declares roots, so `listRoots` reaches the transport rather
-      // than being refused for the missing capability.
       final response = await harness.dispatch(
-        _callTool('roots'),
-        _initialization(
-          capabilities: ClientCapabilities(roots: RootsCapabilities()),
-        ),
+        _callTool('ping'),
+        _initialization(),
       );
 
       final error = response![Keys.error] as Map<String, Object?>;
@@ -943,9 +939,9 @@ final class _DispatcherTestServer extends TestMCPServer
       log(LoggingLevel.error, 'from the handler');
       return CallToolResult(content: [TextContent(text: 'notified')]);
     });
-    registerTool(Tool(name: 'roots', inputSchema: ObjectSchema()), (_) async {
-      final roots = await listRoots(ListRootsRequest());
-      return CallToolResult(content: [TextContent(text: '$roots')]);
+    registerTool(Tool(name: 'ping', inputSchema: ObjectSchema()), (_) async {
+      await ping();
+      return CallToolResult(content: [TextContent(text: 'unreachable')]);
     });
     registerTool(Tool(name: 'shutdown', inputSchema: ObjectSchema()), (
       _,

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -437,11 +437,14 @@ void main() {
       expect(legacy![Keys.result], isNotNull);
     });
 
-    test('fails a server ping instead of hanging', () async {
+    test('rejects a 2025-11-25 roots request instead of hanging', () async {
       final harness = _DispatcherHarness();
       final response = await harness.dispatch(
-        _callTool('ping'),
-        _initialization(),
+        _callTool('roots'),
+        _initialization(
+          capabilities: ClientCapabilities(roots: RootsCapabilities()),
+          protocolVersion: ProtocolVersion.v2025_11_25,
+        ),
       );
 
       final error = response![Keys.error] as Map<String, Object?>;
@@ -663,6 +666,7 @@ void main() {
           },
           _initialization(
             capabilities: ClientCapabilities(roots: RootsCapabilities()),
+            protocolVersion: ProtocolVersion.v2025_11_25,
           ),
           _RootsTrackingDispatcherServer.new,
         );
@@ -939,9 +943,9 @@ final class _DispatcherTestServer extends TestMCPServer
       log(LoggingLevel.error, 'from the handler');
       return CallToolResult(content: [TextContent(text: 'notified')]);
     });
-    registerTool(Tool(name: 'ping', inputSchema: ObjectSchema()), (_) async {
-      await ping();
-      return CallToolResult(content: [TextContent(text: 'unreachable')]);
+    registerTool(Tool(name: 'roots', inputSchema: ObjectSchema()), (_) async {
+      final roots = await listRoots(ListRootsRequest());
+      return CallToolResult(content: [TextContent(text: '$roots')]);
     });
     registerTool(Tool(name: 'shutdown', inputSchema: ObjectSchema()), (
       _,


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

On 2026-07-28 a server could still send the three requests that ask a client
for input. That revision keeps their types for the `InputRequiredResult` that
carries them, but drops the `ServerRequest` union they went out through, and
`removedMethods` never picked that up.

I listed them there and had the senders read that check first. It also refuses
`elicit` on the two revisions that predate `elicitation/create`.

The other senders still go out unchecked, `resources/subscribe`,
`resources/unsubscribe`, `logging/setLevel` and `ping` among them.
