### PR TITLE
answer the input requests in an input_required result

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -97,6 +97,9 @@
     `maximum` and `default` are `number` too. A peer sending
     `{"type": "integer", "minimum": 0.5}` sent something the getter threw on.
     `multipleOf` next to them already read `num`.
+  - `ServerConnection.protocolVersion` is nullable, and is `null` until
+    something settles a version. It used to be a `late` field, which threw
+    when read before then.
 - Add `supportsFormElicitation` and `supportsUrlElicitation` for a server to
   ask before it sends. An empty `elicitation` object still means form, the way
   `elicitation` read before the split.
@@ -158,16 +161,13 @@
 - Add `InputRequiredResult` and `InputRequest`, the result a server answers with
   when it needs input first, see
   https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr.
-  On a connection whose `protocolVersion` is 2026-07-28,
-  `ServerConnection.callTool`, `.getPrompt` and `.readResource` fulfill its
-  input requests through the client's elicitation, sampling and roots handlers,
-  then retry the original request. `initialize` does not negotiate that version
-  yet, so a transport carrying its own supported versions is what reaches this.
-  Retries stop after ten rounds, or when the server asks for a handler the
-  client did not declare, and a result carrying neither input requests nor
-  request state is rejected before any retry. Every round goes out under the
-  progress token the first request carried, which is what the new
-  `MCPBase.sendRequestKeepingProgress` and `MCPBase.closeProgress` are for.
+- On a 2026-07-28 connection, `ServerConnection.callTool`, `.getPrompt` and
+  `.readResource` answer an `input_required` result from the client's
+  elicitation, sampling and roots handlers, then send the original request
+  again. Retries stop after ten rounds.
+- Add `MCPBase.sendRequestKeepingProgress` and `MCPBase.closeProgress`, for a
+  caller which sends several requests under one progress token and closes the
+  stream once it stops sending.
 - Add `WithInputResponses`, the type a client's retry carries.
   `CallToolRequest`, `GetPromptRequest` and `ReadResourceRequest` take an
   `inputResponses` and a `requestState`, matching the three requests the schema

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -166,7 +166,9 @@
 - On a 2026-07-28 connection, `ServerConnection.callTool`, `.getPrompt` and
   `.readResource` answer an `input_required` result from the client's
   elicitation, sampling and roots handlers, then send the original request
-  again. Retries stop after ten rounds.
+  again, through the new `ServerConnection.sendRequestWithInputs`. The spec
+  bounds the rounds nowhere, so `ServerConnection.maxInputRequiredRounds`
+  stops them, at ten unless a caller moves it.
 - Add `MCPBase.sendRequestKeepingProgress` and `MCPBase.closeProgress`.
   `sendRequest` closes a progress stream once its request is done, and this
   pair splits that apart so a retry loop can hold one token across rounds.

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -99,7 +99,8 @@
     `multipleOf` next to them already read `num`.
   - `ServerConnection.protocolVersion` is nullable, and is `null` until
     something settles a version. It used to be a `late` field, which threw
-    when read before then.
+    when read before then. Set `serverInfo` alongside it. Sampling hands that
+    to the handler.
 - Add `supportsFormElicitation` and `supportsUrlElicitation` for a server to
   ask before it sends. An empty `elicitation` object still means form, the way
   `elicitation` read before the split.

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -158,16 +158,16 @@
 - Add `InputRequiredResult` and `InputRequest`, the result a server answers with
   when it needs input first, see
   https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr.
-  On 2026-07-28 connections, `ServerConnection.callTool`, `.getPrompt`, and
-  `.readResource` fulfill its input requests through the client's elicitation,
-  sampling, and roots handlers, then retry the original request. Automatic
-  retries stop after ten rounds or when a required handler is unavailable. A
-  result with neither input requests nor request state is rejected before the
-  retry. Every round goes out under the progress token the first request
-  carried, and the stream `onProgress` returned stays open until the rounds
-  end: `MCPBase.sendRequest` leaves it open on an `input_required` result, and
-  the new `MCPBase.closeProgress` closes it for a caller which spans several
-  requests under one token.
+  On a connection whose `protocolVersion` is 2026-07-28,
+  `ServerConnection.callTool`, `.getPrompt` and `.readResource` fulfill its
+  input requests through the client's elicitation, sampling and roots handlers,
+  then retry the original request. `initialize` does not negotiate that version
+  yet, so a transport carrying its own supported versions is what reaches this.
+  Retries stop after ten rounds, or when the server asks for a handler the
+  client did not declare, and a result carrying neither input requests nor
+  request state is rejected before any retry. Every round goes out under the
+  progress token the first request carried, which is what the new
+  `MCPBase.sendRequestKeepingProgress` and `MCPBase.closeProgress` are for.
 - Add `WithInputResponses`, the type a client's retry carries.
   `CallToolRequest`, `GetPromptRequest` and `ReadResourceRequest` take an
   `inputResponses` and a `requestState`, matching the three requests the schema

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -163,7 +163,11 @@
   sampling, and roots handlers, then retry the original request. Automatic
   retries stop after ten rounds or when a required handler is unavailable. A
   result with neither input requests nor request state is rejected before the
-  retry.
+  retry. Every round goes out under the progress token the first request
+  carried, and the stream `onProgress` returned stays open until the rounds
+  end: `MCPBase.sendRequest` leaves it open on an `input_required` result, and
+  the new `MCPBase.closeProgress` closes it for a caller which spans several
+  requests under one token.
 - Add `WithInputResponses`, the type a client's retry carries.
   `CallToolRequest`, `GetPromptRequest` and `ReadResourceRequest` take an
   `inputResponses` and a `requestState`, matching the three requests the schema

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -168,7 +168,7 @@
   elicitation, sampling and roots handlers, then send the original request
   again, through the new `ServerConnection.sendRequestWithInputs`. The spec
   bounds the rounds nowhere, so `ServerConnection.maxInputRequiredRounds`
-  stops them, at ten unless a caller moves it.
+  stops them, at ten unless a caller moves it or clears it with `null`.
 - Add `MCPBase.sendRequestKeepingProgress` and `MCPBase.closeProgress`.
   `sendRequest` closes a progress stream once its request is done, and this
   pair splits that apart so a retry loop can hold one token across rounds.

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -158,10 +158,12 @@
 - Add `InputRequiredResult` and `InputRequest`, the result a server answers with
   when it needs input first, see
   https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr.
-  `ServerConnection.callTool`, `.getPrompt`, and `.readResource` fulfill its
-  input requests through the client's elicitation, sampling, and roots
-  handlers, then retry the original request. Automatic retries stop after ten
-  rounds or when a required handler is unavailable.
+  On 2026-07-28 connections, `ServerConnection.callTool`, `.getPrompt`, and
+  `.readResource` fulfill its input requests through the client's elicitation,
+  sampling, and roots handlers, then retry the original request. Automatic
+  retries stop after ten rounds or when a required handler is unavailable. A
+  result with neither input requests nor request state is rejected before the
+  retry.
 - Add `WithInputResponses`, the type a client's retry carries.
   `CallToolRequest`, `GetPromptRequest` and `ReadResourceRequest` take an
   `inputResponses` and a `requestState`, matching the three requests the schema

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -158,7 +158,10 @@
 - Add `InputRequiredResult` and `InputRequest`, the result a server answers with
   when it needs input first, see
   https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr.
-  Nothing sends or answers one yet.
+  `ServerConnection.callTool`, `.getPrompt`, and `.readResource` fulfill its
+  input requests through the client's elicitation, sampling, and roots
+  handlers, then retry the original request. Automatic retries stop after ten
+  rounds or when a required handler is unavailable.
 - Add `WithInputResponses`, the type a client's retry carries.
   `CallToolRequest`, `GetPromptRequest` and `ReadResourceRequest` take an
   `inputResponses` and a `requestState`, matching the three requests the schema

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -161,13 +161,14 @@
 - Add `InputRequiredResult` and `InputRequest`, the result a server answers with
   when it needs input first, see
   https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr.
+  A server built with this package does not send one yet.
 - On a 2026-07-28 connection, `ServerConnection.callTool`, `.getPrompt` and
   `.readResource` answer an `input_required` result from the client's
   elicitation, sampling and roots handlers, then send the original request
   again. Retries stop after ten rounds.
-- Add `MCPBase.sendRequestKeepingProgress` and `MCPBase.closeProgress`, for a
-  caller which sends several requests under one progress token and closes the
-  stream once it stops sending.
+- Add `MCPBase.sendRequestKeepingProgress` and `MCPBase.closeProgress`.
+  `sendRequest` closes a progress stream once its request is done, and this
+  pair splits that apart so a retry loop can hold one token across rounds.
 - Add `WithInputResponses`, the type a client's retry carries.
   `CallToolRequest`, `GetPromptRequest` and `ReadResourceRequest` take an
   `inputResponses` and a `requestState`, matching the three requests the schema

