### PR TITLE
cache client responses from server hints

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -177,8 +177,9 @@
   A response is only reused for a request whose `_meta` names 2026-07-28, under
   a key covering the parameters and that metadata. Entries are bounded per
   connection and are dropped by change notifications, stale cursors, and
-  `shutdown`. An `InputRequiredResult` and the retry it asks for are never
-  cached.
+  `shutdown`. A `resources/updated` also drops a read whose contents named
+  that URI, since the notification can name a sub-resource. An
+  `InputRequiredResult` and the retry it asks for are never cached.
 - Add `McpErrorCodes.headerMismatch` (`-32020`),
   `.missingRequiredClientCapability` (`-32021`), and
   `.unsupportedProtocolVersion` (`-32022`), the error codes the 2026-07-28

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -178,8 +178,12 @@
   a key covering the parameters and that metadata. Entries are bounded per
   connection and are dropped by change notifications, stale cursors, and
   `shutdown`. A `resources/updated` also drops a read whose contents named
-  that URI, since the notification can name a sub-resource. An
-  `InputRequiredResult` and the retry it asks for are never cached.
+  that URI, since the notification can name a sub-resource. A read still in
+  flight when one of its contents changes is not stored, and an update leaving
+  out its URI drops every cached read. A cache belongs to one
+  `ServerConnection`, so a `private` result stays inside the authorization
+  context it was fetched under. An `InputRequiredResult` and the retry it asks
+  for are never cached.
 - Add `McpErrorCodes.headerMismatch` (`-32020`),
   `.missingRequiredClientCapability` (`-32021`), and
   `.unsupportedProtocolVersion` (`-32022`), the error codes the 2026-07-28

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -172,18 +172,17 @@
   `ReadResourceResult` now implement `CacheableResult`, so the hints are
   readable on responses from servers that send them, and their factories take
   an optional `ttlMs` and `cacheScope`, which are left out when not passed.
-- Cache client responses for the six operations which carry caching hints, see
+- Cache client responses for the six operations that carry caching hints, see
   https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching.
-  A response is only reused for a request whose `_meta` names 2026-07-28, under
-  a key covering the parameters and that metadata. Entries are bounded per
-  connection and are dropped by change notifications, stale cursors, and
-  `shutdown`. A `resources/updated` also drops a read whose contents named
-  that URI, since the notification can name a sub-resource. A read still in
-  flight when one of its contents changes is not stored, and an update leaving
-  out its URI drops every cached read. A cache belongs to one
-  `ServerConnection`, so a `private` result stays inside the authorization
-  context it was fetched under. An `InputRequiredResult` and the retry it asks
-  for are never cached.
+  A response is reused when the request names 2026-07-28 in its `_meta` or the
+  connection settled on that revision, under a key covering the parameters and
+  that metadata. Entries are bounded per connection and are dropped by change
+  notifications, stale cursors, and `shutdown`. A `resources/updated` drops a
+  read whose contents named that URI, and one leaving its URI out drops every
+  cached read. A read still in flight when one of its contents changes is not
+  stored. A cache belongs to one `ServerConnection`, and a `private` result
+  never leaves it. An `InputRequiredResult` and the retry it asks for are never
+  cached.
 - Add `McpErrorCodes.headerMismatch` (`-32020`),
   `.missingRequiredClientCapability` (`-32021`), and
   `.unsupportedProtocolVersion` (`-32022`), the error codes the 2026-07-28

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -172,6 +172,13 @@
   `ReadResourceResult` now implement `CacheableResult`, so the hints are
   readable on responses from servers that send them, and their factories take
   an optional `ttlMs` and `cacheScope`, which are left out when not passed.
