### PR TITLE
Set client serverInfo only when version negotiation succeeds

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -97,6 +97,10 @@
     `maximum` and `default` are `number` too. A peer sending
     `{"type": "integer", "minimum": 0.5}` sent something the getter threw on.
     `multipleOf` next to them already read `num`.
+  - `ServerConnection.serverInfo` stays `null` when version negotiation fails,
+    the way its dartdoc already described, instead of holding the rejected
+    server's implementation. `initialize` still returns that result and
+    `serverCapabilities` still holds what the server sent.
 - Add `supportsFormElicitation` and `supportsUrlElicitation` for a server to
   ask before it sends. An empty `elicitation` object still means form, the way
   `elicitation` read before the split.

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -318,13 +318,13 @@ base class ServerConnection extends MCPBase {
       InitializeRequest.methodName,
       request,
     );
-    serverInfo = response.serverInfo;
     serverCapabilities = response.capabilities;
     final serverVersion = response.protocolVersion;
     if (serverVersion == null || !serverVersion.isSupported) {
       await shutdown();
     } else {
       protocolVersion = serverVersion;
+      serverInfo = response.serverInfo;
     }
     return response;
   }

--- a/pkgs/dart_mcp/test/client_and_server_test.dart
+++ b/pkgs/dart_mcp/test/client_and_server_test.dart
@@ -347,6 +347,7 @@ void main() {
         await environment.initializeServer();
         expect(environment.client.connections, isEmpty);
         expect(environment.serverConnection.isActive, false);
+        expect(environment.serverConnection.serverInfo, isNull);
       },
     );
   });


### PR DESCRIPTION
`ServerConnection.serverInfo` already documented that it is only non-null once
`initialize` succeeds, but `initialize` assigned it before looking at the
version. A connection shut down over an unsupported version still held the
rejected server's implementation.

I moved the assignment next to `protocolVersion`, so it just lands in the
branch that runs when the version is one we support. `ServerConnection.name`
reads through it. A rejected connection now logs as `unknown`.