--- a/pkgs/dart_mcp/lib/src/api/input_required.dart
+++ b/pkgs/dart_mcp/lib/src/api/input_required.dart
@@ -43,7 +43,20 @@ extension type InputRequest._(Map<String, Object?> _value) {
   ///
   /// The schema requires this next to `elicitation/create` and
   /// `sampling/createMessage`. For `roots/list` it only requires the method.
-  Request? get params => _value[Keys.params] as Request?;
+  ///
+  /// Throws an [ArgumentError] when a server sent something other than an
+  /// object here.
+  Request? get params {
+    final params = _value[Keys.params];
+    if (params == null) return null;
+    if (params is! Map) {
+      throw ArgumentError(
+        'The input request params for "$method" were ${params.runtimeType}, '
+        'expected an object.',
+      );
+    }
+    return params.cast<String, Object?>() as Request;
+  }
 
   /// Whether this carries an [ElicitRequest].
   bool get isElicit => _value[Keys.method] == ElicitRequest.methodName;

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -125,11 +125,12 @@ base class ServerConnection extends MCPBase {
   /// protocol version.
   ProtocolVersion? protocolVersion;
 
-  /// The [Implementation] returned from the [initialize] request.
+  /// The [Implementation] the server described itself with, or `null` until
+  /// one settles it.
   ///
-  /// Only non-null after [initialize] has successfully completed. Sampling
-  /// hands it to the handler, so set it too wherever you set
-  /// [protocolVersion].
+  /// [initialize] fills this in. Assign it directly if your transport settles
+  /// the version outside the handshake, since sampling hands it to the
+  /// handler.
   Implementation? serverInfo;
 
   /// The [ServerCapabilities] returned from the [initialize] request.

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -230,7 +230,6 @@ base class ServerConnection extends MCPBase {
        _elicitationUrlSupport = elicitationUrlSupport,
        _samplingSupport = samplingSupport,
        _rootsSupport = rootsSupport {
-    elicitationFormSupport ??= elicitationSupport;
     if (rootsSupport != null) {
       registerRequestHandler(
         ListRootsRequest.methodName,
@@ -246,7 +245,7 @@ base class ServerConnection extends MCPBase {
       );
     }
 
-    if (elicitationFormSupport != null || elicitationUrlSupport != null) {
+    if (_elicitationFormSupport != null || elicitationUrlSupport != null) {
       registerRequestHandler(ElicitRequest.methodName, (ElicitRequest request) {
         final raw = request.rawMode;
         if (raw != null && !ElicitationMode.values.any((m) => m.name == raw)) {
@@ -257,12 +256,13 @@ base class ServerConnection extends MCPBase {
         }
         switch (request.mode) {
           case ElicitationMode.form:
-            if (elicitationFormSupport == null) {
+            final formSupport = _elicitationFormSupport;
+            if (formSupport == null) {
               throw RpcException.invalidParams(
                 'This client did not declare the elicitation.form capability',
               );
             }
-            return elicitationFormSupport.handleElicitation(request, this);
+            return formSupport.handleElicitation(request, this);
           case ElicitationMode.url:
             if (elicitationUrlSupport == null) {
               throw RpcException.invalidParams(
@@ -433,7 +433,8 @@ base class ServerConnection extends MCPBase {
     WithInputResponses request,
   ) async {
     final originalRequest = request as Map<String, Object?>;
-    var result = (await sendRequest<T>(methodName, request)) as Result;
+    var result =
+        (await sendRequestKeepingProgress<T>(methodName, request)) as Result;
     for (
       var round = 0;
       result.resultType == ResultTypes.inputRequired;
@@ -456,6 +457,8 @@ base class ServerConnection extends MCPBase {
           '`${Keys.inputRequests}` or `${Keys.requestState}`.',
         );
       }
+      // TODO: Pace a leg carrying only request state, which nothing else slows
+      // down, the way the TypeScript and Python SDKs do.
       if (inputRequests != null) {
         final handlers = [
           for (final entry in inputRequests.entries)
@@ -475,7 +478,9 @@ base class ServerConnection extends MCPBase {
                 if (requestState != null) Keys.requestState: requestState,
               }
               as WithInputResponses;
-      result = (await sendRequest<T>(methodName, retryRequest)) as Result;
+      result =
+          (await sendRequestKeepingProgress<T>(methodName, retryRequest))
+              as Result;
     }
     return result as T;
   }
@@ -496,31 +501,20 @@ base class ServerConnection extends MCPBase {
           case ElicitationMode.form:
             final support = _elicitationFormSupport;
             if (support == null) {
-              throw _missingClientCapability(
-                'elicitation.form',
-                ClientCapabilities(
-                  elicitation: ElicitationCapability(form: {}),
-                ),
-              );
+              throw _undeclaredCapability('elicitation.form');
             }
             return () async => await support.handleElicitation(request, this);
           case ElicitationMode.url:
             final support = _elicitationUrlSupport;
             if (support == null) {
-              throw _missingClientCapability(
-                'elicitation.url',
-                ClientCapabilities(elicitation: ElicitationCapability(url: {})),
-              );
+              throw _undeclaredCapability('elicitation.url');
             }
             return () async => await support.handleElicitation(request, this);
         }
       case CreateMessageRequest.methodName:
         final support = _samplingSupport;
         if (support == null) {
-          throw _missingClientCapability(
-            Keys.sampling,
-            ClientCapabilities(sampling: {}),
-          );
+          throw _undeclaredCapability(Keys.sampling);
         }
         final request =
             _inputRequestParams(inputRequest, required: true)!
@@ -531,10 +525,7 @@ base class ServerConnection extends MCPBase {
       case ListRootsRequest.methodName:
         final support = _rootsSupport;
         if (support == null) {
-          throw _missingClientCapability(
-            Keys.roots,
-            ClientCapabilities(roots: RootsCapabilities()),
-          );
+          throw _undeclaredCapability(Keys.roots);
         }
         final request =
             _inputRequestParams(inputRequest, required: false)
@@ -594,13 +585,9 @@ Map<String, Object?>? _inputRequestParams(
   return params.cast<String, Object?>();
 }
 
-RpcException _missingClientCapability(
-  String capability,
-  ClientCapabilities required,
-) => RpcException(
-  McpErrorCodes.missingRequiredClientCapability,
-  'The client did not declare the $capability capability',
-  data: {Keys.requiredCapabilities: required},
+StateError _undeclaredCapability(String capability) => StateError(
+  'The server sent an input request needing the $capability capability, '
+  'which this client did not declare.',
 );
 
 extension ElicitationServerConnection on ElicitRequest {

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -419,6 +419,19 @@ base class ServerConnection extends MCPBase {
     if (serverInfo == null || protocolVersion < ProtocolVersion.v2026_07_28) {
       return sendRequest<T>(methodName, request);
     }
+    try {
+      return await _retryWhileInputRequired<T>(methodName, request);
+    } finally {
+      // Every round runs under the progress token the caller put on the first
+      // request, so the stream it opened outlives all of them.
+      await closeProgress(request);
+    }
+  }
+
+  Future<T> _retryWhileInputRequired<T extends Result>(
+    String methodName,
+    WithInputResponses request,
+  ) async {
     final originalRequest = request as Map<String, Object?>;
     var result = (await sendRequest<T>(methodName, request)) as Result;
     for (

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:collection';
 
-import 'package:async/async.dart';
+import 'package:async/async.dart' show StreamExtensions;
 import 'package:json_rpc_2/json_rpc_2.dart';
 import 'package:meta/meta.dart';
 import 'package:stream_channel/stream_channel.dart';
@@ -134,6 +134,21 @@ base class ServerConnection extends MCPBase {
   /// The [ElicitationUrlSupport] for this connection, if any.
   final ElicitationUrlSupport? _elicitationUrlSupport;
 
+  /// The [ElicitationFormSupport] for this connection, if any.
+  final ElicitationFormSupport? _elicitationFormSupport;
+
+  /// The [SamplingSupport] for this connection, if any.
+  final SamplingSupport? _samplingSupport;
+
+  /// The [RootsSupport] for this connection, if any.
+  final RootsSupport? _rootsSupport;
+
+  /// Maximum number of automatic retries for an `input_required` result.
+  ///
+  /// This prevents an unbounded loop and matches the TypeScript and Python SDK
+  /// defaults.
+  static const _maxInputRequiredRounds = 10;
+
   @override
   String get name => serverInfo?.name ?? super.name;
 
@@ -211,7 +226,10 @@ base class ServerConnection extends MCPBase {
     ElicitationSupport? elicitationSupport,
     ElicitationFormSupport? elicitationFormSupport,
     ElicitationUrlSupport? elicitationUrlSupport,
-  }) : _elicitationUrlSupport = elicitationUrlSupport {
+  }) : _elicitationFormSupport = elicitationFormSupport ?? elicitationSupport,
+       _elicitationUrlSupport = elicitationUrlSupport,
+       _samplingSupport = samplingSupport,
+       _rootsSupport = rootsSupport {
     elicitationFormSupport ??= elicitationSupport;
     if (rootsSupport != null) {
       registerRequestHandler(
@@ -336,7 +354,7 @@ base class ServerConnection extends MCPBase {
   /// Invokes a [Tool] returned from the [ListToolsResult].
   Future<CallToolResult> callTool(CallToolRequest request) async {
     try {
-      return await sendRequest(CallToolRequest.methodName, request);
+      return await _sendRequestWithInputs(CallToolRequest.methodName, request);
     } on RpcException catch (e) {
       // If we are set up to try and auto handle url elicitation and we get
       // an error that the url elicitation is required, we will try and handle
@@ -362,7 +380,10 @@ base class ServerConnection extends MCPBase {
         );
         if (elicitResult.action == ElicitationAction.accept) {
           await elicitationComplete;
-          return await sendRequest(CallToolRequest.methodName, request);
+          return await _sendRequestWithInputs(
+            CallToolRequest.methodName,
+            request,
+          );
         }
       }
       rethrow;
@@ -376,7 +397,7 @@ base class ServerConnection extends MCPBase {
   /// Reads a [Resource] returned from the [ListResourcesResult] or matching
   /// a [ResourceTemplate] from a [ListResourceTemplatesResult].
   Future<ReadResourceResult> readResource(ReadResourceRequest request) =>
-      sendRequest(ReadResourceRequest.methodName, request);
+      _sendRequestWithInputs(ReadResourceRequest.methodName, request);
 
   /// Lists all the [ResourceTemplate]s from this server.
   Future<ListResourceTemplatesResult> listResourceTemplates([
@@ -389,7 +410,117 @@ base class ServerConnection extends MCPBase {
 
   /// Gets the requested [Prompt] from the server.
   Future<GetPromptResult> getPrompt(GetPromptRequest request) =>
-      sendRequest(GetPromptRequest.methodName, request);
+      _sendRequestWithInputs(GetPromptRequest.methodName, request);
+
+  Future<T> _sendRequestWithInputs<T extends Result>(
+    String methodName,
+    WithInputResponses request,
+  ) async {
+    final originalRequest = request as Map<String, Object?>;
+    var result = (await sendRequest<T>(methodName, request)) as Result;
+    for (
+      var round = 0;
+      result.resultType == ResultTypes.inputRequired;
+      round++
+    ) {
+      if (round == _maxInputRequiredRounds) {
+        throw StateError(
+          'The server returned `${ResultTypes.inputRequired}` after '
+          '$_maxInputRequiredRounds retries for `$methodName`. Expected '
+          '`${ResultTypes.complete}`.',
+        );
+      }
+      final inputRequired = result as InputRequiredResult;
+      final responses = <String, Result>{};
+      final inputRequests = inputRequired.inputRequests;
+      if (inputRequests != null) {
+        final handlers = [
+          for (final entry in inputRequests.entries)
+            MapEntry(entry.key, _inputRequestHandler(entry.value)),
+        ];
+        for (final handler in handlers) {
+          responses[handler.key] = await handler.value();
+        }
+      }
+      final retryRequest =
+          <String, Object?>{
+                for (final entry in originalRequest.entries)
+                  if (entry.key != Keys.inputResponses &&
+                      entry.key != Keys.requestState)
+                    entry.key: entry.value,
+                if (responses.isNotEmpty) Keys.inputResponses: responses,
+                if (inputRequired.requestState case final requestState?)
+                  Keys.requestState: requestState,
+              }
+              as WithInputResponses;
+      result = (await sendRequest<T>(methodName, retryRequest)) as Result;
+    }
+    return result as T;
+  }
+
+  Future<Result> Function() _inputRequestHandler(InputRequest inputRequest) {
+    switch (inputRequest.method) {
+      case ElicitRequest.methodName:
+        final request = inputRequest.params as ElicitRequest;
+        final raw = request.rawMode;
+        if (raw != null && !ElicitationMode.values.any((m) => m.name == raw)) {
+          throw StateError(
+            'The elicitation mode was "$raw", which is not one of: '
+            '${ElicitationMode.values.map((m) => m.name).join(', ')}',
+          );
+        }
+        switch (request.mode) {
+          case ElicitationMode.form:
+            final support = _elicitationFormSupport;
+            if (support == null) {
+              throw _missingClientCapability(
+                'elicitation.form',
+                ClientCapabilities(
+                  elicitation: ElicitationCapability(form: {}),
+                ),
+              );
+            }
+            return () async => await support.handleElicitation(request, this);
+          case ElicitationMode.url:
+            final support = _elicitationUrlSupport;
+            if (support == null) {
+              throw _missingClientCapability(
+                'elicitation.url',
+                ClientCapabilities(elicitation: ElicitationCapability(url: {})),
+              );
+            }
+            return () async => await support.handleElicitation(request, this);
+        }
+      case CreateMessageRequest.methodName:
+        final support = _samplingSupport;
+        if (support == null) {
+          throw _missingClientCapability(
+            'sampling',
+            ClientCapabilities(sampling: {}),
+          );
+        }
+        final request = inputRequest.params as CreateMessageRequest;
+        final serverInfo = this.serverInfo!;
+        return () async =>
+            await support.handleCreateMessage(request, serverInfo);
+      case ListRootsRequest.methodName:
+        final support = _rootsSupport;
+        if (support == null) {
+          throw _missingClientCapability(
+            'roots',
+            ClientCapabilities(roots: RootsCapabilities()),
+          );
+        }
+        final request = inputRequest.params as ListRootsRequest?;
+        return () async => await support.handleListRoots(request);
+      default:
+        throw StateError(
+          'The input request method was "${inputRequest.method}", which is '
+          'not one of: ${ElicitRequest.methodName}, '
+          '${CreateMessageRequest.methodName}, ${ListRootsRequest.methodName}',
+        );
+    }
+  }
 
   /// Subscribes this client to a resource by URI (at `request.uri`).
   ///
@@ -420,6 +551,15 @@ base class ServerConnection extends MCPBase {
   Future<CompleteResult> requestCompletions(CompleteRequest request) =>
       sendRequest(CompleteRequest.methodName, request);
 }
+
+RpcException _missingClientCapability(
+  String capability,
+  ClientCapabilities required,
+) => RpcException(
+  McpErrorCodes.missingRequiredClientCapability,
+  'The client did not declare the $capability capability',
+  data: {Keys.requiredCapabilities: required},
+);
 
 extension ElicitationServerConnection on ElicitRequest {
   /// Broadcast stream of notifications for this elicitation ID. Events are not

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -456,7 +456,7 @@ base class ServerConnection extends MCPBase {
       round++
     ) {
       if (round == _maxInputRequiredRounds) {
-        throw StateError(
+        throw ArgumentError(
           'The server returned `${ResultTypes.inputRequired}` after '
           '$_maxInputRequiredRounds retries for `$methodName`. Expected '
           '`${ResultTypes.complete}`.',

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -151,11 +151,11 @@ base class ServerConnection extends MCPBase {
   final RootsSupport? _rootsSupport;
 
   /// How many `input_required` rounds [sendRequestWithInputs] answers before
-  /// it gives up.
+  /// it gives up, or `null` for as many as the server sends.
   ///
   /// The spec sets no bound on the rounds. This one only guards against a
-  /// server that never stops asking, and a caller can move it.
-  int maxInputRequiredRounds = 10;
+  /// server that never stops asking.
+  int? maxInputRequiredRounds = 10;
 
   @override
   String get name => serverInfo?.name ?? super.name;
@@ -467,7 +467,8 @@ base class ServerConnection extends MCPBase {
       result.resultType == ResultTypes.inputRequired;
       round++
     ) {
-      if (round >= maxInputRequiredRounds) {
+      final maxRounds = maxInputRequiredRounds;
+      if (maxRounds != null && round >= maxRounds) {
         throw ArgumentError(
           'The server returned `${ResultTypes.inputRequired}` after '
           '$round retries for `$methodName`. Expected '

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -150,8 +150,12 @@ base class ServerConnection extends MCPBase {
   /// The [RootsSupport] for this connection, if any.
   final RootsSupport? _rootsSupport;
 
-  /// Maximum number of automatic retries for an `input_required` result.
-  static const _maxInputRequiredRounds = 10;
+  /// How many `input_required` rounds [sendRequestWithInputs] answers before
+  /// it gives up.
+  ///
+  /// The spec sets no bound on the rounds. This one only guards against a
+  /// server that never stops asking, and a caller can move it.
+  int maxInputRequiredRounds = 10;
 
   @override
   String get name => serverInfo?.name ?? super.name;
@@ -368,7 +372,7 @@ base class ServerConnection extends MCPBase {
   /// Invokes a [Tool] returned from the [ListToolsResult].
   Future<CallToolResult> callTool(CallToolRequest request) async {
     try {
-      return await _sendRequestWithInputs(CallToolRequest.methodName, request);
+      return await sendRequestWithInputs(CallToolRequest.methodName, request);
     } on RpcException catch (e) {
       // If we are set up to try and auto handle url elicitation and we get
       // an error that the url elicitation is required, we will try and handle
@@ -394,7 +398,7 @@ base class ServerConnection extends MCPBase {
         );
         if (elicitResult.action == ElicitationAction.accept) {
           await elicitationComplete;
-          return await _sendRequestWithInputs(
+          return await sendRequestWithInputs(
             CallToolRequest.methodName,
             request,
           );
@@ -411,7 +415,7 @@ base class ServerConnection extends MCPBase {
   /// Reads a [Resource] returned from the [ListResourcesResult] or matching
   /// a [ResourceTemplate] from a [ListResourceTemplatesResult].
   Future<ReadResourceResult> readResource(ReadResourceRequest request) =>
-      _sendRequestWithInputs(ReadResourceRequest.methodName, request);
+      sendRequestWithInputs(ReadResourceRequest.methodName, request);
 
   /// Lists all the [ResourceTemplate]s from this server.
   Future<ListResourceTemplatesResult> listResourceTemplates([
@@ -424,13 +428,21 @@ base class ServerConnection extends MCPBase {
 
   /// Gets the requested [Prompt] from the server.
   Future<GetPromptResult> getPrompt(GetPromptRequest request) =>
-      _sendRequestWithInputs(GetPromptRequest.methodName, request);
+      sendRequestWithInputs(GetPromptRequest.methodName, request);
 
-  Future<T> _sendRequestWithInputs<T extends Result>(
+  /// Sends [request] like [sendRequest] does, answering any `input_required`
+  /// result before it returns.
+  ///
+  /// Before 2026-07-28 it sends once. An extension adding a method that takes
+  /// input responses can go through here.
+  Future<T> sendRequestWithInputs<T extends Result>(
     String methodName,
     WithInputResponses request,
   ) async {
     final version = protocolVersion;
+    // An unsettled version is not an error. 2026-07-28 dropped the handshake,
+    // and something outside `initialize` settles this one. Either way the
+    // connection has not told us it speaks the revision.
     if (version == null || version < ProtocolVersion.v2026_07_28) {
       return sendRequest<T>(methodName, request);
     }
@@ -455,10 +467,10 @@ base class ServerConnection extends MCPBase {
       result.resultType == ResultTypes.inputRequired;
       round++
     ) {
-      if (round == _maxInputRequiredRounds) {
+      if (round == maxInputRequiredRounds) {
         throw ArgumentError(
           'The server returned `${ResultTypes.inputRequired}` after '
-          '$_maxInputRequiredRounds retries for `$methodName`. Expected '
+          '$maxInputRequiredRounds retries for `$methodName`. Expected '
           '`${ResultTypes.complete}`.',
         );
       }
@@ -502,11 +514,16 @@ base class ServerConnection extends MCPBase {
     return result as T;
   }
 
+  /// Resolves the handler for [inputRequest], one of the three methods a
+  /// server can ask for in an `input_required` result.
+  ///
+  /// Answering those and sending the original request again is a multi
+  /// round-trip request, see
+  /// https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr.
   Future<Result> Function() _inputRequestHandler(InputRequest inputRequest) {
     switch (inputRequest.method) {
       case ElicitRequest.methodName:
-        final request =
-            _inputRequestParams(inputRequest, required: true)! as ElicitRequest;
+        final request = _requiredParams(inputRequest) as ElicitRequest;
         final badMode = _invalidElicitationMode(request);
         if (badMode != null) throw ArgumentError(badMode);
         switch (request.mode) {
@@ -528,9 +545,7 @@ base class ServerConnection extends MCPBase {
         if (support == null) {
           throw _undeclaredCapability(Keys.sampling);
         }
-        final request =
-            _inputRequestParams(inputRequest, required: true)!
-                as CreateMessageRequest;
+        final request = _requiredParams(inputRequest) as CreateMessageRequest;
         final serverInfo = _samplingServerInfo;
         return () async =>
             await support.handleCreateMessage(request, serverInfo);
@@ -539,9 +554,7 @@ base class ServerConnection extends MCPBase {
         if (support == null) {
           throw _undeclaredCapability(Keys.roots);
         }
-        final request =
-            _inputRequestParams(inputRequest, required: false)
-                as ListRootsRequest?;
+        final request = inputRequest.params as ListRootsRequest?;
         return () async => await support.handleListRoots(request);
       default:
         throw ArgumentError(
@@ -582,20 +595,15 @@ base class ServerConnection extends MCPBase {
       sendRequest(CompleteRequest.methodName, request);
 }
 
-Map<String, Object?>? _inputRequestParams(
-  InputRequest inputRequest, {
-  required bool required,
-}) {
-  final params = (inputRequest as Map<String, Object?>)[Keys.params];
-  if (params == null && !required) return null;
-  if (params is! Map) {
-    throw ArgumentError(
-      'The input request params for "${inputRequest.method}" were '
-      '${params.runtimeType}, expected an object.',
-    );
-  }
-  return params.cast<String, Object?>();
-}
+/// [InputRequest.params] for a method whose schema requires them.
+///
+/// Throws an [ArgumentError] naming the method when a server left them out.
+Request _requiredParams(InputRequest inputRequest) =>
+    inputRequest.params ??
+    (throw ArgumentError(
+      'The input request params for "${inputRequest.method}" were absent, '
+      'expected an object.',
+    ));
 
 /// The error message for [request] if it names a mode that is not an
 /// [ElicitationMode], or null if this client can read its mode.

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -115,15 +115,21 @@ base class MCPClient {
 
 /// An active server connection.
 base class ServerConnection extends MCPBase {
-  /// The version of the protocol that was negotiated during initialization.
+  /// The version of the protocol this connection speaks, or `null` until one
+  /// is settled.
+  ///
+  /// [initialize] fills this in for a version this client supports. A
+  /// transport which carries its own supported versions assigns it directly,
+  /// since 2026-07-28 has no handshake to negotiate one.
   ///
   /// Some APIs may error if you attempt to use them without first checking the
   /// protocol version.
-  late ProtocolVersion protocolVersion;
+  ProtocolVersion? protocolVersion;
 
   /// The [Implementation] returned from the [initialize] request.
   ///
-  /// Only non-null after [initialize] has successfully completed.
+  /// Only non-null after [initialize] has successfully completed, or once a
+  /// transport which settles the version itself sets it. Sampling needs one.
   Implementation? serverInfo;
 
   /// The [ServerCapabilities] returned from the [initialize] request.
@@ -409,7 +415,8 @@ base class ServerConnection extends MCPBase {
     String methodName,
     WithInputResponses request,
   ) async {
-    if (serverInfo == null || protocolVersion < ProtocolVersion.v2026_07_28) {
+    final version = protocolVersion;
+    if (version == null || version < ProtocolVersion.v2026_07_28) {
       return sendRequest<T>(methodName, request);
     }
     try {
@@ -451,6 +458,7 @@ base class ServerConnection extends MCPBase {
         );
       }
       // TODO: Delay a retry that carries no input requests, so it cannot spin.
+      // https://github.com/dart-lang/ai/issues/162
       if (inputRequests != null) {
         final handlers = [
           for (final entry in inputRequests.entries)
@@ -506,7 +514,14 @@ base class ServerConnection extends MCPBase {
         final request =
             _inputRequestParams(inputRequest, required: true)!
                 as CreateMessageRequest;
-        final serverInfo = this.serverInfo!;
+        final serverInfo = this.serverInfo;
+        if (serverInfo == null) {
+          throw StateError(
+            'The server sent a sampling input request, but this connection '
+            'has no `serverInfo` to give the handler. Only `initialize` fills '
+            'it in, and 2026-07-28 has no handshake to run.',
+          );
+        }
         return () async =>
             await support.handleCreateMessage(request, serverInfo);
       case ListRootsRequest.methodName:

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -242,15 +242,10 @@ base class ServerConnection extends MCPBase {
       );
     }
 
-    if (_elicitationFormSupport != null || elicitationUrlSupport != null) {
+    if (_elicitationFormSupport != null || _elicitationUrlSupport != null) {
       registerRequestHandler(ElicitRequest.methodName, (ElicitRequest request) {
-        final raw = request.rawMode;
-        if (raw != null && !ElicitationMode.values.any((m) => m.name == raw)) {
-          throw RpcException.invalidParams(
-            'The elicitation mode was "$raw", which is not one of: '
-            '${ElicitationMode.values.map((m) => m.name).join(', ')}',
-          );
-        }
+        final badMode = _invalidElicitationMode(request);
+        if (badMode != null) throw RpcException.invalidParams(badMode);
         switch (request.mode) {
           case ElicitationMode.form:
             final formSupport = _elicitationFormSupport;
@@ -261,12 +256,13 @@ base class ServerConnection extends MCPBase {
             }
             return formSupport.handleElicitation(request, this);
           case ElicitationMode.url:
-            if (elicitationUrlSupport == null) {
+            final urlSupport = _elicitationUrlSupport;
+            if (urlSupport == null) {
               throw RpcException.invalidParams(
                 'This client did not declare the elicitation.url capability',
               );
             }
-            return elicitationUrlSupport.handleElicitation(request, this);
+            return urlSupport.handleElicitation(request, this);
         }
       });
     }
@@ -454,7 +450,7 @@ base class ServerConnection extends MCPBase {
           '`${Keys.inputRequests}` or `${Keys.requestState}`.',
         );
       }
-      // TODO: Pace a retry for a result that carries no input requests.
+      // TODO: Delay a retry that carries no input requests, so it cannot spin.
       if (inputRequests != null) {
         final handlers = [
           for (final entry in inputRequests.entries)
@@ -486,13 +482,8 @@ base class ServerConnection extends MCPBase {
       case ElicitRequest.methodName:
         final request =
             _inputRequestParams(inputRequest, required: true)! as ElicitRequest;
-        final raw = request.rawMode;
-        if (raw != null && !ElicitationMode.values.any((m) => m.name == raw)) {
-          throw StateError(
-            'The elicitation mode was "$raw", which is not one of: '
-            '${ElicitationMode.values.map((m) => m.name).join(', ')}',
-          );
-        }
+        final badMode = _invalidElicitationMode(request);
+        if (badMode != null) throw StateError(badMode);
         switch (request.mode) {
           case ElicitationMode.form:
             final support = _elicitationFormSupport;
@@ -579,6 +570,21 @@ Map<String, Object?>? _inputRequestParams(
     );
   }
   return params.cast<String, Object?>();
+}
+
+/// The error message for [request] if it names a mode that is not an
+/// [ElicitationMode], or null if this client can read its mode.
+///
+/// [ElicitRequest.mode] reports an unknown mode as `Bad state: No element`, so
+/// both entry points check the raw value first and name it themselves. They
+/// throw different types, which is why this returns the message.
+String? _invalidElicitationMode(ElicitRequest request) {
+  final raw = request.rawMode;
+  if (raw == null || ElicitationMode.values.any((m) => m.name == raw)) {
+    return null;
+  }
+  return 'The elicitation mode was "$raw", which is not one of: '
+      '${ElicitationMode.values.map((m) => m.name).join(', ')}';
 }
 
 StateError _undeclaredCapability(String capability) => StateError(

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -472,7 +472,7 @@ base class ServerConnection extends MCPBase {
           '`${Keys.inputRequests}` or `${Keys.requestState}`.',
         );
       }
-      // TODO: Delay a retry that carries no input requests, so it cannot spin.
+      // TODO: Delay a retry that carries no input requests.
       // https://github.com/dart-lang/ai/issues/162
       if (inputRequests != null) {
         // Resolve every handler before running any, so a request this client

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -144,9 +144,6 @@ base class ServerConnection extends MCPBase {
   final RootsSupport? _rootsSupport;
 
   /// Maximum number of automatic retries for an `input_required` result.
-  ///
-  /// This prevents an unbounded loop and matches the TypeScript and Python SDK
-  /// defaults.
   static const _maxInputRequiredRounds = 10;
 
   @override
@@ -457,8 +454,7 @@ base class ServerConnection extends MCPBase {
           '`${Keys.inputRequests}` or `${Keys.requestState}`.',
         );
       }
-      // TODO: Pace a leg carrying only request state, which nothing else slows
-      // down, the way the TypeScript and Python SDKs do.
+      // TODO: Pace a retry for a result that carries no input requests.
       if (inputRequests != null) {
         final handlers = [
           for (final entry in inputRequests.entries)

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -520,8 +520,8 @@ base class ServerConnection extends MCPBase {
         if (serverInfo == null) {
           throw StateError(
             'The server sent a sampling input request, but this connection '
-            'has no `serverInfo` to give the handler. Only `initialize` fills '
-            'it in, and 2026-07-28 has no handshake to run.',
+            'has no `serverInfo` to give the handler. Set it alongside '
+            '`protocolVersion` when your transport settles the version.',
           );
         }
         return () async =>

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -416,6 +416,9 @@ base class ServerConnection extends MCPBase {
     String methodName,
     WithInputResponses request,
   ) async {
+    if (serverInfo == null || protocolVersion < ProtocolVersion.v2026_07_28) {
+      return sendRequest<T>(methodName, request);
+    }
     final originalRequest = request as Map<String, Object?>;
     var result = (await sendRequest<T>(methodName, request)) as Result;
     for (
@@ -433,6 +436,13 @@ base class ServerConnection extends MCPBase {
       final inputRequired = result as InputRequiredResult;
       final responses = <String, Result>{};
       final inputRequests = inputRequired.inputRequests;
+      final requestState = inputRequired.requestState;
+      if (inputRequests == null && requestState == null) {
+        throw StateError(
+          'The server returned `${ResultTypes.inputRequired}` without '
+          '`${Keys.inputRequests}` or `${Keys.requestState}`.',
+        );
+      }
       if (inputRequests != null) {
         final handlers = [
           for (final entry in inputRequests.entries)
@@ -449,8 +459,7 @@ base class ServerConnection extends MCPBase {
                       entry.key != Keys.requestState)
                     entry.key: entry.value,
                 if (responses.isNotEmpty) Keys.inputResponses: responses,
-                if (inputRequired.requestState case final requestState?)
-                  Keys.requestState: requestState,
+                if (requestState != null) Keys.requestState: requestState,
               }
               as WithInputResponses;
       result = (await sendRequest<T>(methodName, retryRequest)) as Result;
@@ -461,7 +470,8 @@ base class ServerConnection extends MCPBase {
   Future<Result> Function() _inputRequestHandler(InputRequest inputRequest) {
     switch (inputRequest.method) {
       case ElicitRequest.methodName:
-        final request = inputRequest.params as ElicitRequest;
+        final request =
+            _inputRequestParams(inputRequest, required: true)! as ElicitRequest;
         final raw = request.rawMode;
         if (raw != null && !ElicitationMode.values.any((m) => m.name == raw)) {
           throw StateError(
@@ -495,11 +505,13 @@ base class ServerConnection extends MCPBase {
         final support = _samplingSupport;
         if (support == null) {
           throw _missingClientCapability(
-            'sampling',
+            Keys.sampling,
             ClientCapabilities(sampling: {}),
           );
         }
-        final request = inputRequest.params as CreateMessageRequest;
+        final request =
+            _inputRequestParams(inputRequest, required: true)!
+                as CreateMessageRequest;
         final serverInfo = this.serverInfo!;
         return () async =>
             await support.handleCreateMessage(request, serverInfo);
@@ -507,11 +519,13 @@ base class ServerConnection extends MCPBase {
         final support = _rootsSupport;
         if (support == null) {
           throw _missingClientCapability(
-            'roots',
+            Keys.roots,
             ClientCapabilities(roots: RootsCapabilities()),
           );
         }
-        final request = inputRequest.params as ListRootsRequest?;
+        final request =
+            _inputRequestParams(inputRequest, required: false)
+                as ListRootsRequest?;
         return () async => await support.handleListRoots(request);
       default:
         throw StateError(
@@ -550,6 +564,21 @@ base class ServerConnection extends MCPBase {
   // TODO: Implement automatic debouncing.
   Future<CompleteResult> requestCompletions(CompleteRequest request) =>
       sendRequest(CompleteRequest.methodName, request);
+}
+
+Map<String, Object?>? _inputRequestParams(
+  InputRequest inputRequest, {
+  required bool required,
+}) {
+  final params = (inputRequest as Map<String, Object?>)[Keys.params];
+  if (params == null && !required) return null;
+  if (params is! Map) {
+    throw StateError(
+      'The input request params for "${inputRequest.method}" were '
+      '${params.runtimeType}, expected an object.',
+    );
+  }
+  return params.cast<String, Object?>();
 }
 
 RpcException _missingClientCapability(

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -156,6 +156,20 @@ base class ServerConnection extends MCPBase {
   @override
   String get name => serverInfo?.name ?? super.name;
 
+  /// The [serverInfo] to hand [SamplingSupport.handleCreateMessage], which
+  /// takes it non-null.
+  Implementation get _samplingServerInfo {
+    final serverInfo = this.serverInfo;
+    if (serverInfo == null) {
+      throw StateError(
+        'The server asked for sampling, but this connection has no '
+        '`serverInfo` to give the handler. Set it alongside `protocolVersion` '
+        'when your transport settles the version.',
+      );
+    }
+    return serverInfo;
+  }
+
   /// Emits an event any time the server notifies us of a change to the list of
   /// prompts it supports.
   ///
@@ -245,7 +259,7 @@ base class ServerConnection extends MCPBase {
       registerRequestHandler(
         CreateMessageRequest.methodName,
         (CreateMessageRequest request) =>
-            samplingSupport.handleCreateMessage(request, serverInfo!),
+            samplingSupport.handleCreateMessage(request, _samplingServerInfo),
       );
     }
 
@@ -517,14 +531,7 @@ base class ServerConnection extends MCPBase {
         final request =
             _inputRequestParams(inputRequest, required: true)!
                 as CreateMessageRequest;
-        final serverInfo = this.serverInfo;
-        if (serverInfo == null) {
-          throw StateError(
-            'The server sent a sampling input request, but this connection '
-            'has no `serverInfo` to give the handler. Set it alongside '
-            '`protocolVersion` when your transport settles the version.',
-          );
-        }
+        final serverInfo = _samplingServerInfo;
         return () async =>
             await support.handleCreateMessage(request, serverInfo);
       case ListRootsRequest.methodName:

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -467,10 +467,10 @@ base class ServerConnection extends MCPBase {
       result.resultType == ResultTypes.inputRequired;
       round++
     ) {
-      if (round == maxInputRequiredRounds) {
+      if (round >= maxInputRequiredRounds) {
         throw ArgumentError(
           'The server returned `${ResultTypes.inputRequired}` after '
-          '$maxInputRequiredRounds retries for `$methodName`. Expected '
+          '$round retries for `$methodName`. Expected '
           '`${ResultTypes.complete}`.',
         );
       }

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -118,9 +118,8 @@ base class ServerConnection extends MCPBase {
   /// The version of the protocol this connection speaks, or `null` until one
   /// is settled.
   ///
-  /// [initialize] fills this in for a version this client supports. A
-  /// transport which carries its own supported versions assigns it directly,
-  /// since 2026-07-28 has no handshake to negotiate one.
+  /// [initialize] fills this in for a version this client supports. Assign it
+  /// directly if your transport settles the version outside the handshake.
   ///
   /// Some APIs may error if you attempt to use them without first checking the
   /// protocol version.
@@ -128,8 +127,9 @@ base class ServerConnection extends MCPBase {
 
   /// The [Implementation] returned from the [initialize] request.
   ///
-  /// Only non-null after [initialize] has successfully completed, or once a
-  /// transport which settles the version itself sets it. Sampling needs one.
+  /// Only non-null after [initialize] has successfully completed. Sampling
+  /// hands it to the handler, so set it too wherever you set
+  /// [protocolVersion].
   Implementation? serverInfo;
 
   /// The [ServerCapabilities] returned from the [initialize] request.
@@ -452,7 +452,7 @@ base class ServerConnection extends MCPBase {
       final inputRequests = inputRequired.inputRequests;
       final requestState = inputRequired.requestState;
       if (inputRequests == null && requestState == null) {
-        throw StateError(
+        throw ArgumentError(
           'The server returned `${ResultTypes.inputRequired}` without '
           '`${Keys.inputRequests}` or `${Keys.requestState}`.',
         );
@@ -460,6 +460,8 @@ base class ServerConnection extends MCPBase {
       // TODO: Delay a retry that carries no input requests, so it cannot spin.
       // https://github.com/dart-lang/ai/issues/162
       if (inputRequests != null) {
+        // Resolve every handler before running any, so a request this client
+        // cannot serve stops the round before a partial dispatch.
         final handlers = [
           for (final entry in inputRequests.entries)
             MapEntry(entry.key, _inputRequestHandler(entry.value)),
@@ -491,7 +493,7 @@ base class ServerConnection extends MCPBase {
         final request =
             _inputRequestParams(inputRequest, required: true)! as ElicitRequest;
         final badMode = _invalidElicitationMode(request);
-        if (badMode != null) throw StateError(badMode);
+        if (badMode != null) throw ArgumentError(badMode);
         switch (request.mode) {
           case ElicitationMode.form:
             final support = _elicitationFormSupport;
@@ -534,7 +536,7 @@ base class ServerConnection extends MCPBase {
                 as ListRootsRequest?;
         return () async => await support.handleListRoots(request);
       default:
-        throw StateError(
+        throw ArgumentError(
           'The input request method was "${inputRequest.method}", which is '
           'not one of: ${ElicitRequest.methodName}, '
           '${CreateMessageRequest.methodName}, ${ListRootsRequest.methodName}',
@@ -579,7 +581,7 @@ Map<String, Object?>? _inputRequestParams(
   final params = (inputRequest as Map<String, Object?>)[Keys.params];
   if (params == null && !required) return null;
   if (params is! Map) {
-    throw StateError(
+    throw ArgumentError(
       'The input request params for "${inputRequest.method}" were '
       '${params.runtimeType}, expected an object.',
     );
@@ -591,8 +593,9 @@ Map<String, Object?>? _inputRequestParams(
 /// [ElicitationMode], or null if this client can read its mode.
 ///
 /// [ElicitRequest.mode] reports an unknown mode as `Bad state: No element`, so
-/// both entry points check the raw value first and name it themselves. They
-/// throw different types, which is why this returns the message.
+/// both entry points check the raw value first and name it themselves. One
+/// answers the server with an [RpcException] and the other throws to the
+/// caller, so this returns the message and lets each one wrap it.
 String? _invalidElicitationMode(ElicitRequest request) {
   final raw = request.rawMode;
   if (raw == null || ElicitationMode.values.any((m) => m.name == raw)) {

--- a/pkgs/dart_mcp/lib/src/shared.dart
+++ b/pkgs/dart_mcp/lib/src/shared.dart
@@ -132,7 +132,7 @@ base class MCPBase {
   /// Sends [request] to the peer like [sendRequest] does, but leaves any
   /// progress stream for it open.
   ///
-  /// This is for a caller which sends several requests under one progress
+  /// This is for a caller that sends several requests under one progress
   /// token, such as an `input_required` retry. That caller owns the token and
   /// hands it back with [closeProgress] once it stops sending.
   @protected

--- a/pkgs/dart_mcp/lib/src/shared.dart
+++ b/pkgs/dart_mcp/lib/src/shared.dart
@@ -14,6 +14,7 @@ import 'package:json_rpc_2/json_rpc_2.dart';
 import 'package:meta/meta.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'api/api.dart';
+import 'utils/constants.dart';
 
 /// Base class for MCP server-related implementations.
 ///
@@ -116,20 +117,23 @@ base class MCPBase {
   /// Sends [request] to the peer, and handles coercing the response to the
   /// type [T].
   ///
-  /// Closes any progress streams for [request] once the response has been
-  /// received.
+  /// Closes any progress streams for [request] once the request is done. An
+  /// `input_required` result does not finish it, since the client sends the
+  /// request again under the same progress token, so that stream stays open
+  /// and whoever retries closes it with [closeProgress].
   Future<T> sendRequest<T extends Result?>(
     String methodName, [
     Request? request,
   ]) async {
+    Map<String, Object?>? response;
     try {
-      return ((await _peer.sendRequest(methodName, request)) as Map?)
-              ?.cast<String, Object?>()
-          as T;
+      response =
+          ((await _peer.sendRequest(methodName, request)) as Map?)
+              ?.cast<String, Object?>();
+      return response as T;
     } finally {
-      final token = request?.meta?.progressToken;
-      if (token != null) {
-        await _progressControllers.remove(token)?.close();
+      if ((response as Result?)?.resultType != ResultTypes.inputRequired) {
+        await closeProgress(request);
       }
     }
   }
@@ -163,6 +167,17 @@ base class MCPBase {
     return (_progressControllers[token] ??=
             StreamController<ProgressNotification>.broadcast())
         .stream;
+  }
+
+  /// Closes the stream [onProgress] returned for [request], if it opened one.
+  ///
+  /// [sendRequest] calls this when a request is done. A caller which sends
+  /// several requests under one progress token, such as an `input_required`
+  /// retry, calls it once it stops sending them.
+  @protected
+  Future<void> closeProgress(Request? request) async {
+    final token = request?.meta?.progressToken;
+    if (token != null) await _progressControllers.remove(token)?.close();
   }
 
   /// Pings the peer, and returns whether or not it responded within

--- a/pkgs/dart_mcp/lib/src/shared.dart
+++ b/pkgs/dart_mcp/lib/src/shared.dart
@@ -14,7 +14,6 @@ import 'package:json_rpc_2/json_rpc_2.dart';
 import 'package:meta/meta.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'api/api.dart';
-import 'utils/constants.dart';
 
 /// Base class for MCP server-related implementations.
 ///
@@ -117,26 +116,33 @@ base class MCPBase {
   /// Sends [request] to the peer, and handles coercing the response to the
   /// type [T].
   ///
-  /// Closes any progress streams for [request] once the request is done. An
-  /// `input_required` result does not finish it, since the client sends the
-  /// request again under the same progress token, so that stream stays open
-  /// and whoever retries closes it with [closeProgress].
+  /// Closes any progress streams for [request] once the response has been
+  /// received.
   Future<T> sendRequest<T extends Result?>(
     String methodName, [
     Request? request,
   ]) async {
-    Map<String, Object?>? response;
     try {
-      response =
-          ((await _peer.sendRequest(methodName, request)) as Map?)
-              ?.cast<String, Object?>();
-      return response as T;
+      return await sendRequestKeepingProgress<T>(methodName, request);
     } finally {
-      if ((response as Result?)?.resultType != ResultTypes.inputRequired) {
-        await closeProgress(request);
-      }
+      await closeProgress(request);
     }
   }
+
+  /// Sends [request] to the peer like [sendRequest] does, but leaves any
+  /// progress stream for it open.
+  ///
+  /// This is for a caller which sends several requests under one progress
+  /// token, such as an `input_required` retry. That caller owns the token and
+  /// hands it back with [closeProgress] once it stops sending.
+  @protected
+  Future<T> sendRequestKeepingProgress<T extends Result?>(
+    String methodName, [
+    Request? request,
+  ]) async =>
+      ((await _peer.sendRequest(methodName, request)) as Map?)
+              ?.cast<String, Object?>()
+          as T;
 
   /// The peer may ping us at any time, and we should respond with an empty
   /// response.
@@ -171,9 +177,8 @@ base class MCPBase {
 
   /// Closes the stream [onProgress] returned for [request], if it opened one.
   ///
-  /// [sendRequest] calls this when a request is done. A caller which sends
-  /// several requests under one progress token, such as an `input_required`
-  /// retry, calls it once it stops sending them.
+  /// [sendRequest] calls this when a request is done. A caller using
+  /// [sendRequestKeepingProgress] calls it once it stops sending.
   @protected
   Future<void> closeProgress(Request? request) async {
     final token = request?.meta?.progressToken;

--- a/pkgs/dart_mcp/test/client/input_required_test.dart
+++ b/pkgs/dart_mcp/test/client/input_required_test.dart
@@ -10,6 +10,46 @@ import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
 
 void main() {
+  test('does not interpret input-required results before 2026-07-28', () async {
+    final client = MCPClient(
+      Implementation(name: 'test client', version: '0.1.0'),
+    );
+    final harness = _WireHarness(client, (request, requestNumber) {
+      return switch (request['method']) {
+        InitializeRequest.methodName => {
+          'protocolVersion': '2025-11-25',
+          'capabilities': <String, Object?>{},
+          'serverInfo': {'name': 'wire server', 'version': '1'},
+        },
+        CallToolRequest.methodName => {
+          'resultType': 'input_required',
+          'content': [
+            {'type': 'text', 'text': 'legacy result'},
+          ],
+        },
+        _ => throw StateError('Unexpected method ${request['method']}'),
+      };
+    }, protocolVersion: null);
+
+    await harness.connection.initialize(
+      InitializeRequest(
+        protocolVersion: ProtocolVersion.v2025_11_25,
+        capabilities: client.capabilities,
+        clientInfo: client.implementation,
+      ),
+    );
+    final result = await harness.connection.callTool(
+      CallToolRequest(name: 'task'),
+    );
+
+    expect(harness.connection.protocolVersion, ProtocolVersion.v2025_11_25);
+    expect((result.content.single as TextContent).text, 'legacy result');
+    expect(harness.requests.map((request) => request['method']), [
+      InitializeRequest.methodName,
+      CallToolRequest.methodName,
+    ]);
+  });
+
   test('dispatches each input request and retries the tool call', () async {
     final client =
         _InputClient()
@@ -84,6 +124,45 @@ void main() {
       {'uri': 'file:///workspace', 'name': 'workspace'},
     ]);
     expect(harness.requests.first['id'], isNot(harness.requests.last['id']));
+  });
+
+  test('retries after accepting a URL elicitation', () async {
+    final client = _UrlInputClient();
+    final harness = _WireHarness(client, (request, requestNumber) {
+      if (requestNumber == 1) {
+        return {
+          'resultType': 'input_required',
+          'inputRequests': {
+            'url': {
+              'method': 'elicitation/create',
+              'params': {
+                'mode': 'url',
+                'message': 'Open the URL',
+                'url': 'https://example.com',
+              },
+            },
+          },
+          'requestState': 'url-state',
+        };
+      }
+      return {
+        'resultType': 'complete',
+        'content': [
+          {'type': 'text', 'text': 'done'},
+        ],
+      };
+    });
+
+    await harness.connection.callTool(CallToolRequest(name: 'task'));
+
+    expect(client.callCount, 1);
+    expect(harness.requests, hasLength(2));
+    final retry = _params(harness.requests.last);
+    expect(retry['requestState'], 'url-state');
+    expect(
+      ((retry['inputResponses'] as Map)['url'] as Map)['action'],
+      'accept',
+    );
   });
 
   final requestCases = <
@@ -221,6 +300,76 @@ void main() {
     expect(secondRetry, isNot(contains('requestState')));
   });
 
+  for (final boundaryCase in [
+    (
+      name: 'an empty request state',
+      result: <String, Object?>{
+        'resultType': 'input_required',
+        'requestState': '',
+      },
+      expectedState: '',
+    ),
+    (
+      name: 'an empty input request map',
+      result: <String, Object?>{
+        'resultType': 'input_required',
+        'inputRequests': <String, Object?>{},
+      },
+      expectedState: null,
+    ),
+  ]) {
+    test('retries with ${boundaryCase.name}', () async {
+      final harness = _WireHarness(
+        MCPClient(Implementation(name: 'test client', version: '0.1.0')),
+        (request, requestNumber) =>
+            requestNumber == 1
+                ? boundaryCase.result
+                : {
+                  'resultType': 'complete',
+                  'content': [
+                    {'type': 'text', 'text': 'done'},
+                  ],
+                },
+      );
+
+      await harness.connection.callTool(CallToolRequest(name: 'task'));
+
+      final retry = _params(harness.requests.last);
+      expect(retry['requestState'], boundaryCase.expectedState);
+      expect(retry, isNot(contains('inputResponses')));
+    });
+  }
+
+  for (final method in [
+    ElicitRequest.methodName,
+    CreateMessageRequest.methodName,
+    ListRootsRequest.methodName,
+  ]) {
+    test('rejects non-object params for $method', () async {
+      final harness = _WireHarness(
+        _InputClient(),
+        (request, requestNumber) => {
+          'resultType': 'input_required',
+          'inputRequests': {
+            'invalid': {'method': method, 'params': 'not an object'},
+          },
+        },
+      );
+
+      await expectLater(
+        harness.connection.callTool(CallToolRequest(name: 'task')),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            allOf(contains(method), contains('expected an object')),
+          ),
+        ),
+      );
+      expect(harness.requests, hasLength(1));
+    });
+  }
+
   test('stops when an input request needs an undeclared capability', () async {
     final client = _ElicitationClient();
     final harness = _WireHarness(
@@ -261,6 +410,25 @@ void main() {
     );
     expect(harness.requests, hasLength(1));
     expect(client.callCount, 0);
+  });
+
+  test('rejects an input-required result without requests or state', () async {
+    final harness = _WireHarness(
+      MCPClient(Implementation(name: 'test client', version: '0.1.0')),
+      (request, requestNumber) => {'resultType': 'input_required'},
+    );
+
+    await expectLater(
+      harness.connection.callTool(CallToolRequest(name: 'task')),
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          allOf(contains('inputRequests'), contains('requestState')),
+        ),
+      ),
+    );
+    expect(harness.requests, hasLength(1));
   });
 
   test('stops after ten input-required retry rounds', () async {
@@ -308,11 +476,18 @@ final class _WireHarness {
   late final ServerConnection connection;
   late final StreamSubscription<Map<String, Object?>> _subscription;
 
-  _WireHarness(this.client, this._respond) {
+  _WireHarness(
+    this.client,
+    this._respond, {
+    ProtocolVersion? protocolVersion = ProtocolVersion.v2026_07_28,
+  }) {
     connection = client.connectServer(
       StreamChannel.withGuarantees(_incoming.stream, _outgoing.sink),
     );
-    connection.serverInfo = Implementation(name: 'wire server', version: '1');
+    if (protocolVersion != null) {
+      connection.protocolVersion = protocolVersion;
+      connection.serverInfo = Implementation(name: 'wire server', version: '1');
+    }
     _subscription = _outgoing.stream.listen((request) {
       requests.add(request);
       _incoming.add({
@@ -373,6 +548,22 @@ final class _ElicitationClient extends MCPClient with ElicitationFormSupport {
   int callCount = 0;
 
   _ElicitationClient()
+    : super(Implementation(name: 'test client', version: '0.1.0'));
+
+  @override
+  FutureOr<ElicitResult> handleElicitation(
+    ElicitRequest request,
+    ServerConnection connection,
+  ) {
+    callCount++;
+    return ElicitResult(action: ElicitationAction.accept);
+  }
+}
+
+final class _UrlInputClient extends MCPClient with ElicitationUrlSupport {
+  int callCount = 0;
+
+  _UrlInputClient()
     : super(Implementation(name: 'test client', version: '0.1.0'));
 
   @override

--- a/pkgs/dart_mcp/test/client/input_required_test.dart
+++ b/pkgs/dart_mcp/test/client/input_required_test.dart
@@ -49,8 +49,7 @@ void main() {
     ]);
   });
 
-  test('does not interpret an input-required result before a version is '
-      'settled', () async {
+  test('treats an unsettled version like one before 2026-07-28', () async {
     final client =
         _InputClient()
           ..addRoot(Root(uri: 'file:///workspace', name: 'workspace'));
@@ -692,6 +691,29 @@ void main() {
       harness.requests.map((request) => request['id']).toSet(),
       hasLength(11),
     );
+  });
+
+  test('stops after the rounds the caller set', () async {
+    final harness = _WireHarness(
+      MCPClient(Implementation(name: 'test client', version: '0.1.0')),
+      (request, requestNumber) => {
+        'resultType': 'input_required',
+        'requestState': 'still-waiting',
+      },
+    );
+    harness.connection.maxInputRequiredRounds = 2;
+
+    await expectLater(
+      harness.connection.callTool(CallToolRequest(name: 'task')),
+      throwsA(
+        isA<ArgumentError>().having(
+          (error) => error.message,
+          'message',
+          allOf(contains('input_required'), contains('2')),
+        ),
+      ),
+    );
+    expect(harness.requests, hasLength(3));
   });
 
   test('reports progress from every round under the original token', () async {

--- a/pkgs/dart_mcp/test/client/input_required_test.dart
+++ b/pkgs/dart_mcp/test/client/input_required_test.dart
@@ -362,6 +362,41 @@ void main() {
     expect(secondRetry, isNot(contains('requestState')));
   });
 
+  test(
+    'drops earlier input responses on a round that answers nothing',
+    () async {
+      final harness = _WireHarness(
+        MCPClient(Implementation(name: 'test client', version: '0.1.0')),
+        (request, requestNumber) =>
+            requestNumber == 1
+                ? {'resultType': 'input_required', 'requestState': 'state-only'}
+                : {
+                  'resultType': 'complete',
+                  'content': [
+                    {'type': 'text', 'text': 'done'},
+                  ],
+                },
+      );
+
+      await harness.connection.callTool(
+        CallToolRequest(
+          name: 'task',
+          inputResponses: {
+            'old': ElicitResult(action: ElicitationAction.decline),
+          },
+        ),
+      );
+
+      expect(harness.requests, hasLength(2));
+      expect((_params(harness.requests.first)['inputResponses'] as Map).keys, [
+        'old',
+      ]);
+      final retry = _params(harness.requests.last);
+      expect(retry, isNot(contains('inputResponses')));
+      expect(retry['requestState'], 'state-only');
+    },
+  );
+
   for (final boundaryCase in [
     (
       name: 'an empty request state',
@@ -460,6 +495,37 @@ void main() {
       expect(harness.requests, hasLength(1));
     });
   }
+
+  test('answers a roots/list request that carries no params', () async {
+    final client =
+        _InputClient()
+          ..addRoot(Root(uri: 'file:///workspace', name: 'workspace'));
+    final harness = _WireHarness(
+      client,
+      (request, requestNumber) =>
+          requestNumber == 1
+              ? {
+                'resultType': 'input_required',
+                'inputRequests': {
+                  'roots': {'method': 'roots/list'},
+                },
+              }
+              : {
+                'resultType': 'complete',
+                'content': [
+                  {'type': 'text', 'text': 'done'},
+                ],
+              },
+    );
+
+    await harness.connection.callTool(CallToolRequest(name: 'task'));
+
+    expect(client.handled, ['roots/list']);
+    expect(harness.requests, hasLength(2));
+    expect((_params(harness.requests.last)['inputResponses'] as Map).keys, [
+      'roots',
+    ]);
+  });
 
   test('rejects an input request whose elicitation mode is unknown', () async {
     final client = _InputClient();

--- a/pkgs/dart_mcp/test/client/input_required_test.dart
+++ b/pkgs/dart_mcp/test/client/input_required_test.dart
@@ -747,6 +747,32 @@ void main() {
     expect(harness.requests, hasLength(1));
   });
 
+  test('answers past the default cap when the caller clears it', () async {
+    final harness = _WireHarness(
+      MCPClient(Implementation(name: 'test client', version: '0.1.0')),
+      (request, requestNumber) =>
+          requestNumber <= 12
+              ? {
+                'resultType': 'input_required',
+                'requestState': 'still-waiting',
+              }
+              : {
+                'resultType': 'complete',
+                'content': [
+                  {'type': 'text', 'text': 'done'},
+                ],
+              },
+    );
+    harness.connection.maxInputRequiredRounds = null;
+
+    final result = await harness.connection.callTool(
+      CallToolRequest(name: 'task'),
+    );
+
+    expect((result.content.single as TextContent).text, 'done');
+    expect(harness.requests, hasLength(13));
+  });
+
   test('reports progress from every round under the original token', () async {
     final harness = _WireHarness(
       MCPClient(Implementation(name: 'test client', version: '0.1.0')),

--- a/pkgs/dart_mcp/test/client/input_required_test.dart
+++ b/pkgs/dart_mcp/test/client/input_required_test.dart
@@ -456,6 +456,79 @@ void main() {
       hasLength(11),
     );
   });
+
+  test('reports progress from every round under the original token', () async {
+    final harness = _WireHarness(
+      MCPClient(Implementation(name: 'test client', version: '0.1.0')),
+      (request, requestNumber) =>
+          requestNumber == 1
+              ? {'resultType': 'input_required', 'requestState': 'state'}
+              : {
+                'resultType': 'complete',
+                'content': [
+                  {'type': 'text', 'text': 'done'},
+                ],
+              },
+      sendProgress: true,
+    );
+    final request = CallToolRequest(
+      name: 'task',
+      meta: MetaWithProgressToken(progressToken: ProgressToken('token')),
+    );
+    final progress = <num>[];
+    var streamClosed = false;
+    harness.connection
+        .onProgress(request)
+        .listen(
+          (notification) => progress.add(notification.progress),
+          onDone: () => streamClosed = true,
+        );
+
+    await harness.connection.callTool(request);
+    await pumpEventQueue();
+
+    expect(harness.requests, hasLength(2));
+    expect(harness.progressSent, 2);
+    expect(progress, [1, 2]);
+    expect(streamClosed, isTrue);
+  });
+
+  test('closes the progress stream once the retries stop', () async {
+    final harness = _WireHarness(
+      MCPClient(Implementation(name: 'test client', version: '0.1.0')),
+      (request, requestNumber) => {
+        'resultType': 'input_required',
+        'requestState': 'still-waiting',
+      },
+      sendProgress: true,
+    );
+    final request = CallToolRequest(
+      name: 'task',
+      meta: MetaWithProgressToken(progressToken: ProgressToken('token')),
+    );
+    final progress = <num>[];
+    var streamClosed = false;
+    harness.connection
+        .onProgress(request)
+        .listen(
+          (notification) => progress.add(notification.progress),
+          onDone: () => streamClosed = true,
+        );
+
+    await expectLater(
+      harness.connection.callTool(request),
+      throwsA(isA<StateError>()),
+    );
+    await pumpEventQueue();
+
+    expect(harness.requests, hasLength(11));
+    expect(
+      harness.requests.map((request) => _params(request)['_meta']),
+      everyElement({'progressToken': 'token'}),
+    );
+    expect(progress, hasLength(11));
+    expect(streamClosed, isTrue);
+  });
 }
 
 Map<String, Object?> _params(Map<String, Object?> request) =>
@@ -470,9 +543,18 @@ typedef _Responder =
 final class _WireHarness {
   final MCPClient client;
   final _Responder _respond;
+
+  /// Whether to answer a request carrying a progress token with one progress
+  /// notification before its result.
+  final bool sendProgress;
+
   final _incoming = StreamController<Map<String, Object?>>();
   final _outgoing = StreamController<Map<String, Object?>>();
   final requests = <Map<String, Object?>>[];
+
+  /// How many progress notifications [sendProgress] has sent so far.
+  int progressSent = 0;
+
   late final ServerConnection connection;
   late final StreamSubscription<Map<String, Object?>> _subscription;
 
@@ -480,6 +562,7 @@ final class _WireHarness {
     this.client,
     this._respond, {
     ProtocolVersion? protocolVersion = ProtocolVersion.v2026_07_28,
+    this.sendProgress = false,
   }) {
     connection = client.connectServer(
       StreamChannel.withGuarantees(_incoming.stream, _outgoing.sink),
@@ -490,6 +573,14 @@ final class _WireHarness {
     }
     _subscription = _outgoing.stream.listen((request) {
       requests.add(request);
+      final token = (_params(request)['_meta'] as Map?)?['progressToken'];
+      if (sendProgress && token != null) {
+        _incoming.add({
+          'jsonrpc': '2.0',
+          'method': ProgressNotification.methodName,
+          'params': {'progressToken': token, 'progress': ++progressSent},
+        });
+      }
       _incoming.add({
         'jsonrpc': '2.0',
         'id': request['id'],

--- a/pkgs/dart_mcp/test/client/input_required_test.dart
+++ b/pkgs/dart_mcp/test/client/input_required_test.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:dart_mcp/client.dart';
-import 'package:json_rpc_2/json_rpc_2.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
 
@@ -399,13 +398,11 @@ void main() {
     await expectLater(
       harness.connection.callTool(CallToolRequest(name: 'task')),
       throwsA(
-        isA<RpcException>()
-            .having((error) => error.code, 'code', -32021)
-            .having(
-              (error) => (error.data as Map)['requiredCapabilities'],
-              'required capabilities',
-              {'sampling': <String, Object?>{}},
-            ),
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          contains('sampling'),
+        ),
       ),
     );
     expect(harness.requests, hasLength(1));
@@ -529,6 +526,34 @@ void main() {
     expect(progress, hasLength(11));
     expect(streamClosed, isTrue);
   });
+
+  test(
+    'releases the progress token on a connection before 2026-07-28',
+    () async {
+      final harness = _WireHarness(
+        MCPClient(Implementation(name: 'test client', version: '0.1.0')),
+        (request, requestNumber) => {
+          'resultType': 'input_required',
+          'requestState': 'state',
+        },
+        protocolVersion: ProtocolVersion.v2025_11_25,
+      );
+      final request = CallToolRequest(
+        name: 'task',
+        meta: MetaWithProgressToken(progressToken: ProgressToken('token')),
+      );
+      var streamClosed = false;
+      harness.connection
+          .onProgress(request)
+          .listen((notification) {}, onDone: () => streamClosed = true);
+
+      await harness.connection.callTool(request);
+      await pumpEventQueue();
+
+      expect(harness.requests, hasLength(1));
+      expect(streamClosed, isTrue);
+    },
+  );
 }
 
 Map<String, Object?> _params(Map<String, Object?> request) =>

--- a/pkgs/dart_mcp/test/client/input_required_test.dart
+++ b/pkgs/dart_mcp/test/client/input_required_test.dart
@@ -369,6 +369,35 @@ void main() {
     });
   }
 
+  test('rejects an input request whose elicitation mode is unknown', () async {
+    final client = _InputClient();
+    final harness = _WireHarness(
+      client,
+      (request, requestNumber) => {
+        'resultType': 'input_required',
+        'inputRequests': {
+          'form': {
+            'method': 'elicitation/create',
+            'params': {'mode': 'voice', 'message': 'Enter a value'},
+          },
+        },
+      },
+    );
+
+    await expectLater(
+      harness.connection.callTool(CallToolRequest(name: 'task')),
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          allOf(contains('voice'), contains('form')),
+        ),
+      ),
+    );
+    expect(harness.requests, hasLength(1));
+    expect(client.handled, isEmpty);
+  });
+
   test('stops when an input request needs an undeclared capability', () async {
     final client = _ElicitationClient();
     final harness = _WireHarness(

--- a/pkgs/dart_mcp/test/client/input_required_test.dart
+++ b/pkgs/dart_mcp/test/client/input_required_test.dart
@@ -1,0 +1,386 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:dart_mcp/client.dart';
+import 'package:json_rpc_2/json_rpc_2.dart';
+import 'package:stream_channel/stream_channel.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('dispatches each input request and retries the tool call', () async {
+    final client =
+        _InputClient()
+          ..addRoot(Root(uri: 'file:///workspace', name: 'workspace'));
+    final harness = _WireHarness(client, (request, requestNumber) {
+      if (requestNumber == 1) {
+        return {
+          'resultType': 'input_required',
+          'inputRequests': {
+            'form': {
+              'method': 'elicitation/create',
+              'params': {
+                'mode': 'form',
+                'message': 'Enter a value',
+                'requestedSchema': {
+                  'type': 'object',
+                  'properties': <String, Object?>{},
+                },
+              },
+            },
+            'sample': {
+              'method': 'sampling/createMessage',
+              'params': {'messages': <Object?>[], 'maxTokens': 1},
+            },
+            'roots': {'method': 'roots/list', 'params': <String, Object?>{}},
+          },
+          'requestState': 'opaque-state',
+        };
+      }
+      return {
+        'resultType': 'complete',
+        'content': [
+          {'type': 'text', 'text': 'done'},
+        ],
+      };
+    });
+
+    final result = await harness.connection.callTool(
+      CallToolRequest(
+        name: 'task',
+        arguments: {'keep': 1},
+        meta: MetaWithProgressToken(progressToken: ProgressToken('progress')),
+      ),
+    );
+
+    expect((result.content.single as TextContent).text, 'done');
+    expect(harness.requests, hasLength(2));
+    expect(
+      client.handled,
+      unorderedEquals([
+        'elicitation/create',
+        'sampling/createMessage',
+        'roots/list',
+      ]),
+    );
+    final first = _params(harness.requests.first);
+    final retry = _params(harness.requests.last);
+    expect(first, {
+      'name': 'task',
+      'arguments': {'keep': 1},
+      '_meta': {'progressToken': 'progress'},
+    });
+    expect(retry['name'], 'task');
+    expect(retry['arguments'], {'keep': 1});
+    expect(retry['_meta'], {'progressToken': 'progress'});
+    expect(retry['requestState'], 'opaque-state');
+    final responses = retry['inputResponses'] as Map;
+    expect(responses.keys, unorderedEquals(['form', 'sample', 'roots']));
+    expect((responses['form'] as Map)['action'], 'accept');
+    expect((responses['sample'] as Map)['model'], 'test-model');
+    expect((responses['roots'] as Map)['roots'], [
+      {'uri': 'file:///workspace', 'name': 'workspace'},
+    ]);
+    expect(harness.requests.first['id'], isNot(harness.requests.last['id']));
+  });
+
+  final requestCases = <
+    ({
+      String method,
+      Future<void> Function(ServerConnection) invoke,
+      Map<String, Object?> terminal,
+    })
+  >[
+    (
+      method: 'tools/call',
+      invoke: (connection) async {
+        final result = await connection.callTool(CallToolRequest(name: 'task'));
+        expect((result.content.single as TextContent).text, 'done');
+      },
+      terminal: {
+        'resultType': 'complete',
+        'content': [
+          {'type': 'text', 'text': 'done'},
+        ],
+      },
+    ),
+    (
+      method: 'prompts/get',
+      invoke: (connection) async {
+        final result = await connection.getPrompt(GetPromptRequest(name: 'p'));
+        expect(result.messages, hasLength(1));
+      },
+      terminal: {
+        'resultType': 'complete',
+        'messages': [
+          {
+            'role': 'assistant',
+            'content': {'type': 'text', 'text': 'done'},
+          },
+        ],
+      },
+    ),
+    (
+      method: 'resources/read',
+      invoke: (connection) async {
+        final result = await connection.readResource(
+          ReadResourceRequest(uri: 'file:///resource'),
+        );
+        expect(result.contents, hasLength(1));
+      },
+      terminal: {
+        'resultType': 'complete',
+        'contents': [
+          {'uri': 'file:///resource', 'text': 'done'},
+        ],
+      },
+    ),
+  ];
+  for (final requestCase in requestCases) {
+    test('retries ${requestCase.method} with request state', () async {
+      final harness = _WireHarness(_InputClient(), (request, requestNumber) {
+        if (requestNumber == 1) {
+          return {'resultType': 'input_required', 'requestState': 'state-only'};
+        }
+        return requestCase.terminal;
+      });
+
+      await requestCase.invoke(harness.connection);
+
+      expect(harness.requests, hasLength(2));
+      expect(harness.requests.map((request) => request['method']), [
+        requestCase.method,
+        requestCase.method,
+      ]);
+      expect(_params(harness.requests.first), isNot(contains('requestState')));
+      expect(_params(harness.requests.last)['requestState'], 'state-only');
+      expect(_params(harness.requests.last), isNot(contains('inputResponses')));
+      expect(harness.requests.first['id'], isNot(harness.requests.last['id']));
+    });
+  }
+
+  test('uses only the latest input responses on a later round', () async {
+    final client =
+        _InputClient()
+          ..addRoot(Root(uri: 'file:///workspace', name: 'workspace'));
+    final harness = _WireHarness(client, (request, requestNumber) {
+      return switch (requestNumber) {
+        1 => {
+          'resultType': 'input_required',
+          'inputRequests': {
+            'form': {
+              'method': 'elicitation/create',
+              'params': {
+                'mode': 'form',
+                'message': 'Enter a value',
+                'requestedSchema': {
+                  'type': 'object',
+                  'properties': <String, Object?>{},
+                },
+              },
+            },
+          },
+          'requestState': 'first-state',
+        },
+        2 => {
+          'resultType': 'input_required',
+          'inputRequests': {
+            'roots': {'method': 'roots/list', 'params': <String, Object?>{}},
+          },
+        },
+        _ => {
+          'resultType': 'complete',
+          'content': [
+            {'type': 'text', 'text': 'done'},
+          ],
+        },
+      };
+    });
+
+    await harness.connection.callTool(
+      CallToolRequest(
+        name: 'task',
+        inputResponses: {
+          'old': ElicitResult(action: ElicitationAction.decline),
+        },
+        requestState: 'old-state',
+      ),
+    );
+
+    expect(harness.requests, hasLength(3));
+    final initial = _params(harness.requests.first);
+    final firstRetry = _params(harness.requests[1]);
+    final secondRetry = _params(harness.requests[2]);
+    expect((initial['inputResponses'] as Map).keys, ['old']);
+    expect(initial['requestState'], 'old-state');
+    expect((firstRetry['inputResponses'] as Map).keys, ['form']);
+    expect(firstRetry['requestState'], 'first-state');
+    expect((secondRetry['inputResponses'] as Map).keys, ['roots']);
+    expect(secondRetry, isNot(contains('requestState')));
+  });
+
+  test('stops when an input request needs an undeclared capability', () async {
+    final client = _ElicitationClient();
+    final harness = _WireHarness(
+      client,
+      (request, requestNumber) => {
+        'resultType': 'input_required',
+        'inputRequests': {
+          'form': {
+            'method': 'elicitation/create',
+            'params': {
+              'mode': 'form',
+              'message': 'Enter a value',
+              'requestedSchema': {
+                'type': 'object',
+                'properties': <String, Object?>{},
+              },
+            },
+          },
+          'sample': {
+            'method': 'sampling/createMessage',
+            'params': {'messages': <Object?>[], 'maxTokens': 1},
+          },
+        },
+      },
+    );
+
+    await expectLater(
+      harness.connection.callTool(CallToolRequest(name: 'task')),
+      throwsA(
+        isA<RpcException>()
+            .having((error) => error.code, 'code', -32021)
+            .having(
+              (error) => (error.data as Map)['requiredCapabilities'],
+              'required capabilities',
+              {'sampling': <String, Object?>{}},
+            ),
+      ),
+    );
+    expect(harness.requests, hasLength(1));
+    expect(client.callCount, 0);
+  });
+
+  test('stops after ten input-required retry rounds', () async {
+    final harness = _WireHarness(
+      MCPClient(Implementation(name: 'test client', version: '0.1.0')),
+      (request, requestNumber) => {
+        'resultType': 'input_required',
+        'requestState': 'still-waiting',
+      },
+    );
+
+    await expectLater(
+      harness.connection.callTool(CallToolRequest(name: 'task')),
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          allOf(contains('input_required'), contains('10')),
+        ),
+      ),
+    );
+    expect(harness.requests, hasLength(11));
+    expect(
+      harness.requests.map((request) => request['id']).toSet(),
+      hasLength(11),
+    );
+  });
+}
+
+Map<String, Object?> _params(Map<String, Object?> request) =>
+    (request['params'] as Map).cast<String, Object?>();
+
+typedef _Responder =
+    Map<String, Object?> Function(
+      Map<String, Object?> request,
+      int requestNumber,
+    );
+
+final class _WireHarness {
+  final MCPClient client;
+  final _Responder _respond;
+  final _incoming = StreamController<Map<String, Object?>>();
+  final _outgoing = StreamController<Map<String, Object?>>();
+  final requests = <Map<String, Object?>>[];
+  late final ServerConnection connection;
+  late final StreamSubscription<Map<String, Object?>> _subscription;
+
+  _WireHarness(this.client, this._respond) {
+    connection = client.connectServer(
+      StreamChannel.withGuarantees(_incoming.stream, _outgoing.sink),
+    );
+    connection.serverInfo = Implementation(name: 'wire server', version: '1');
+    _subscription = _outgoing.stream.listen((request) {
+      requests.add(request);
+      _incoming.add({
+        'jsonrpc': '2.0',
+        'id': request['id'],
+        'result': _respond(request, requests.length),
+      });
+    });
+    addTearDown(_close);
+  }
+
+  Future<void> _close() async {
+    await client.shutdown();
+    await _subscription.cancel();
+    await _incoming.close();
+  }
+}
+
+final class _InputClient extends MCPClient
+    with RootsSupport, SamplingSupport, ElicitationFormSupport {
+  final handled = <String>[];
+
+  _InputClient() : super(Implementation(name: 'test client', version: '0.1.0'));
+
+  @override
+  FutureOr<ElicitResult> handleElicitation(
+    ElicitRequest request,
+    ServerConnection connection,
+  ) {
+    handled.add('elicitation/create');
+    return ElicitResult(
+      action: ElicitationAction.accept,
+      content: {'answer': 'accepted'},
+    );
+  }
+
+  @override
+  FutureOr<CreateMessageResult> handleCreateMessage(
+    CreateMessageRequest request,
+    Implementation serverInfo,
+  ) {
+    handled.add('sampling/createMessage');
+    return CreateMessageResult(
+      role: Role.assistant,
+      content: Content.text(text: 'sampled'),
+      model: 'test-model',
+    );
+  }
+
+  @override
+  FutureOr<ListRootsResult> handleListRoots([ListRootsRequest? request]) {
+    handled.add('roots/list');
+    return super.handleListRoots(request);
+  }
+}
+
+final class _ElicitationClient extends MCPClient with ElicitationFormSupport {
+  int callCount = 0;
+
+  _ElicitationClient()
+    : super(Implementation(name: 'test client', version: '0.1.0'));
+
+  @override
+  FutureOr<ElicitResult> handleElicitation(
+    ElicitRequest request,
+    ServerConnection connection,
+  ) {
+    callCount++;
+    return ElicitResult(action: ElicitationAction.accept);
+  }
+}

--- a/pkgs/dart_mcp/test/client/input_required_test.dart
+++ b/pkgs/dart_mcp/test/client/input_required_test.dart
@@ -49,6 +49,40 @@ void main() {
     ]);
   });
 
+  test('retries on a connection whose transport settled the version', () async {
+    final client =
+        _InputClient()
+          ..addRoot(Root(uri: 'file:///workspace', name: 'workspace'));
+    final harness = _WireHarness(client, (request, requestNumber) {
+      if (requestNumber == 1) {
+        return {
+          'resultType': 'input_required',
+          'inputRequests': {
+            'roots': {'method': 'roots/list', 'params': <String, Object?>{}},
+          },
+        };
+      }
+      return {
+        'resultType': 'complete',
+        'content': [
+          {'type': 'text', 'text': 'done'},
+        ],
+      };
+    }, withServerInfo: false);
+
+    final result = await harness.connection.callTool(
+      CallToolRequest(name: 'task'),
+    );
+
+    expect(harness.connection.serverInfo, isNull);
+    expect((result.content.single as TextContent).text, 'done');
+    expect(client.handled, ['roots/list']);
+    expect(harness.requests, hasLength(2));
+    expect((_params(harness.requests.last)['inputResponses'] as Map).keys, [
+      'roots',
+    ]);
+  });
+
   test('dispatches each input request and retries the tool call', () async {
     final client =
         _InputClient()
@@ -438,6 +472,36 @@ void main() {
     expect(client.callCount, 0);
   });
 
+  test('stops when a sampling input request has no serverInfo', () async {
+    final client = _InputClient();
+    final harness = _WireHarness(
+      client,
+      (request, requestNumber) => {
+        'resultType': 'input_required',
+        'inputRequests': {
+          'sample': {
+            'method': 'sampling/createMessage',
+            'params': {'messages': <Object?>[], 'maxTokens': 1},
+          },
+        },
+      },
+      withServerInfo: false,
+    );
+
+    await expectLater(
+      harness.connection.callTool(CallToolRequest(name: 'task')),
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          contains('serverInfo'),
+        ),
+      ),
+    );
+    expect(harness.requests, hasLength(1));
+    expect(client.handled, isEmpty);
+  });
+
   test('rejects an input-required result without requests or state', () async {
     final harness = _WireHarness(
       MCPClient(Implementation(name: 'test client', version: '0.1.0')),
@@ -617,12 +681,13 @@ final class _WireHarness {
     this._respond, {
     ProtocolVersion? protocolVersion = ProtocolVersion.v2026_07_28,
     this.sendProgress = false,
+    bool withServerInfo = true,
   }) {
     connection = client.connectServer(
       StreamChannel.withGuarantees(_incoming.stream, _outgoing.sink),
     );
-    if (protocolVersion != null) {
-      connection.protocolVersion = protocolVersion;
+    connection.protocolVersion = protocolVersion;
+    if (protocolVersion != null && withServerInfo) {
       connection.serverInfo = Implementation(name: 'wire server', version: '1');
     }
     _subscription = _outgoing.stream.listen((request) {

--- a/pkgs/dart_mcp/test/client/input_required_test.dart
+++ b/pkgs/dart_mcp/test/client/input_required_test.dart
@@ -560,6 +560,29 @@ void main() {
     expect(client.handled, isEmpty);
   });
 
+  test('names the missing serverInfo on a direct sampling request', () async {
+    final client = _InputClient();
+    final harness = _WireHarness(
+      client,
+      (request, requestNumber) => throw StateError('no client requests here'),
+      withServerInfo: false,
+    );
+
+    harness.send({
+      'jsonrpc': '2.0',
+      'id': 'sample',
+      'method': CreateMessageRequest.methodName,
+      'params': {'messages': <Object?>[], 'maxTokens': 1},
+    });
+    await pumpEventQueue();
+
+    expect(
+      (harness.responses.single['error'] as Map)['message'],
+      contains('`serverInfo`'),
+    );
+    expect(client.handled, isEmpty);
+  });
+
   test('rejects an input-required result without requests or state', () async {
     final harness = _WireHarness(
       MCPClient(Implementation(name: 'test client', version: '0.1.0')),
@@ -728,6 +751,9 @@ final class _WireHarness {
   final _outgoing = StreamController<Map<String, Object?>>();
   final requests = <Map<String, Object?>>[];
 
+  /// What this client answered the requests [send] made, in order.
+  final responses = <Map<String, Object?>>[];
+
   /// How many progress notifications [sendProgress] has sent so far.
   int progressSent = 0;
 
@@ -749,6 +775,10 @@ final class _WireHarness {
       connection.serverInfo = Implementation(name: 'wire server', version: '1');
     }
     _subscription = _outgoing.stream.listen((request) {
+      if (!request.containsKey('method')) {
+        responses.add(request);
+        return;
+      }
       requests.add(request);
       final token = (_params(request)['_meta'] as Map?)?['progressToken'];
       if (sendProgress && token != null) {
@@ -766,6 +796,9 @@ final class _WireHarness {
     });
     addTearDown(_close);
   }
+
+  /// Sends [request] to the client the way a server would.
+  void send(Map<String, Object?> request) => _incoming.add(request);
 
   Future<void> _close() async {
     await client.shutdown();

--- a/pkgs/dart_mcp/test/client/input_required_test.dart
+++ b/pkgs/dart_mcp/test/client/input_required_test.dart
@@ -49,6 +49,35 @@ void main() {
     ]);
   });
 
+  test('does not interpret an input-required result before a version is '
+      'settled', () async {
+    final client =
+        _InputClient()
+          ..addRoot(Root(uri: 'file:///workspace', name: 'workspace'));
+    final harness = _WireHarness(
+      client,
+      (request, requestNumber) => {
+        'resultType': 'input_required',
+        'content': [
+          {'type': 'text', 'text': 'unsettled result'},
+        ],
+        'inputRequests': {
+          'roots': {'method': 'roots/list', 'params': <String, Object?>{}},
+        },
+      },
+      protocolVersion: null,
+    );
+
+    final result = await harness.connection.callTool(
+      CallToolRequest(name: 'task'),
+    );
+
+    expect(harness.connection.protocolVersion, isNull);
+    expect((result.content.single as TextContent).text, 'unsettled result');
+    expect(client.handled, isEmpty);
+    expect(harness.requests, hasLength(1));
+  });
+
   test('retries on a connection whose transport settled the version', () async {
     final client =
         _InputClient()
@@ -392,7 +421,36 @@ void main() {
       await expectLater(
         harness.connection.callTool(CallToolRequest(name: 'task')),
         throwsA(
-          isA<StateError>().having(
+          isA<ArgumentError>().having(
+            (error) => error.message,
+            'message',
+            allOf(contains(method), contains('expected an object')),
+          ),
+        ),
+      );
+      expect(harness.requests, hasLength(1));
+    });
+  }
+
+  for (final method in [
+    ElicitRequest.methodName,
+    CreateMessageRequest.methodName,
+  ]) {
+    test('rejects absent params for $method', () async {
+      final harness = _WireHarness(
+        _InputClient(),
+        (request, requestNumber) => {
+          'resultType': 'input_required',
+          'inputRequests': {
+            'absent': {'method': method},
+          },
+        },
+      );
+
+      await expectLater(
+        harness.connection.callTool(CallToolRequest(name: 'task')),
+        throwsA(
+          isA<ArgumentError>().having(
             (error) => error.message,
             'message',
             allOf(contains(method), contains('expected an object')),
@@ -421,7 +479,7 @@ void main() {
     await expectLater(
       harness.connection.callTool(CallToolRequest(name: 'task')),
       throwsA(
-        isA<StateError>().having(
+        isA<ArgumentError>().having(
           (error) => error.message,
           'message',
           allOf(contains('voice'), contains('form')),
@@ -511,7 +569,7 @@ void main() {
     await expectLater(
       harness.connection.callTool(CallToolRequest(name: 'task')),
       throwsA(
-        isA<StateError>().having(
+        isA<ArgumentError>().having(
           (error) => error.message,
           'message',
           allOf(contains('inputRequests'), contains('requestState')),

--- a/pkgs/dart_mcp/test/client/input_required_test.dart
+++ b/pkgs/dart_mcp/test/client/input_required_test.dart
@@ -716,6 +716,37 @@ void main() {
     expect(harness.requests, hasLength(3));
   });
 
+  test('stops without retrying on a negative round cap', () async {
+    final harness = _WireHarness(
+      MCPClient(Implementation(name: 'test client', version: '0.1.0')),
+      (request, requestNumber) =>
+          requestNumber == 1
+              ? {
+                'resultType': 'input_required',
+                'requestState': 'still-waiting',
+              }
+              : {
+                'resultType': 'complete',
+                'content': [
+                  {'type': 'text', 'text': 'done'},
+                ],
+              },
+    );
+    harness.connection.maxInputRequiredRounds = -1;
+
+    await expectLater(
+      harness.connection.callTool(CallToolRequest(name: 'task')),
+      throwsA(
+        isA<ArgumentError>().having(
+          (error) => error.message,
+          'message',
+          allOf(contains('input_required'), contains('0 retries')),
+        ),
+      ),
+    );
+    expect(harness.requests, hasLength(1));
+  });
+
   test('reports progress from every round under the original token', () async {
     final harness = _WireHarness(
       MCPClient(Implementation(name: 'test client', version: '0.1.0')),

--- a/pkgs/dart_mcp/test/client/input_required_test.dart
+++ b/pkgs/dart_mcp/test/client/input_required_test.dart
@@ -614,7 +614,7 @@ void main() {
     await expectLater(
       harness.connection.callTool(CallToolRequest(name: 'task')),
       throwsA(
-        isA<StateError>().having(
+        isA<ArgumentError>().having(
           (error) => error.message,
           'message',
           allOf(contains('input_required'), contains('10')),
@@ -688,7 +688,7 @@ void main() {
 
     await expectLater(
       harness.connection.callTool(request),
-      throwsA(isA<StateError>()),
+      throwsA(isA<ArgumentError>()),
     );
     await pumpEventQueue();
 


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

The client half of MRTR. On an `input_required` result the connection fills in
what the server asked for and sends the call again. A request it cannot build
fails the call instead of answering the rest.

The handshake stops at 2025-11-25, so only a transport setting the version
itself reaches 2026-07-28. I made `protocolVersion` nullable. Nothing fills in
`serverInfo` there either, and both sampling paths name it.

`ServerConnection` gains `sendRequestWithInputs` for a mixin adding an
extension method. `maxInputRequiredRounds` moves the cap off ten. `MCPBase`
gains `@protected` `sendRequestKeepingProgress` and `closeProgress`. A retry
holds one progress token across its rounds.