+- Cache client responses for the six operations which carry caching hints, see
+  https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching.
+  A response is only reused for a request whose `_meta` names 2026-07-28, under
+  a key covering the parameters and that metadata. Entries are bounded per
+  connection and are dropped by change notifications, stale cursors, and
+  `shutdown`. An `InputRequiredResult` and the retry it asks for are never
+  cached.
 - Add `McpErrorCodes.headerMismatch` (`-32020`),
   `.missingRequiredClientCapability` (`-32021`), and
   `.unsupportedProtocolVersion` (`-32022`), the error codes the 2026-07-28

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -376,11 +376,13 @@ base class ServerConnection extends MCPBase {
   /// response cache where the 2026-07-28 caching rules allow it.
   ///
   /// [sendRequest] and [sendRequestWithInputs] both go through here, so a
-  /// `resources/read` that later retries still consults the cache. Only a
-  /// request whose `_meta` names 2026-07-28 is cached. Cached answers drop
-  /// when the matching list-changed or resource-updated notification arrives,
-  /// when a paginated request reports its cursor is no longer valid, and on
-  /// [shutdown].
+  /// `resources/read` that later retries still consults the cache. A request
+  /// is cached when its `_meta` names 2026-07-28, or when it leaves the
+  /// version out and this connection settled on that revision. Cached answers
+  /// drop when the matching list-changed or resource-updated notification
+  /// arrives, when a paginated request reports its cursor is no longer valid,
+  /// and on [shutdown].
+  @protected
   @override
   Future<T> sendRequestKeepingProgress<T extends Result?>(
     String methodName, [

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -124,10 +124,40 @@ base class ServerConnection extends MCPBase {
   @visibleForTesting
   int get cachedResponseCount => _responseCache._entries.length;
 
+  /// The maximum number of responses cached by this connection.
+  ///
+  /// Reducing the value evicts the oldest entries first. Zero disables the
+  /// cache. The default is 512.
+  int get maxCachedResponses => _responseCache.maxEntries;
+  set maxCachedResponses(int value) {
+    RangeError.checkNotNegative(value, 'maxCachedResponses');
+    while (_responseCache._entries.length > value) {
+      _responseCache._entries.remove(_responseCache._entries.keys.first);
+    }
+    _responseCache.maxEntries = value;
+  }
+
+  /// The maximum TTL accepted for responses received by this connection.
+  ///
+  /// Zero disables the cache. The default is 24 hours.
+  Duration get maxCachedResponseTtl => _responseCache.maxTtl;
+  set maxCachedResponseTtl(Duration value) {
+    if (value.isNegative) {
+      throw ArgumentError.value(value, 'maxCachedResponseTtl');
+    }
+    _responseCache.maxTtl = value;
+  }
+
   /// Advances the cache clock by [duration].
   @visibleForTesting
   void elapseCachedResponses(Duration duration) {
     _responseCache._elapsedOffset += duration;
+  }
+
+  /// Stops the real-time part of the cache clock.
+  @visibleForTesting
+  void pauseCachedResponseClock() {
+    _responseCache._clock.stop();
   }
 
   /// The version of the protocol this connection speaks, or `null` until one
@@ -336,13 +366,7 @@ base class ServerConnection extends MCPBase {
     registerNotificationHandler<ResourceUpdatedNotification>(
       ResourceUpdatedNotification.methodName,
       (notification) {
-        // A notification that leaves `uri` out still reaches subscribers.
-        final uri = (notification as Map<String, Object?>)[Keys.uri];
-        if (uri is String) {
-          _responseCache.invalidateResource(uri);
-        } else {
-          _responseCache.invalidateAllResources();
-        }
+        _responseCache.invalidateResource(notification.uri);
         _resourceUpdatedController.sink.add(notification);
       },
     );

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -139,13 +139,16 @@ base class ServerConnection extends MCPBase {
 
   /// The maximum TTL accepted for responses received by this connection.
   ///
-  /// Zero disables the cache. The default is 24 hours.
+  /// Changing the value discards stored responses. Zero disables the cache.
+  /// The default is 24 hours.
   Duration get maxCachedResponseTtl => _responseCache.maxTtl;
   set maxCachedResponseTtl(Duration value) {
     if (value.isNegative) {
       throw ArgumentError.value(value, 'maxCachedResponseTtl');
     }
+    if (_responseCache.maxTtl == value) return;
     _responseCache.maxTtl = value;
+    _responseCache._entries.clear();
   }
 
   /// Advances the cache clock by [duration].

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -389,7 +389,13 @@ base class ServerConnection extends MCPBase {
     final meta = (request as Map<String, Object?>?)?[Keys.meta];
     final version =
         meta is Map<String, Object?> ? meta[Keys.protocolVersionMeta] : null;
-    if (version != ProtocolVersion.v2026_07_28.versionString) {
+    // Only `discover` names the revision in its own metadata. Every other
+    // request leaves it out and the negotiated version is what says whether
+    // the answer can be reused.
+    final onRevision =
+        version == ProtocolVersion.v2026_07_28.versionString ||
+        (version == null && protocolVersion == ProtocolVersion.v2026_07_28);
+    if (!onRevision) {
       return super.sendRequestKeepingProgress<T>(methodName, request);
     }
     return _responseCache.sendRequest<T>(

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -6,6 +6,8 @@ import 'dart:async';
 import 'dart:collection';
 
 import 'package:async/async.dart' show StreamExtensions;
+import 'package:collection/collection.dart';
+import 'package:json_rpc_2/error_code.dart' as error_code;
 import 'package:json_rpc_2/json_rpc_2.dart';
 import 'package:meta/meta.dart';
 import 'package:stream_channel/stream_channel.dart';
@@ -16,6 +18,7 @@ import '../shared.dart';
 import '../utils/constants.dart';
 
 part 'elicitation_support.dart';
+part 'response_cache.dart';
 part 'roots_support.dart';
 part 'sampling_support.dart';
 
@@ -115,6 +118,8 @@ base class MCPClient {
 
 /// An active server connection.
 base class ServerConnection extends MCPBase {
+  final _responseCache = _ClientResponseCache();
+
   /// The version of the protocol this connection speaks, or `null` until one
   /// is settled.
   ///
@@ -292,24 +297,40 @@ base class ServerConnection extends MCPBase {
       });
     }
 
-    registerNotificationHandler(
+    registerNotificationHandler<PromptListChangedNotification?>(
       PromptListChangedNotification.methodName,
-      _promptListChangedController.sink.add,
+      (notification) {
+        _responseCache.invalidateMethod(ListPromptsRequest.methodName);
+        _promptListChangedController.sink.add(notification);
+      },
     );
 
-    registerNotificationHandler(
+    registerNotificationHandler<ToolListChangedNotification?>(
       ToolListChangedNotification.methodName,
-      _toolListChangedController.sink.add,
+      (notification) {
+        _responseCache.invalidateMethod(ListToolsRequest.methodName);
+        _toolListChangedController.sink.add(notification);
+      },
     );
 
-    registerNotificationHandler(
+    registerNotificationHandler<ResourceListChangedNotification?>(
       ResourceListChangedNotification.methodName,
-      _resourceListChangedController.sink.add,
+      (notification) {
+        _responseCache
+          ..invalidateMethod(ListResourcesRequest.methodName)
+          ..invalidateMethod(ListResourceTemplatesRequest.methodName);
+        _resourceListChangedController.sink.add(notification);
+      },
     );
 
-    registerNotificationHandler(
+    registerNotificationHandler<ResourceUpdatedNotification>(
       ResourceUpdatedNotification.methodName,
-      _resourceUpdatedController.sink.add,
+      (notification) {
+        // A notification which leaves `uri` out still reaches subscribers.
+        final uri = (notification as Map<String, Object?>)[Keys.uri];
+        if (uri is String) _responseCache.invalidateResource(uri);
+        _resourceUpdatedController.sink.add(notification);
+      },
     );
 
     registerNotificationHandler(
@@ -326,6 +347,7 @@ base class ServerConnection extends MCPBase {
   /// Close all connections and streams so the process can cleanly exit.
   @override
   Future<void> shutdown() async {
+    _responseCache.clear();
     await Future.wait([
       super.shutdown(),
       _promptListChangedController.close(),
@@ -334,6 +356,33 @@ base class ServerConnection extends MCPBase {
       _resourceUpdatedController.close(),
       _logController.close(),
     ]);
+  }
+
+  /// Sends a request to the server, and answers it from this connection's
+  /// response cache where the 2026-07-28 caching rules allow it.
+  ///
+  /// [sendRequest] and [sendRequestWithInputs] both go through here, so a
+  /// `resources/read` that later retries still consults the cache. Only a
+  /// request whose `_meta` names 2026-07-28 is cached. Cached answers drop
+  /// when the matching list-changed or resource-updated notification arrives,
+  /// when a paginated request reports its cursor is no longer valid, and on
+  /// [shutdown].
+  @override
+  Future<T> sendRequestKeepingProgress<T extends Result?>(
+    String methodName, [
+    Request? request,
+  ]) {
+    final meta = (request as Map<String, Object?>?)?[Keys.meta];
+    final version =
+        meta is Map<String, Object?> ? meta[Keys.protocolVersionMeta] : null;
+    if (version != ProtocolVersion.v2026_07_28.versionString) {
+      return super.sendRequestKeepingProgress<T>(methodName, request);
+    }
+    return _responseCache.sendRequest<T>(
+      methodName,
+      request,
+      () => super.sendRequestKeepingProgress<T>(methodName, request),
+    );
   }
 
   /// Called after a successful call to [initialize].

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -120,6 +120,16 @@ base class MCPClient {
 base class ServerConnection extends MCPBase {
   final _responseCache = _ClientResponseCache();
 
+  /// The number of stored responses on this connection.
+  @visibleForTesting
+  int get cachedResponseCount => _responseCache._entries.length;
+
+  /// Advances the cache clock by [duration].
+  @visibleForTesting
+  void elapseCachedResponses(Duration duration) {
+    _responseCache._elapsedOffset += duration;
+  }
+
   /// The version of the protocol this connection speaks, or `null` until one
   /// is settled.
   ///

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -338,7 +338,11 @@ base class ServerConnection extends MCPBase {
       (notification) {
         // A notification which leaves `uri` out still reaches subscribers.
         final uri = (notification as Map<String, Object?>)[Keys.uri];
-        if (uri is String) _responseCache.invalidateResource(uri);
+        if (uri is String) {
+          _responseCache.invalidateResource(uri);
+        } else {
+          _responseCache.invalidateAllResources();
+        }
         _resourceUpdatedController.sink.add(notification);
       },
     );

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -336,7 +336,7 @@ base class ServerConnection extends MCPBase {
     registerNotificationHandler<ResourceUpdatedNotification>(
       ResourceUpdatedNotification.methodName,
       (notification) {
-        // A notification which leaves `uri` out still reaches subscribers.
+        // A notification that leaves `uri` out still reaches subscribers.
         final uri = (notification as Map<String, Object?>)[Keys.uri];
         if (uri is String) {
           _responseCache.invalidateResource(uri);

--- a/pkgs/dart_mcp/lib/src/client/response_cache.dart
+++ b/pkgs/dart_mcp/lib/src/client/response_cache.dart
@@ -1,0 +1,244 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+part of 'client.dart';
+
+final class _CacheKey {
+  const _CacheKey(this.methodName, this.parameter, this.context);
+
+  final String methodName;
+  final Object? parameter;
+  final Map<String, Object?>? context;
+
+  @override
+  bool operator ==(Object other) =>
+      other is _CacheKey &&
+      other.methodName == methodName &&
+      other.parameter == parameter &&
+      const DeepCollectionEquality().equals(other.context, context);
+
+  @override
+  int get hashCode => Object.hash(
+    methodName,
+    parameter,
+    const DeepCollectionEquality().hash(context),
+  );
+}
+
+final class _CacheEntry {
+  const _CacheEntry(this.result, this.expiresAt);
+
+  final Map<String, Object?> result;
+  final Duration expiresAt;
+}
+
+/// The `_meta` fields which change the answer to a cacheable request.
+///
+/// A request carrying any other field is sent to the server, since this
+/// package cannot tell whether that field changes the answer.
+const _contextKeys = {
+  Keys.protocolVersionMeta,
+  Keys.clientCapabilitiesMeta,
+  Keys.clientInfoMeta,
+  Keys.logLevelMeta,
+};
+
+/// The cache behind [ServerConnection.sendRequest].
+///
+/// Holds the results of the six operations the 2026-07-28 caching rules name,
+/// keyed by the request method, the parameters which change the answer, and
+/// the per-request context the caller sent. A result is stored only while it
+/// is complete, carries a positive `ttlMs` and carries a scope the schema
+/// allows, and the answers to an [InputRequiredResult] stay out entirely. A
+/// `ttlMs` past a day is clamped to a day. Without that a server could pin an
+/// answer for the life of the process, and a value large enough to overflow a
+/// [Duration] would write an entry that is already stale.
+///
+/// https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching
+final class _ClientResponseCache {
+  static const _maxEntries = 512;
+  static const _maxTtl = Duration(hours: 24);
+
+  final _entries = <_CacheKey, _CacheEntry>{};
+  final _pending = <_CacheKey, Object>{};
+  final _clock = Stopwatch()..start();
+
+  Future<T> sendRequest<T extends Result?>(
+    String methodName,
+    Request? request,
+    Future<T> Function() send,
+  ) async {
+    final requestMap = request as Map<String, Object?>?;
+    final meta = requestMap?[Keys.meta];
+    final metaMap = meta is Map<String, Object?> ? meta : null;
+    final cacheRequest =
+        requestMap == null || metaMap == null
+            ? requestMap
+            : ({...requestMap}..remove(Keys.meta));
+    final key =
+        metaMap != null && !metaMap.keys.every(_contextKeys.contains)
+            ? null
+            : _keyFor(methodName, cacheRequest, _contextOf(metaMap));
+
+    try {
+      return await (key == null ? send() : _sendAndStore<T>(key, send));
+    } on RpcException catch (error) {
+      if (error.code == error_code.INVALID_PARAMS &&
+          cacheRequest?.containsKey(Keys.cursor) == true) {
+        invalidateMethod(methodName);
+      }
+      rethrow;
+    }
+  }
+
+  Future<T> _sendAndStore<T extends Result?>(
+    _CacheKey key,
+    Future<T> Function() send,
+  ) async {
+    final entry = _entries[key];
+    if (entry != null) {
+      if (entry.expiresAt.compareTo(_clock.elapsed) > 0) {
+        return _copyMap(entry.result) as T;
+      }
+      _entries.remove(key);
+    }
+
+    final token = Object();
+    _pending[key] = token;
+    try {
+      final result = await send();
+      final receivedAt = _clock.elapsed;
+      if (result == null || _pending[key] != token) return result;
+
+      final resultMap = result as Map<String, Object?>;
+      final resultType = resultMap[Keys.resultType];
+      final ttlMs = resultMap[Keys.ttlMs];
+      final cacheScope = resultMap[Keys.cacheScope];
+      // A server on an earlier revision leaves `resultType` out, and the
+      // schema requires reading that as complete, which is what
+      // `Result.resultType` reports. An [InputRequiredResult] carries the
+      // fields the client retries with, so a result carrying them is interim
+      // whatever it labels itself. A hint outside what the schema allows is
+      // read as no hint at all, the way `CacheableResult` reads it.
+      if ((resultType != null && resultType != ResultTypes.complete) ||
+          resultMap.containsKey(Keys.inputRequests) ||
+          resultMap.containsKey(Keys.requestState) ||
+          ttlMs is! int ||
+          ttlMs <= 0 ||
+          !CacheScope.values.any((scope) => scope.name == cacheScope)) {
+        return result;
+      }
+
+      final ttl =
+          ttlMs > _maxTtl.inMilliseconds
+              ? _maxTtl
+              : Duration(milliseconds: ttlMs);
+      if (!_entries.containsKey(key) && _entries.length >= _maxEntries) {
+        _entries.remove(_entries.keys.first);
+      }
+      _entries[key] = _CacheEntry(_copyMap(resultMap), receivedAt + ttl);
+      return result;
+    } finally {
+      if (_pending[key] == token) _pending.remove(key);
+    }
+  }
+
+  /// The values from [meta] which change the answer to a cacheable request.
+  Map<String, Object?>? _contextOf(Map<String, Object?>? meta) {
+    if (meta == null) return null;
+    final context = <String, Object?>{
+      for (final key in _contextKeys)
+        if (meta.containsKey(key)) key: _copyValue(meta[key]),
+    };
+    return context.isEmpty ? null : context;
+  }
+
+  void invalidateMethod(String methodName) {
+    _entries.removeWhere((key, _) => key.methodName == methodName);
+    _pending.removeWhere((key, _) => key.methodName == methodName);
+  }
+
+  void invalidateResource(String uri) {
+    bool matches(_CacheKey key) =>
+        key.methodName == ReadResourceRequest.methodName &&
+        key.parameter == uri;
+    _entries.removeWhere((key, _) => matches(key));
+    _pending.removeWhere((key, _) => matches(key));
+  }
+
+  void clear() {
+    _entries.clear();
+    _pending.clear();
+  }
+
+  /// The key [request] is cached under, or `null` when it is not cacheable.
+  ///
+  /// Each cacheable method names the parameters which change its answer, and
+  /// a request carrying anything else gets no key. That is what keeps the
+  /// retry of an [InputRequiredResult] out: the schema says a request carrying
+  /// `inputResponses` or `requestState` must not be cached, since it depends
+  /// on inputs no key covers, and such a request never matches one of these
+  /// shapes.
+  _CacheKey? _keyFor(
+    String methodName,
+    Map<String, Object?>? request,
+    Map<String, Object?>? context,
+  ) => switch (methodName) {
+    DiscoverRequest.methodName =>
+      request == null || request.isEmpty
+          ? _CacheKey(methodName, null, context)
+          : null,
+    ListPromptsRequest.methodName ||
+    ListResourcesRequest.methodName ||
+    ListResourceTemplatesRequest.methodName ||
+    ListToolsRequest.methodName => _listKey(methodName, request, context),
+    ReadResourceRequest.methodName => _readResourceKey(
+      methodName,
+      request,
+      context,
+    ),
+    _ => null,
+  };
+
+  _CacheKey? _listKey(
+    String methodName,
+    Map<String, Object?>? request,
+    Map<String, Object?>? context,
+  ) {
+    if (request == null || request.isEmpty) {
+      return _CacheKey(methodName, null, context);
+    }
+    final cursor = request[Keys.cursor];
+    if (request.length != 1 || cursor is! String) return null;
+    return _CacheKey(methodName, cursor, context);
+  }
+
+  _CacheKey? _readResourceKey(
+    String methodName,
+    Map<String, Object?>? request,
+    Map<String, Object?>? context,
+  ) {
+    if (request == null) return null;
+    final uri = request[Keys.uri];
+    if (request.length != 1 || uri is! String) return null;
+    return _CacheKey(methodName, uri, context);
+  }
+}
+
+Map<String, Object?> _copyMap(Map<String, Object?> value) => {
+  for (final entry in value.entries) entry.key: _copyValue(entry.value),
+};
+
+Object? _copyValue(Object? value) {
+  if (value is Map<String, Object?>) return _copyMap(value);
+  if (value is Map<Object?, Object?>) {
+    return <Object?, Object?>{
+      for (final entry in value.entries) entry.key: _copyValue(entry.value),
+    };
+  }
+  if (value is List<Object?>) {
+    return <Object?>[for (final item in value) _copyValue(item)];
+  }
+  return value;
+}

--- a/pkgs/dart_mcp/lib/src/client/response_cache.dart
+++ b/pkgs/dart_mcp/lib/src/client/response_cache.dart
@@ -62,6 +62,8 @@ const _contextKeys = {
 ///
 /// https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching
 final class _ClientResponseCache {
+  static const _maxDuration = Duration(microseconds: 9223372036854775807);
+
   int maxEntries = 512;
   Duration maxTtl = const Duration(hours: 24);
 
@@ -183,8 +185,10 @@ final class _ClientResponseCache {
     final updated = _updatedWhilePending[pending];
     if (updated != null && _carriesAny(resultMap, updated)) return result;
     // The TTL is added to the stopwatch reading captured when the response
-    // arrived.
-    _entries[key] = _CacheEntry(_copyMap(resultMap), receivedAt + ttl);
+    // arrived. Saturation keeps the monotonic deadline in range.
+    final expiresAt =
+        receivedAt > _maxDuration - ttl ? _maxDuration : receivedAt + ttl;
+    _entries[key] = _CacheEntry(_copyMap(resultMap), expiresAt);
     return result;
   }
 

--- a/pkgs/dart_mcp/lib/src/client/response_cache.dart
+++ b/pkgs/dart_mcp/lib/src/client/response_cache.dart
@@ -56,9 +56,10 @@ const _contextKeys = {
 /// the per-request context the caller sent. A result is stored only while it
 /// is complete, carries a positive `ttlMs` and carries a scope the schema
 /// allows, and the answers to an [InputRequiredResult] stay out entirely. A
-/// `ttlMs` past a day is clamped to a day. Without that a server could pin an
-/// answer for the life of the process, and a value large enough to overflow a
-/// [Duration] would write an entry that is already stale.
+/// `ttlMs` past the configured maximum is clamped to that limit. Without a
+/// bound a server could pin an answer for the life of the process, and a value
+/// large enough to overflow a [Duration] would write an entry that is already
+/// stale.
 ///
 /// https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching
 final class _ClientResponseCache {

--- a/pkgs/dart_mcp/lib/src/client/response_cache.dart
+++ b/pkgs/dart_mcp/lib/src/client/response_cache.dart
@@ -63,6 +63,9 @@ final class _ClientResponseCache {
   final _entries = <_CacheKey, _CacheEntry>{};
   final _pending = <_CacheKey, Object>{};
   final _clock = Stopwatch()..start();
+  Duration _elapsedOffset = Duration.zero;
+
+  Duration get _elapsed => _clock.elapsed + _elapsedOffset;
 
   Future<T> sendRequest<T extends Result?>(
     String methodName,
@@ -98,7 +101,7 @@ final class _ClientResponseCache {
   ) async {
     final entry = _entries[key];
     if (entry != null) {
-      if (entry.expiresAt.compareTo(_clock.elapsed) > 0) {
+      if (entry.expiresAt.compareTo(_elapsed) > 0) {
         return _copyMap(entry.result) as T;
       }
       _entries.remove(key);
@@ -108,7 +111,7 @@ final class _ClientResponseCache {
     _pending[key] = token;
     try {
       final result = await send();
-      final receivedAt = _clock.elapsed;
+      final receivedAt = _elapsed;
       if (result == null || _pending[key] != token) return result;
 
       final resultMap = result as Map<String, Object?>;

--- a/pkgs/dart_mcp/lib/src/client/response_cache.dart
+++ b/pkgs/dart_mcp/lib/src/client/response_cache.dart
@@ -182,6 +182,8 @@ final class _ClientResponseCache {
     // out of date, and a read only learns its contents once it gets here.
     final updated = _updatedWhilePending[pending];
     if (updated != null && _carriesAny(resultMap, updated)) return result;
+    // The TTL is added to the stopwatch reading captured when the response
+    // arrived.
     _entries[key] = _CacheEntry(_copyMap(resultMap), receivedAt + ttl);
     return result;
   }

--- a/pkgs/dart_mcp/lib/src/client/response_cache.dart
+++ b/pkgs/dart_mcp/lib/src/client/response_cache.dart
@@ -62,6 +62,10 @@ final class _ClientResponseCache {
 
   final _entries = <_CacheKey, _CacheEntry>{};
   final _pending = <_CacheKey, Object>{};
+
+  /// The resource URIs updated while a `resources/read` was in flight, under
+  /// the token of that read.
+  final _updatedWhilePending = <Object, Set<String>>{};
   final _clock = Stopwatch()..start();
   Duration _elapsedOffset = Duration.zero;
 
@@ -109,6 +113,9 @@ final class _ClientResponseCache {
 
     final token = Object();
     _pending[key] = token;
+    if (key.methodName == ReadResourceRequest.methodName) {
+      _updatedWhilePending[token] = <String>{};
+    }
     try {
       final result = await send();
       final receivedAt = _elapsed;
@@ -140,10 +147,16 @@ final class _ClientResponseCache {
       if (!_entries.containsKey(key) && _entries.length >= _maxEntries) {
         _entries.remove(_entries.keys.first);
       }
+      // An answer which arrives after one of its own contents changed is
+      // already out of date, and a read only learns which contents it carries
+      // once it gets here.
+      final updated = _updatedWhilePending[token];
+      if (updated != null && _carriesAny(resultMap, updated)) return result;
       _entries[key] = _CacheEntry(_copyMap(resultMap), receivedAt + ttl);
       return result;
     } finally {
       if (_pending[key] == token) _pending.remove(key);
+      _updatedWhilePending.remove(token);
     }
   }
 
@@ -175,6 +188,33 @@ final class _ClientResponseCache {
 
     _entries.removeWhere(matches);
     _pending.removeWhere((key, _) => matches(key, null));
+    for (final MapEntry(key: pending, :value) in _pending.entries) {
+      if (pending.methodName == ReadResourceRequest.methodName) {
+        _updatedWhilePending[value]?.add(uri);
+      }
+    }
+  }
+
+  /// Whether [result] carries content for any URI in [uris].
+  static bool _carriesAny(Map<String, Object?> result, Set<String> uris) {
+    if (uris.isEmpty) return false;
+    final contents = result[Keys.contents];
+    return contents is List &&
+        contents.any(
+          (content) => content is Map && uris.contains(content[Keys.uri]),
+        );
+  }
+
+  /// Drops every cached and in-flight `resources/read`.
+  ///
+  /// A notification leaving its `uri` out cannot name what changed, so nothing
+  /// read before it can be trusted.
+  void invalidateAllResources() {
+    bool isRead(_CacheKey key) =>
+        key.methodName == ReadResourceRequest.methodName;
+    _entries.removeWhere((key, _) => isRead(key));
+    _pending.removeWhere((key, _) => isRead(key));
+    _updatedWhilePending.clear();
   }
 
   void clear() {

--- a/pkgs/dart_mcp/lib/src/client/response_cache.dart
+++ b/pkgs/dart_mcp/lib/src/client/response_cache.dart
@@ -163,11 +163,18 @@ final class _ClientResponseCache {
   }
 
   void invalidateResource(String uri) {
-    bool matches(_CacheKey key) =>
-        key.methodName == ReadResourceRequest.methodName &&
-        key.parameter == uri;
-    _entries.removeWhere((key, _) => matches(key));
-    _pending.removeWhere((key, _) => matches(key));
+    // The notification can name a sub-resource of the one which was read, so a
+    // result which carried that URI in its contents is stale as well.
+    bool matches(_CacheKey key, _CacheEntry? entry) {
+      if (key.methodName != ReadResourceRequest.methodName) return false;
+      if (key.parameter == uri) return true;
+      final contents = entry?.result[Keys.contents];
+      return contents is List &&
+          contents.any((content) => content is Map && content[Keys.uri] == uri);
+    }
+
+    _entries.removeWhere(matches);
+    _pending.removeWhere((key, _) => matches(key, null));
   }
 
   void clear() {

--- a/pkgs/dart_mcp/lib/src/client/response_cache.dart
+++ b/pkgs/dart_mcp/lib/src/client/response_cache.dart
@@ -56,15 +56,11 @@ const _contextKeys = {
 /// the per-request context the caller sent. A result is stored only while it
 /// is complete, carries a positive `ttlMs` and carries a scope the schema
 /// allows, and the answers to an [InputRequiredResult] stay out entirely. A
-/// `ttlMs` past the configured maximum is clamped to that limit. Without a
-/// bound a server could pin an answer for the life of the process, and a value
-/// large enough to overflow a [Duration] would write an entry that is already
-/// stale.
+/// `ttlMs` past the configured maximum is clamped to that limit, since without
+/// a bound a server could pin an answer for the life of the process.
 ///
 /// https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching
 final class _ClientResponseCache {
-  static const _maxDuration = Duration(microseconds: 9223372036854775807);
-
   int maxEntries = 512;
   Duration maxTtl = const Duration(hours: 24);
 
@@ -187,8 +183,7 @@ final class _ClientResponseCache {
     if (updated != null && _carriesAny(resultMap, updated)) return result;
     // The TTL is added to the stopwatch reading captured when the response
     // arrived. Saturation keeps the monotonic deadline in range.
-    final expiresAt =
-        receivedAt > _maxDuration - ttl ? _maxDuration : receivedAt + ttl;
+    final expiresAt = receivedAt + ttl;
     _entries[key] = _CacheEntry(_copyMap(resultMap), expiresAt);
     return result;
   }

--- a/pkgs/dart_mcp/lib/src/client/response_cache.dart
+++ b/pkgs/dart_mcp/lib/src/client/response_cache.dart
@@ -33,7 +33,7 @@ final class _CacheEntry {
   final Duration expiresAt;
 }
 
-/// The `_meta` fields which change the answer to a cacheable request.
+/// The `_meta` fields that change the answer to a cacheable request.
 ///
 /// A request carrying any other field is sent to the server, since this
 /// package cannot tell whether that field changes the answer.
@@ -47,7 +47,7 @@ const _contextKeys = {
 /// The cache behind [ServerConnection.sendRequest].
 ///
 /// Holds the results of the six operations the 2026-07-28 caching rules name,
-/// keyed by the request method, the parameters which change the answer, and
+/// keyed by the request method, the parameters that change the answer, and
 /// the per-request context the caller sent. A result is stored only while it
 /// is complete, carries a positive `ttlMs` and carries a scope the schema
 /// allows, and the answers to an [InputRequiredResult] stay out entirely. A
@@ -147,7 +147,7 @@ final class _ClientResponseCache {
       if (!_entries.containsKey(key) && _entries.length >= _maxEntries) {
         _entries.remove(_entries.keys.first);
       }
-      // An answer which arrives after one of its own contents changed is
+      // An answer that arrives after one of its own contents changed is
       // already out of date, and a read only learns which contents it carries
       // once it gets here.
       final updated = _updatedWhilePending[token];
@@ -176,8 +176,8 @@ final class _ClientResponseCache {
   }
 
   void invalidateResource(String uri) {
-    // The notification can name a sub-resource of the one which was read, so a
-    // result which carried that URI in its contents is stale as well.
+    // The notification can name a sub-resource of the one that was read, so a
+    // result carrying that URI in its contents is stale as well.
     bool matches(_CacheKey key, _CacheEntry? entry) {
       if (key.methodName != ReadResourceRequest.methodName) return false;
       if (key.parameter == uri) return true;
@@ -224,7 +224,7 @@ final class _ClientResponseCache {
 
   /// The key [request] is cached under, or `null` when it is not cacheable.
   ///
-  /// Each cacheable method names the parameters which change its answer, and
+  /// Each cacheable method names the parameters that change its answer, and
   /// a request carrying anything else gets no key. That is what keeps the
   /// retry of an [InputRequiredResult] out: the schema says a request carrying
   /// `inputResponses` or `requestState` must not be cached, since it depends

--- a/pkgs/dart_mcp/lib/src/client/response_cache.dart
+++ b/pkgs/dart_mcp/lib/src/client/response_cache.dart
@@ -30,6 +30,11 @@ final class _CacheEntry {
   const _CacheEntry(this.result, this.expiresAt);
 
   final Map<String, Object?> result;
+
+  /// Elapsed stopwatch time when this entry expires.
+  ///
+  /// A [Duration] keeps expiry monotonic and is compared with the cache
+  /// stopwatch, not the wall clock.
   final Duration expiresAt;
 }
 
@@ -57,18 +62,19 @@ const _contextKeys = {
 ///
 /// https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching
 final class _ClientResponseCache {
-  static const _maxEntries = 512;
-  static const _maxTtl = Duration(hours: 24);
+  int maxEntries = 512;
+  Duration maxTtl = const Duration(hours: 24);
 
   final _entries = <_CacheKey, _CacheEntry>{};
-  final _pending = <_CacheKey, Object>{};
+  final _pending = <_CacheKey, Future<Result?>>{};
 
   /// The resource URIs updated while a `resources/read` was in flight, under
   /// the token of that read.
-  final _updatedWhilePending = <Object, Set<String>>{};
+  final _updatedWhilePending = <Future<Result?>, Set<String>>{};
   final _clock = Stopwatch()..start();
   Duration _elapsedOffset = Duration.zero;
 
+  /// Cache time is the live stopwatch reading plus this test-only offset.
   Duration get _elapsed => _clock.elapsed + _elapsedOffset;
 
   Future<T> sendRequest<T extends Result?>(
@@ -103,61 +109,81 @@ final class _ClientResponseCache {
     _CacheKey key,
     Future<T> Function() send,
   ) async {
-    final entry = _entries[key];
-    if (entry != null) {
-      if (entry.expiresAt.compareTo(_elapsed) > 0) {
-        return _copyMap(entry.result) as T;
+    final cached = _cachedEntry(key);
+    if (cached != null) return _copyMap(cached.result) as T;
+
+    final pending = _pending[key];
+    if (pending != null) {
+      try {
+        await pending;
+      } catch (_) {
+        // The caller that started the request receives its error. This caller
+        // still gets a chance to make a fresh request.
       }
-      _entries.remove(key);
+      final cached = _cachedEntry(key);
+      if (cached != null) return _copyMap(cached.result) as T;
     }
 
-    final token = Object();
-    _pending[key] = token;
-    if (key.methodName == ReadResourceRequest.methodName) {
-      _updatedWhilePending[token] = <String>{};
-    }
+    late final Future<T> current;
+    current = _requestAndStore<T>(key, send, () => current);
+    _pending[key] = current;
     try {
-      final result = await send();
-      final receivedAt = _elapsed;
-      if (result == null || _pending[key] != token) return result;
-
-      final resultMap = result as Map<String, Object?>;
-      final resultType = resultMap[Keys.resultType];
-      final ttlMs = resultMap[Keys.ttlMs];
-      final cacheScope = resultMap[Keys.cacheScope];
-      // A server on an earlier revision leaves `resultType` out, and the
-      // schema requires reading that as complete, which is what
-      // `Result.resultType` reports. An [InputRequiredResult] carries the
-      // fields the client retries with, so a result carrying them is interim
-      // whatever it labels itself. A hint outside what the schema allows is
-      // read as no hint at all, the way `CacheableResult` reads it.
-      if ((resultType != null && resultType != ResultTypes.complete) ||
-          resultMap.containsKey(Keys.inputRequests) ||
-          resultMap.containsKey(Keys.requestState) ||
-          ttlMs is! int ||
-          ttlMs <= 0 ||
-          !CacheScope.values.any((scope) => scope.name == cacheScope)) {
-        return result;
-      }
-
-      final ttl =
-          ttlMs > _maxTtl.inMilliseconds
-              ? _maxTtl
-              : Duration(milliseconds: ttlMs);
-      if (!_entries.containsKey(key) && _entries.length >= _maxEntries) {
-        _entries.remove(_entries.keys.first);
-      }
-      // An answer that arrives after one of its own contents changed is
-      // already out of date, and a read only learns which contents it carries
-      // once it gets here.
-      final updated = _updatedWhilePending[token];
-      if (updated != null && _carriesAny(resultMap, updated)) return result;
-      _entries[key] = _CacheEntry(_copyMap(resultMap), receivedAt + ttl);
-      return result;
+      return await current;
     } finally {
-      if (_pending[key] == token) _pending.remove(key);
-      _updatedWhilePending.remove(token);
+      if (identical(_pending[key], current)) unawaited(_pending.remove(key));
+      _updatedWhilePending.remove(current);
     }
+  }
+
+  _CacheEntry? _cachedEntry(_CacheKey key) {
+    final entry = _entries[key];
+    if (entry == null) return null;
+    if (entry.expiresAt.compareTo(_elapsed) > 0) return entry;
+    _entries.remove(key);
+    return null;
+  }
+
+  Future<T> _requestAndStore<T extends Result?>(
+    _CacheKey key,
+    Future<T> Function() send,
+    Future<T> Function() current,
+  ) async {
+    final result = await send();
+    final receivedAt = _elapsed;
+    final pending = current();
+    if (result == null || !identical(_pending[key], pending)) return result;
+
+    final resultMap = result as Map<String, Object?>;
+    final resultType = resultMap[Keys.resultType];
+    final ttlMs = resultMap[Keys.ttlMs];
+    final cacheScope = resultMap[Keys.cacheScope];
+    // A server on an earlier revision leaves `resultType` out, and the
+    // schema requires reading that as complete. `Result.resultType` reports
+    // the same value. An [InputRequiredResult] carries the
+    // fields the client retries with, so a result carrying them is interim
+    // whatever it labels itself. A hint outside what the schema allows is
+    // read as no hint at all, matching `CacheableResult`.
+    if ((resultType != null && resultType != ResultTypes.complete) ||
+        resultMap.containsKey(Keys.inputRequests) ||
+        resultMap.containsKey(Keys.requestState) ||
+        ttlMs is! int ||
+        ttlMs <= 0 ||
+        !CacheScope.values.any((scope) => scope.name == cacheScope)) {
+      return result;
+    }
+
+    final ttl =
+        ttlMs > maxTtl.inMilliseconds ? maxTtl : Duration(milliseconds: ttlMs);
+    if (ttl <= Duration.zero || maxEntries == 0) return result;
+    if (!_entries.containsKey(key) && _entries.length >= maxEntries) {
+      _entries.remove(_entries.keys.first);
+    }
+    // An answer that arrives after one of its own contents changed is already
+    // out of date, and a read only learns its contents once it gets here.
+    final updated = _updatedWhilePending[pending];
+    if (updated != null && _carriesAny(resultMap, updated)) return result;
+    _entries[key] = _CacheEntry(_copyMap(resultMap), receivedAt + ttl);
+    return result;
   }
 
   /// The values from [meta] which change the answer to a cacheable request.
@@ -190,7 +216,7 @@ final class _ClientResponseCache {
     _pending.removeWhere((key, _) => matches(key, null));
     for (final MapEntry(key: pending, :value) in _pending.entries) {
       if (pending.methodName == ReadResourceRequest.methodName) {
-        _updatedWhilePending[value]?.add(uri);
+        (_updatedWhilePending[value] ??= <String>{}).add(uri);
       }
     }
   }
@@ -205,21 +231,10 @@ final class _ClientResponseCache {
         );
   }
 
-  /// Drops every cached and in-flight `resources/read`.
-  ///
-  /// A notification leaving its `uri` out cannot name what changed, so nothing
-  /// read before it can be trusted.
-  void invalidateAllResources() {
-    bool isRead(_CacheKey key) =>
-        key.methodName == ReadResourceRequest.methodName;
-    _entries.removeWhere((key, _) => isRead(key));
-    _pending.removeWhere((key, _) => isRead(key));
-    _updatedWhilePending.clear();
-  }
-
   void clear() {
     _entries.clear();
     _pending.clear();
+    _updatedWhilePending.clear();
   }
 
   /// The key [request] is cached under, or `null` when it is not cacheable.

--- a/pkgs/dart_mcp/test/client/response_cache_test.dart
+++ b/pkgs/dart_mcp/test/client/response_cache_test.dart
@@ -669,31 +669,6 @@ void main() {
       expect(server.readCalls['file:///kept'], 1);
     });
 
-    test('clamps a ttl which overflows a duration', () async {
-      // `Duration(milliseconds: 9223372036854775807)` is negative, so an
-      // unclamped entry would already be stale when it is written.
-      server.ttlMs = 9223372036854775807;
-
-      await listTools();
-      await listTools();
-
-      expect(server.calls[ListToolsRequest.methodName], 1);
-    });
-
-    test('saturates an expiry which overflows a duration', () async {
-      connection
-        ..maxCachedResponseTtl = const Duration(
-          microseconds: 9223372036854775807,
-        )
-        ..pauseCachedResponseClock();
-      server.ttlMs = 9223372036854775807;
-
-      await listTools();
-      await listTools();
-
-      expect(server.calls[ListToolsRequest.methodName], 1);
-    });
-
     test('defaults the maximum ttl to a day', () async {
       connection.pauseCachedResponseClock();
       server.ttlMs = const Duration(hours: 36).inMilliseconds;

--- a/pkgs/dart_mcp/test/client/response_cache_test.dart
+++ b/pkgs/dart_mcp/test/client/response_cache_test.dart
@@ -567,6 +567,33 @@ void main() {
       expect(server.calls[ListToolsRequest.methodName], 1);
     });
 
+    test('clamps a ttl past a day', () async {
+      // 36 hours sits between the one-day cap and a two-day cap, so a
+      // 48-hour clamp would still have this entry after a day.
+      server.ttlMs = const Duration(hours: 36).inMilliseconds;
+
+      await listTools();
+      connection.elapseCachedResponses(
+        const Duration(hours: 24) - const Duration(seconds: 1),
+      );
+      await listTools();
+      expect(server.calls[ListToolsRequest.methodName], 1);
+
+      connection.elapseCachedResponses(const Duration(seconds: 2));
+      await listTools();
+      expect(server.calls[ListToolsRequest.methodName], 2);
+    });
+
+    test('drops cached entries on shutdown', () async {
+      await listTools();
+      await listTools();
+      expect(server.calls[ListToolsRequest.methodName], 1);
+      expect(connection.cachedResponseCount, 1);
+
+      await connection.shutdown();
+      expect(connection.cachedResponseCount, 0);
+    });
+
     test('delivers a resource notification which leaves out its uri', () async {
       final updates = <ResourceUpdatedNotification>[];
       final subscription = connection.resourceUpdated.listen(updates.add);

--- a/pkgs/dart_mcp/test/client/response_cache_test.dart
+++ b/pkgs/dart_mcp/test/client/response_cache_test.dart
@@ -421,6 +421,37 @@ void main() {
       expect(server.readCalls, {'file:///first': 2, 'file:///second': 1});
     });
 
+    test(
+      'invalidates a read whose contents name the updated resource',
+      () async {
+        const parent = 'file:///dir';
+        const child = 'file:///dir/child';
+        // The schema says the updated URI might be a sub-resource of the
+        // one subscribed to, and a read can answer with several contents.
+        server.readResult =
+            (_, count) => ReadResourceResult.fromMap({
+              Keys.resultType: ResultTypes.complete,
+              Keys.contents: [
+                TextResourceContents(uri: child, text: 'read-$count'),
+              ],
+              Keys.ttlMs: 60000,
+              Keys.cacheScope: CacheScope.private.name,
+            });
+        await readResource(parent);
+        await readResource(parent);
+        expect(server.readCalls[parent], 1);
+
+        server.sendNotification(
+          ResourceUpdatedNotification.methodName,
+          ResourceUpdatedNotification(uri: child),
+        );
+        await pumpEventQueue();
+
+        await readResource(parent);
+        expect(server.readCalls[parent], 2);
+      },
+    );
+
     test('does not store responses invalidated while in flight', () async {
       final toolsResult = Completer<ListToolsResult>();
       server.listToolsResult = (_, _) => toolsResult.future;

--- a/pkgs/dart_mcp/test/client/response_cache_test.dart
+++ b/pkgs/dart_mcp/test/client/response_cache_test.dart
@@ -380,6 +380,16 @@ void main() {
       expect(server.calls[ListToolsRequest.methodName], 2);
     });
 
+    test('reuses a result when the handshake settled the revision', () async {
+      // Only `discover` names the revision in its own metadata, so a plain
+      // call has to lean on the version the handshake settled.
+      connection.protocolVersion = ProtocolVersion.v2026_07_28;
+      await connection.listTools(ListToolsRequest(meta: null));
+      await connection.listTools(ListToolsRequest(meta: null));
+
+      expect(server.calls[ListToolsRequest.methodName], 1);
+    });
+
     test('invalidates entries when change notifications arrive', () async {
       await listTools();
       await listPrompts();

--- a/pkgs/dart_mcp/test/client/response_cache_test.dart
+++ b/pkgs/dart_mcp/test/client/response_cache_test.dart
@@ -680,6 +680,36 @@ void main() {
       expect(server.calls[ListToolsRequest.methodName], 1);
     });
 
+    test('saturates an expiry which overflows a duration', () async {
+      connection
+        ..maxCachedResponseTtl = const Duration(
+          microseconds: 9223372036854775807,
+        )
+        ..pauseCachedResponseClock();
+      server.ttlMs = 9223372036854775807;
+
+      await listTools();
+      await listTools();
+
+      expect(server.calls[ListToolsRequest.methodName], 1);
+    });
+
+    test('defaults the maximum ttl to a day', () async {
+      connection.pauseCachedResponseClock();
+      server.ttlMs = const Duration(hours: 36).inMilliseconds;
+
+      await listTools();
+      connection.elapseCachedResponses(
+        const Duration(hours: 24) - const Duration(seconds: 1),
+      );
+      await listTools();
+      expect(server.calls[ListToolsRequest.methodName], 1);
+
+      connection.elapseCachedResponses(const Duration(seconds: 2));
+      await listTools();
+      expect(server.calls[ListToolsRequest.methodName], 2);
+    });
+
     test('uses the configured maximum ttl', () async {
       connection
         ..maxCachedResponseTtl = const Duration(hours: 1)

--- a/pkgs/dart_mcp/test/client/response_cache_test.dart
+++ b/pkgs/dart_mcp/test/client/response_cache_test.dart
@@ -1,0 +1,754 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:dart_mcp/client.dart';
+import 'package:dart_mcp/server.dart';
+import 'package:dart_mcp/src/utils/constants.dart';
+import 'package:json_rpc_2/error_code.dart' as error_code;
+import 'package:json_rpc_2/json_rpc_2.dart' show RpcException;
+import 'package:stream_channel/stream_channel.dart';
+import 'package:test/test.dart';
+
+import '../test_utils.dart';
+
+void main() {
+  test('client does not cache modern-shaped legacy responses', () async {
+    late _CacheServer server;
+    final environment = TestEnvironment(
+      TestMCPClient(),
+      (channel) => server = _CacheServer(channel),
+    );
+
+    await environment.serverConnection.listTools();
+    await environment.serverConnection.listTools();
+
+    expect(server.calls[ListToolsRequest.methodName], 2);
+  });
+
+  test('client caches inline responses without a resultType', () async {
+    late _CacheServer server;
+    final environment = TestEnvironment(
+      TestMCPClient(),
+      (channel) => server = _CacheServer(channel),
+    );
+    server.includeResultType = false;
+    ListToolsRequest request(String extension) => ListToolsRequest(
+      meta: MetaWithProgressToken.fromMap({
+        Keys.protocolVersionMeta: ProtocolVersion.v2026_07_28.versionString,
+        Keys.clientCapabilitiesMeta: {
+          Keys.extensions: {extension: <String, Object?>{}},
+        },
+      }),
+    );
+
+    await environment.serverConnection.listTools(request('com.example/one'));
+    await environment.serverConnection.listTools(request('com.example/one'));
+    expect(server.calls[ListToolsRequest.methodName], 1);
+  });
+
+  test('client caches request-scoped server responses', () async {
+    final responses = StreamController<Map<String, Object?>>();
+    final requests = StreamController<Map<String, Object?>>();
+    final calls = <String, int>{};
+    final subscription = requests.stream
+        .asyncMap((message) {
+          return handleRequestScopedMessage(
+            message,
+            MCPServerInitialization(
+              protocolVersion: ProtocolVersion.v2026_07_28,
+              clientCapabilities: ClientCapabilities(),
+            ),
+            (channel) => _RequestScopedCacheServer(channel, calls),
+          );
+        })
+        .listen((response) {
+          if (response != null) responses.add(response);
+        });
+    final client = TestMCPClient();
+    final connection = client.connectServer(
+      StreamChannel.withCloseGuarantee(responses.stream, requests.sink),
+    );
+    addTearDown(() async {
+      await client.shutdown();
+      await subscription.cancel();
+      if (!responses.isClosed) await responses.close();
+    });
+    final meta = MetaWithProgressToken.fromMap({
+      Keys.protocolVersionMeta: ProtocolVersion.v2026_07_28.versionString,
+      Keys.clientCapabilitiesMeta: <String, Object?>{},
+    });
+
+    await connection.listTools(ListToolsRequest(meta: meta));
+    await connection.listTools(ListToolsRequest(meta: meta));
+    expect(calls[ListToolsRequest.methodName], 1);
+
+    await connection.listTools();
+    await connection.listTools();
+    expect(calls[ListToolsRequest.methodName], 3);
+  });
+
+  group('client response cache', () {
+    late TestEnvironment<TestMCPClient, _CacheServer> environment;
+    late _CacheServer server;
+    late ServerConnection connection;
+
+    /// The envelope the schema requires on a 2026-07-28 request, and what
+    /// selects the cache.
+    final meta = MetaWithProgressToken.fromMap({
+      Keys.protocolVersionMeta: ProtocolVersion.v2026_07_28.versionString,
+    });
+
+    setUp(() async {
+      environment = TestEnvironment(
+        TestMCPClient(),
+        (channel) => server = _CacheServer(channel),
+      );
+      connection = environment.serverConnection;
+    });
+
+    Future<DiscoverResult> discover() => connection.discover(
+      protocolVersion: ProtocolVersion.v2026_07_28,
+      capabilities: ClientCapabilities(),
+    );
+    Future<ListToolsResult> listTools([Cursor? cursor]) =>
+        connection.listTools(ListToolsRequest(cursor: cursor, meta: meta));
+    Future<ListPromptsResult> listPrompts() =>
+        connection.listPrompts(ListPromptsRequest(meta: meta));
+    Future<ListResourcesResult> listResources() =>
+        connection.listResources(ListResourcesRequest(meta: meta));
+    Future<ListResourceTemplatesResult> listResourceTemplates() => connection
+        .listResourceTemplates(ListResourceTemplatesRequest(meta: meta));
+    Future<ReadResourceResult> readResource(String uri) =>
+        connection.readResource(ReadResourceRequest(uri: uri, meta: meta));
+
+    test('separates modern request contexts', () async {
+      ListToolsRequest request(String extension) => ListToolsRequest(
+        meta: MetaWithProgressToken.fromMap({
+          Keys.protocolVersionMeta: ProtocolVersion.v2026_07_28.versionString,
+          Keys.clientCapabilitiesMeta: {
+            Keys.extensions: {extension: <String, Object?>{}},
+          },
+        }),
+      );
+
+      await connection.listTools(request('com.example/one'));
+      await connection.listTools(request('com.example/one'));
+      expect(server.calls[ListToolsRequest.methodName], 1);
+
+      await connection.listTools(request('com.example/two'));
+      expect(server.calls[ListToolsRequest.methodName], 2);
+    });
+
+    test('caches the six cacheable operations', () async {
+      await discover();
+      await discover();
+      await listTools();
+      await listTools();
+      await listPrompts();
+      await listPrompts();
+      await listResources();
+      await listResources();
+      await listResourceTemplates();
+      await listResourceTemplates();
+      await readResource('file:///cached');
+      await readResource('file:///cached');
+
+      expect(server.calls, {
+        DiscoverRequest.methodName: 1,
+        ListToolsRequest.methodName: 1,
+        ListPromptsRequest.methodName: 1,
+        ListResourcesRequest.methodName: 1,
+        ListResourceTemplatesRequest.methodName: 1,
+        ReadResourceRequest.methodName: 1,
+      });
+    });
+
+    test('uses positive ttl until expiry and requires a scope', () async {
+      server.ttlMs = 0;
+      await listTools();
+      await listTools();
+      expect(server.calls[ListToolsRequest.methodName], 2);
+
+      server.ttlMs = 20;
+      await listPrompts();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      await listPrompts();
+      expect(server.calls[ListPromptsRequest.methodName], 2);
+
+      server.ttlMs = 60000;
+      server.cacheScope = null;
+      await listResources();
+      await listResources();
+      expect(server.calls[ListResourcesRequest.methodName], 2);
+
+      server
+        ..ttlMs = null
+        ..cacheScope = CacheScope.private;
+      await listResourceTemplates();
+      await listResourceTemplates();
+      expect(server.calls[ListResourceTemplatesRequest.methodName], 2);
+
+      server
+        ..ttlMs = 60000
+        ..cacheScope = CacheScope.public;
+      await readResource('file:///public');
+      await readResource('file:///public');
+      expect(server.readCalls['file:///public'], 1);
+    });
+
+    test('bypasses the cache for unknown metadata', () async {
+      expect((await listTools()).tools.single.name, 'tool-1');
+
+      final request = ListToolsRequest(
+        meta: MetaWithProgressToken.fromMap({
+          Keys.protocolVersionMeta: ProtocolVersion.v2026_07_28.versionString,
+          Keys.progressToken: ProgressToken(1),
+        }),
+      );
+      expect((await connection.listTools(request)).tools.single.name, 'tool-2');
+      expect((await connection.listTools(request)).tools.single.name, 'tool-3');
+      expect((await listTools()).tools.single.name, 'tool-1');
+
+      expect(server.calls[ListToolsRequest.methodName], 3);
+    });
+
+    test('returns responses with malformed cache hints', () async {
+      for (final field in [Keys.ttlMs, Keys.cacheScope]) {
+        server.malformedHint = field;
+        await listTools(Cursor(field));
+        await listTools(Cursor(field));
+      }
+      server.malformedHint = null;
+
+      expect(server.calls[ListToolsRequest.methodName], 4);
+    });
+
+    test('bounds cached entries', () async {
+      for (var i = 0; i <= 512; i++) {
+        await readResource('file:///$i');
+      }
+      await readResource('file:///0');
+
+      expect(server.readCalls['file:///0'], 2);
+    });
+
+    test('separates methods, cursors, and resource uris', () async {
+      await listTools(Cursor('page-1'));
+      await listTools(Cursor('page-1'));
+      await listTools(Cursor('page-2'));
+      await listTools(Cursor('page-2'));
+      expect(server.calls[ListToolsRequest.methodName], 2);
+
+      await readResource('file:///first');
+      await readResource('file:///first');
+      await readResource('file:///second');
+      await readResource('file:///second');
+      expect(server.readCalls, {'file:///first': 1, 'file:///second': 1});
+    });
+
+    test('invalid cursor evicts cached list pages', () async {
+      expect((await listTools()).tools.single.name, 'tool-1');
+      expect((await listTools()).tools.single.name, 'tool-1');
+
+      final validPage = Cursor('valid');
+      expect((await listTools(validPage)).tools.single.name, 'tool-2');
+      expect((await listTools(validPage)).tools.single.name, 'tool-2');
+
+      final cursor = Cursor('expired');
+      server.errorToolCursor = cursor;
+      server.toolCursorErrorCode = error_code.INVALID_PARAMS;
+      await expectLater(
+        listTools(cursor),
+        throwsA(
+          isA<RpcException>().having(
+            (error) => error.code,
+            'code',
+            error_code.INVALID_PARAMS,
+          ),
+        ),
+      );
+
+      server.errorToolCursor = null;
+      expect((await listTools()).tools.single.name, 'tool-4');
+      expect((await listTools(validPage)).tools.single.name, 'tool-5');
+      expect(server.calls[ListToolsRequest.methodName], 5);
+    });
+
+    test('other RPC errors preserve cached list pages', () async {
+      final validPage = Cursor('valid');
+      expect((await listTools(validPage)).tools.single.name, 'tool-1');
+      expect((await listTools(validPage)).tools.single.name, 'tool-1');
+
+      final cursor = Cursor('failed');
+      server.errorToolCursor = cursor;
+      server.toolCursorErrorCode = error_code.INTERNAL_ERROR;
+      await expectLater(
+        listTools(cursor),
+        throwsA(
+          isA<RpcException>().having(
+            (error) => error.code,
+            'code',
+            error_code.INTERNAL_ERROR,
+          ),
+        ),
+      );
+
+      server.errorToolCursor = null;
+      expect((await listTools(validPage)).tools.single.name, 'tool-1');
+      expect(server.calls[ListToolsRequest.methodName], 2);
+    });
+
+    test('does not cache an input_required result', () async {
+      // `resources/read` is cacheable, and the same payload may carry the
+      // `ttlMs` / `cacheScope` hints together with `resultType:
+      // input_required`. Interim results are not cacheable.
+      // https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching
+      server.readResult =
+          (_, _) => ReadResourceResult.fromMap({
+            Keys.resultType: ResultTypes.inputRequired,
+            Keys.contents: [
+              TextResourceContents(uri: 'file:///interim', text: 'secret'),
+            ],
+            Keys.ttlMs: 60000,
+            Keys.cacheScope: CacheScope.private.name,
+          });
+      expect(
+        (await readResource('file:///interim')).resultType,
+        ResultTypes.inputRequired,
+      );
+      await readResource('file:///interim');
+      expect(server.readCalls['file:///interim'], 2);
+    });
+
+    test('does not cache input-required retries', () async {
+      server.readResult = server.completeRead;
+      final withState = ReadResourceRequest(
+        uri: 'file:///state-retry',
+        requestState: 'state',
+        meta: meta,
+      );
+      await connection.readResource(withState);
+      await connection.readResource(withState);
+      expect(server.readCalls['file:///state-retry'], 2);
+
+      final withResponses = ReadResourceRequest(
+        uri: 'file:///response-retry',
+        inputResponses: {
+          'answer': ElicitResult(action: ElicitationAction.decline),
+        },
+        meta: meta,
+      );
+      await connection.readResource(withResponses);
+      await connection.readResource(withResponses);
+      expect(server.readCalls['file:///response-retry'], 2);
+
+      // A server which leaves `resultType` out is read as answering
+      // `complete`, so the fields the client retries with are what mark these
+      // two interim.
+      for (final interim in [
+        {
+          Keys.inputRequests: <String, Object?>{
+            'answer': InputRequest.listRoots(ListRootsRequest()),
+          },
+        },
+        {Keys.requestState: 'state'},
+      ]) {
+        server.readResult =
+            (_, _) => InputRequiredResult.fromMap({
+              ...interim,
+              Keys.ttlMs: 60000,
+              Keys.cacheScope: CacheScope.private.name,
+            });
+        final uri = 'file:///${interim.keys.single}';
+        await readResource(uri);
+        await readResource(uri);
+        expect(server.readCalls[uri], 2);
+      }
+
+      // A paginated request keys on its cursor, and a retry of one carries
+      // the same cursor, so only the parameters it adds keep the two apart.
+      final listRetry = ListToolsRequest.fromMap({
+        Keys.cursor: Cursor('page-1'),
+        Keys.requestState: 'state',
+        Keys.meta: meta,
+      });
+      await connection.listTools(listRetry);
+      await connection.listTools(listRetry);
+      expect(server.calls[ListToolsRequest.methodName], 2);
+    });
+
+    test('invalidates entries when change notifications arrive', () async {
+      await listTools();
+      await listPrompts();
+      await listResources();
+      await listResourceTemplates();
+      await readResource('file:///first');
+      await readResource('file:///second');
+
+      server
+        ..sendNotification(
+          ToolListChangedNotification.methodName,
+          ToolListChangedNotification(),
+        )
+        ..sendNotification(
+          PromptListChangedNotification.methodName,
+          PromptListChangedNotification(),
+        )
+        ..sendNotification(
+          ResourceListChangedNotification.methodName,
+          ResourceListChangedNotification(),
+        )
+        ..sendNotification(
+          ResourceUpdatedNotification.methodName,
+          ResourceUpdatedNotification(uri: 'file:///first'),
+        );
+      await pumpEventQueue();
+
+      await listTools();
+      await listPrompts();
+      await listResources();
+      await listResourceTemplates();
+      await readResource('file:///first');
+      await readResource('file:///second');
+
+      expect(server.calls[ListToolsRequest.methodName], 2);
+      expect(server.calls[ListPromptsRequest.methodName], 2);
+      expect(server.calls[ListResourcesRequest.methodName], 2);
+      expect(server.calls[ListResourceTemplatesRequest.methodName], 2);
+      expect(server.readCalls, {'file:///first': 2, 'file:///second': 1});
+    });
+
+    test('does not store responses invalidated while in flight', () async {
+      final toolsResult = Completer<ListToolsResult>();
+      server.listToolsResult = (_, _) => toolsResult.future;
+      final pendingTools = listTools();
+      await pumpEventQueue();
+      expect(server.calls[ListToolsRequest.methodName], 1);
+
+      server.sendNotification(
+        ToolListChangedNotification.methodName,
+        ToolListChangedNotification(),
+      );
+      await pumpEventQueue();
+      toolsResult.complete(server.completeTools(1));
+      await pendingTools;
+
+      server.listToolsResult = null;
+      expect((await listTools()).tools.single.name, 'tool-2');
+      expect(server.calls[ListToolsRequest.methodName], 2);
+
+      final firstResult = Completer<ReadResourceResult>();
+      final secondResult = Completer<ReadResourceResult>();
+      const first = 'file:///in-flight';
+      const second = 'file:///other-in-flight';
+      server.readResult =
+          (request, _) =>
+              request.uri == first ? firstResult.future : secondResult.future;
+      final pendingFirst = readResource(first);
+      final pendingSecond = readResource(second);
+      await pumpEventQueue();
+      expect(server.readCalls, {first: 1, second: 1});
+
+      server.sendNotification(
+        ResourceUpdatedNotification.methodName,
+        ResourceUpdatedNotification(uri: first),
+      );
+      await pumpEventQueue();
+      firstResult.complete(
+        server.completeRead(ReadResourceRequest(uri: first), 1),
+      );
+      secondResult.complete(
+        server.completeRead(ReadResourceRequest(uri: second), 2),
+      );
+      await Future.wait([pendingFirst, pendingSecond]);
+
+      server.readResult = null;
+      final nextFirst = await readResource(first);
+      final nextSecond = await readResource(second);
+      expect(nextFirst.contents.single, isA<TextResourceContents>());
+      expect(
+        (nextFirst.contents.single as TextResourceContents).text,
+        'read-3',
+      );
+      expect(nextSecond.contents.single, isA<TextResourceContents>());
+      expect(
+        (nextSecond.contents.single as TextResourceContents).text,
+        'read-2',
+      );
+      expect(server.readCalls, {first: 2, second: 1});
+    });
+
+    test('returns copies of cached response maps', () async {
+      server.resultMeta = Meta.fromMap({
+        'com.example/nested': <Object?, Object?>{'value': 1},
+      });
+      final first = await listTools();
+      (first.tools.single as Map<String, Object?>)[Keys.name] = 'changed';
+      first.tools.clear();
+      (first.meta!['com.example/nested'] as Map)['value'] = 2;
+
+      final second = await listTools();
+      expect(second.tools, hasLength(1));
+      expect(second.tools.single.name, 'tool-1');
+      expect((second.meta!['com.example/nested'] as Map)['value'], 1);
+      (second.tools.single as Map<String, Object?>)[Keys.name] =
+          'changed-again';
+
+      final third = await listTools();
+      expect(third.tools.single.name, 'tool-1');
+      expect(server.calls[ListToolsRequest.methodName], 1);
+    });
+
+    test('sends every request naming an earlier revision', () async {
+      final legacy = ListToolsRequest(
+        meta: MetaWithProgressToken.fromMap({
+          Keys.protocolVersionMeta: ProtocolVersion.v2025_11_25.versionString,
+        }),
+      );
+
+      await connection.listTools(legacy);
+      await connection.listTools(legacy);
+
+      expect(server.calls[ListToolsRequest.methodName], 2);
+    });
+
+    test('an invalid cursor on a bypassed request evicts pages', () async {
+      final page = Cursor('page-1');
+      expect((await listTools(page)).tools.single.name, 'tool-1');
+      expect((await listTools(page)).tools.single.name, 'tool-1');
+
+      final cursor = Cursor('expired');
+      server.errorToolCursor = cursor;
+      server.toolCursorErrorCode = error_code.INVALID_PARAMS;
+      await expectLater(
+        connection.listTools(
+          ListToolsRequest.fromMap({
+            Keys.cursor: cursor,
+            Keys.meta: {
+              Keys.protocolVersionMeta:
+                  ProtocolVersion.v2026_07_28.versionString,
+              'com.example/unknown': true,
+            },
+          }),
+        ),
+        throwsA(isA<RpcException>()),
+      );
+
+      server.errorToolCursor = null;
+      expect((await listTools(page)).tools.single.name, 'tool-3');
+      expect(server.calls[ListToolsRequest.methodName], 3);
+    });
+
+    test('a zero ttl does not take a cache slot', () async {
+      await readResource('file:///kept');
+
+      server.ttlMs = 0;
+      for (var i = 0; i <= 512; i++) {
+        await readResource('file:///stale-$i');
+      }
+
+      server.ttlMs = 60000;
+      await readResource('file:///kept');
+
+      expect(server.readCalls['file:///kept'], 1);
+    });
+
+    test('clamps a ttl which overflows a duration', () async {
+      // `Duration(milliseconds: 9223372036854775807)` is negative, so an
+      // unclamped entry would already be stale when it is written.
+      server.ttlMs = 9223372036854775807;
+
+      await listTools();
+      await listTools();
+
+      expect(server.calls[ListToolsRequest.methodName], 1);
+    });
+
+    test('delivers a resource notification which leaves out its uri', () async {
+      final updates = <ResourceUpdatedNotification>[];
+      final subscription = connection.resourceUpdated.listen(updates.add);
+      addTearDown(subscription.cancel);
+
+      server.sendNotification(
+        ResourceUpdatedNotification.methodName,
+        ResourceUpdatedNotification.fromMap(<String, Object?>{}),
+      );
+      await pumpEventQueue();
+
+      expect(updates.single, isEmpty);
+    });
+  });
+}
+
+final class _RequestScopedCacheServer extends TestMCPServer {
+  _RequestScopedCacheServer(super.channel, this.calls) {
+    registerRequestHandler<ListToolsRequest?, ListToolsResult>(
+      ListToolsRequest.methodName,
+      _listTools,
+    );
+  }
+
+  final Map<String, int> calls;
+
+  ListToolsResult _listTools(ListToolsRequest? _) {
+    final count = calls.update(
+      ListToolsRequest.methodName,
+      (count) => count + 1,
+      ifAbsent: () => 1,
+    );
+    return ListToolsResult(
+      tools: [Tool(name: 'tool-$count', inputSchema: ObjectSchema())],
+      ttlMs: 60000,
+      cacheScope: CacheScope.private,
+    );
+  }
+}
+
+final class _CacheServer extends TestMCPServer {
+  _CacheServer(super.channel) {
+    registerRequestHandler<DiscoverRequest?, DiscoverResult>(
+      DiscoverRequest.methodName,
+      _discover,
+    );
+    registerRequestHandler<ListToolsRequest?, ListToolsResult>(
+      ListToolsRequest.methodName,
+      _listTools,
+    );
+    registerRequestHandler<ListPromptsRequest?, ListPromptsResult>(
+      ListPromptsRequest.methodName,
+      _listPrompts,
+    );
+    registerRequestHandler<ListResourcesRequest?, ListResourcesResult>(
+      ListResourcesRequest.methodName,
+      _listResources,
+    );
+    registerRequestHandler<
+      ListResourceTemplatesRequest?,
+      ListResourceTemplatesResult
+    >(ListResourceTemplatesRequest.methodName, _listResourceTemplates);
+    registerRequestHandler<ReadResourceRequest, Result>(
+      ReadResourceRequest.methodName,
+      _readResource,
+    );
+  }
+
+  final calls = <String, int>{};
+  final readCalls = <String, int>{};
+  int? ttlMs = 60000;
+  CacheScope? cacheScope = CacheScope.private;
+  bool includeResultType = true;
+  Cursor? errorToolCursor;
+  int? toolCursorErrorCode;
+  Meta? resultMeta;
+  String? malformedHint;
+  FutureOr<ListToolsResult> Function(ListToolsRequest?, int)? listToolsResult;
+  FutureOr<Result> Function(ReadResourceRequest, int)? readResult;
+
+  int _record(String methodName) =>
+      calls.update(methodName, (count) => count + 1, ifAbsent: () => 1);
+
+  T _complete<T extends Result>(T result) {
+    if (includeResultType) {
+      (result as Map<String, Object?>)[Keys.resultType] = ResultTypes.complete;
+    }
+    if (malformedHint case final field?) {
+      (result as Map<String, Object?>)[field] = false;
+    }
+    return result;
+  }
+
+  DiscoverResult _discover(DiscoverRequest? _) {
+    _record(DiscoverRequest.methodName);
+    return _complete(
+      DiscoverResult(
+        supportedVersions: [ProtocolVersion.v2026_07_28.versionString],
+        capabilities: ServerCapabilities(),
+        ttlMs: ttlMs,
+        cacheScope: cacheScope,
+      ),
+    );
+  }
+
+  FutureOr<ListToolsResult> _listTools(ListToolsRequest? request) {
+    final count = _record(ListToolsRequest.methodName);
+    final cursor = request?.cursor;
+    if (errorToolCursor != null && cursor == errorToolCursor) {
+      throw RpcException(
+        toolCursorErrorCode!,
+        'The cursor "$cursor" failed. Every other cursor is valid.',
+      );
+    }
+    return listToolsResult?.call(request, count) ?? completeTools(count);
+  }
+
+  ListToolsResult completeTools(int count) {
+    return _complete(
+      ListToolsResult(
+        tools: [Tool(name: 'tool-$count', inputSchema: ObjectSchema())],
+        ttlMs: ttlMs,
+        cacheScope: cacheScope,
+        meta: resultMeta,
+      ),
+    );
+  }
+
+  ListPromptsResult _listPrompts(ListPromptsRequest? _) {
+    final count = _record(ListPromptsRequest.methodName);
+    return _complete(
+      ListPromptsResult(
+        prompts: [Prompt(name: 'prompt-$count')],
+        ttlMs: ttlMs,
+        cacheScope: cacheScope,
+      ),
+    );
+  }
+
+  ListResourcesResult _listResources(ListResourcesRequest? _) {
+    final count = _record(ListResourcesRequest.methodName);
+    return _complete(
+      ListResourcesResult(
+        resources: [Resource(uri: 'file:///$count', name: 'resource-$count')],
+        ttlMs: ttlMs,
+        cacheScope: cacheScope,
+      ),
+    );
+  }
+
+  ListResourceTemplatesResult _listResourceTemplates(
+    ListResourceTemplatesRequest? _,
+  ) {
+    final count = _record(ListResourceTemplatesRequest.methodName);
+    return _complete(
+      ListResourceTemplatesResult(
+        resourceTemplates: [
+          ResourceTemplate(
+            uriTemplate: 'file:///{name}',
+            name: 'template-$count',
+          ),
+        ],
+        ttlMs: ttlMs,
+        cacheScope: cacheScope,
+      ),
+    );
+  }
+
+  FutureOr<Result> _readResource(ReadResourceRequest request) {
+    final count = _record(ReadResourceRequest.methodName);
+    readCalls.update(request.uri, (count) => count + 1, ifAbsent: () => 1);
+    return readResult?.call(request, count) ?? completeRead(request, count);
+  }
+
+  ReadResourceResult completeRead(ReadResourceRequest request, int count) =>
+      _complete(
+        ReadResourceResult(
+          contents: [
+            TextResourceContents(uri: request.uri, text: 'read-$count'),
+          ],
+          ttlMs: ttlMs,
+          cacheScope: cacheScope,
+        ),
+      );
+}

--- a/pkgs/dart_mcp/test/client/response_cache_test.dart
+++ b/pkgs/dart_mcp/test/client/response_cache_test.dart
@@ -452,6 +452,54 @@ void main() {
       },
     );
 
+    test(
+      'does not store a read whose contents changed while in flight',
+      () async {
+        const parent = 'file:///dir';
+        const child = 'file:///dir/child';
+        final pending = Completer<ReadResourceResult>();
+        server.readResult = (_, _) => pending.future;
+        final inFlight = readResource(parent);
+        await pumpEventQueue();
+        expect(server.readCalls[parent], 1);
+
+        server.sendNotification(
+          ResourceUpdatedNotification.methodName,
+          ResourceUpdatedNotification(uri: child),
+        );
+        await pumpEventQueue();
+        pending.complete(
+          ReadResourceResult.fromMap({
+            Keys.resultType: ResultTypes.complete,
+            Keys.contents: [TextResourceContents(uri: child, text: 'read-1')],
+            Keys.ttlMs: 60000,
+            Keys.cacheScope: CacheScope.private.name,
+          }),
+        );
+        await inFlight;
+
+        server.readResult = null;
+        await readResource(parent);
+        expect(server.readCalls[parent], 2);
+      },
+    );
+
+    test('drops cached reads when an update leaves out its uri', () async {
+      const kept = 'file:///kept-through-update';
+      await readResource(kept);
+      await readResource(kept);
+      expect(server.readCalls[kept], 1);
+
+      server.sendNotification(
+        ResourceUpdatedNotification.methodName,
+        ResourceUpdatedNotification.fromMap(<String, Object?>{}),
+      );
+      await pumpEventQueue();
+
+      await readResource(kept);
+      expect(server.readCalls[kept], 2);
+    });
+
     test('does not store responses invalidated while in flight', () async {
       final toolsResult = Completer<ListToolsResult>();
       server.listToolsResult = (_, _) => toolsResult.future;

--- a/pkgs/dart_mcp/test/client/response_cache_test.dart
+++ b/pkgs/dart_mcp/test/client/response_cache_test.dart
@@ -167,6 +167,7 @@ void main() {
     });
 
     test('uses positive ttl until expiry and requires a scope', () async {
+      connection.pauseCachedResponseClock();
       server.ttlMs = 0;
       await listTools();
       await listTools();
@@ -175,6 +176,9 @@ void main() {
       server.ttlMs = 20;
       await listPrompts();
       await Future<void>.delayed(const Duration(milliseconds: 50));
+      await listPrompts();
+      expect(server.calls[ListPromptsRequest.methodName], 1);
+      connection.elapseCachedResponses(const Duration(milliseconds: 21));
       await listPrompts();
       expect(server.calls[ListPromptsRequest.methodName], 2);
 
@@ -226,13 +230,49 @@ void main() {
       expect(server.calls[ListToolsRequest.methodName], 4);
     });
 
-    test('bounds cached entries', () async {
-      for (var i = 0; i <= 512; i++) {
+    test('uses the configured cache size', () async {
+      connection.maxCachedResponses = 2;
+      for (var i = 0; i <= 2; i++) {
         await readResource('file:///$i');
       }
       await readResource('file:///0');
 
       expect(server.readCalls['file:///0'], 2);
+    });
+
+    test('shares an in-flight request', () async {
+      final result = Completer<ListToolsResult>();
+      server.listToolsResult = (_, _) => result.future;
+
+      final first = listTools();
+      await pumpEventQueue();
+      final second = listTools();
+      await pumpEventQueue();
+      expect(server.calls[ListToolsRequest.methodName], 1);
+
+      result.complete(server.completeTools(1));
+      final responses = await Future.wait([first, second]);
+      expect(responses.map((response) => response.tools.single.name), [
+        'tool-1',
+        'tool-1',
+      ]);
+      expect(server.calls[ListToolsRequest.methodName], 1);
+    });
+
+    test('retries after an in-flight result is not cacheable', () async {
+      final result = Completer<ListToolsResult>();
+      server.listToolsResult = (_, _) => result.future;
+
+      final first = listTools();
+      await pumpEventQueue();
+      final second = listTools();
+      await pumpEventQueue();
+      expect(server.calls[ListToolsRequest.methodName], 1);
+
+      server.ttlMs = 0;
+      result.complete(server.completeTools(1));
+      await Future.wait([first, second]);
+      expect(server.calls[ListToolsRequest.methodName], 2);
     });
 
     test('separates methods, cursors, and resource uris', () async {
@@ -494,22 +534,6 @@ void main() {
       },
     );
 
-    test('drops cached reads when an update leaves out its uri', () async {
-      const kept = 'file:///kept-through-update';
-      await readResource(kept);
-      await readResource(kept);
-      expect(server.readCalls[kept], 1);
-
-      server.sendNotification(
-        ResourceUpdatedNotification.methodName,
-        ResourceUpdatedNotification.fromMap(<String, Object?>{}),
-      );
-      await pumpEventQueue();
-
-      await readResource(kept);
-      expect(server.readCalls[kept], 2);
-    });
-
     test('does not store responses invalidated while in flight', () async {
       final toolsResult = Completer<ListToolsResult>();
       server.listToolsResult = (_, _) => toolsResult.future;
@@ -656,19 +680,14 @@ void main() {
       expect(server.calls[ListToolsRequest.methodName], 1);
     });
 
-    test('clamps a ttl past a day', () async {
-      // 36 hours sits between the one-day cap and a two-day cap, so a
-      // 48-hour clamp would still have this entry after a day.
-      server.ttlMs = const Duration(hours: 36).inMilliseconds;
+    test('uses the configured maximum ttl', () async {
+      connection
+        ..maxCachedResponseTtl = const Duration(hours: 1)
+        ..pauseCachedResponseClock();
+      server.ttlMs = const Duration(hours: 2).inMilliseconds;
 
       await listTools();
-      connection.elapseCachedResponses(
-        const Duration(hours: 24) - const Duration(seconds: 1),
-      );
-      await listTools();
-      expect(server.calls[ListToolsRequest.methodName], 1);
-
-      connection.elapseCachedResponses(const Duration(seconds: 2));
+      connection.elapseCachedResponses(const Duration(hours: 1));
       await listTools();
       expect(server.calls[ListToolsRequest.methodName], 2);
     });
@@ -681,20 +700,6 @@ void main() {
 
       await connection.shutdown();
       expect(connection.cachedResponseCount, 0);
-    });
-
-    test('delivers a resource notification which leaves out its uri', () async {
-      final updates = <ResourceUpdatedNotification>[];
-      final subscription = connection.resourceUpdated.listen(updates.add);
-      addTearDown(subscription.cancel);
-
-      server.sendNotification(
-        ResourceUpdatedNotification.methodName,
-        ResourceUpdatedNotification.fromMap(<String, Object?>{}),
-      );
-      await pumpEventQueue();
-
-      expect(updates.single, isEmpty);
     });
   });
 }

--- a/pkgs/dart_mcp/test/client/response_cache_test.dart
+++ b/pkgs/dart_mcp/test/client/response_cache_test.dart
@@ -722,6 +722,28 @@ void main() {
       expect(server.calls[ListToolsRequest.methodName], 2);
     });
 
+    test('changing the maximum ttl clears cached responses', () async {
+      await listTools();
+      expect(connection.cachedResponseCount, 1);
+
+      connection.maxCachedResponseTtl = const Duration(hours: 1);
+      expect(connection.cachedResponseCount, 0);
+      await listTools();
+
+      expect(server.calls[ListToolsRequest.methodName], 2);
+    });
+
+    test('a zero maximum ttl disables response caching', () async {
+      await listTools();
+      connection.maxCachedResponseTtl = Duration.zero;
+
+      await listTools();
+      await listTools();
+
+      expect(connection.cachedResponseCount, 0);
+      expect(server.calls[ListToolsRequest.methodName], 3);
+    });
+
     test('drops cached entries on shutdown', () async {
       await listTools();
       await listTools();


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

The client reuses complete results for the six 2026-07-28 operations that
carry caching hints, keyed by the parameters and the request metadata. I
wrapped `sendRequestKeepingProgress` so `sendRequestWithInputs` still hits
the cache. Entries drop on change notifications, a stale cursor, and
`shutdown`. The cache belongs to one `ServerConnection`. A `private` result
never leaves the authorization context it came from.

The multi round-trip page never mentions caching. The caching utilities page
(https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching)
says an `input_required` result is not cacheable, and a retry carrying
`inputResponses` or `requestState` MUST NOT be cached. I kept both out even
when a `resources/read` payload also sends the hints.
