### PR TITLE
let tool, prompt and resource handlers answer with an input-required result

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -124,7 +124,8 @@
     result and `InputRequiredResult` implement. A handler can ask for input
     before it answers. The `registerTool`, `addPrompt`, `addResource` and
     `updateResource` parameters taking those handlers widen with them.
-    `Result.isInputRequired` tells them apart.
+    `Result.isInputRequired` tells them apart. Nothing on the 2025-11-25 path
+    moves, since the completed results implement the new supertypes.
 - Add `supportsFormElicitation` and `supportsUrlElicitation` for a server to
   ask before it sends. An empty `elicitation` object still means form, the way
   `elicitation` read before the split.

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -118,6 +118,11 @@
     the way its dartdoc already described, instead of holding the rejected
     server's implementation. `initialize` still returns that result and
     `serverCapabilities` still holds what the server sent.
+  - `ToolsSupport.callTool`, `PromptsSupport.getPrompt` and
+    `ResourcesSupport.readResource` return `CallToolResponse`,
+    `GetPromptResponse` and `ReadResourceResponse`, which both the completed
+    result and `InputRequiredResult` implement, so a handler can ask for input
+    before it answers. `Result.isInputRequired` tells them apart.
 - Add `supportsFormElicitation` and `supportsUrlElicitation` for a server to
   ask before it sends. An empty `elicitation` object still means form, the way
   `elicitation` read before the split.
@@ -185,7 +190,6 @@
 - Add `InputRequiredResult` and `InputRequest`, the result a server answers with
   when it needs input first, see
   https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr.
-  A server built with this package does not send one yet.
 - On a 2026-07-28 connection, `ServerConnection.callTool`, `.getPrompt` and
   `.readResource` answer an `input_required` result from the client's
   elicitation, sampling and roots handlers, then send the original request

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -121,9 +121,9 @@
   - `ToolsSupport.callTool`, `PromptsSupport.getPrompt` and
     `ResourcesSupport.readResource` return `CallToolResponse`,
     `GetPromptResponse` and `ReadResourceResponse`, which both the completed
-    result and `InputRequiredResult` implement, so a handler can ask for input
-    before it answers. The `registerTool`, `registerPrompt`, `addResource` and
-    `addResourceTemplate` parameters taking those handlers widen with them.
+    result and `InputRequiredResult` implement. A handler can ask for input
+    before it answers. The `registerTool`, `addPrompt`, `addResource` and
+    `updateResource` parameters taking those handlers widen with them.
     `Result.isInputRequired` tells them apart.
 - Add `supportsFormElicitation` and `supportsUrlElicitation` for a server to
   ask before it sends. An empty `elicitation` object still means form, the way

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -124,8 +124,11 @@
     result and `InputRequiredResult` implement. A handler can ask for input
     before it answers. The `registerTool`, `addPrompt`, `addResource` and
     `updateResource` parameters taking those handlers widen with them.
-    `Result.isInputRequired` tells them apart. Nothing on the 2025-11-25 path
-    moves, since the completed results implement the new supertypes.
+    `Result.isInputRequired` tells them apart. Handlers passed to those
+    parameters still type check, since the completed results implement the new
+    supertypes. A subclass or mixin overriding one of those three methods
+    declares the wider return type, then checks `isInputRequired` and casts
+    before it reads the completed result.
 - Add `supportsFormElicitation` and `supportsUrlElicitation` for a server to
   ask before it sends. An empty `elicitation` object still means form, the way
   `elicitation` read before the split.

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -122,7 +122,9 @@
     `ResourcesSupport.readResource` return `CallToolResponse`,
     `GetPromptResponse` and `ReadResourceResponse`, which both the completed
     result and `InputRequiredResult` implement, so a handler can ask for input
-    before it answers. `Result.isInputRequired` tells them apart.
+    before it answers. The `registerTool`, `registerPrompt`, `addResource` and
+    `addResourceTemplate` parameters taking those handlers widen with them.
+    `Result.isInputRequired` tells them apart.
 - Add `supportsFormElicitation` and `supportsUrlElicitation` for a server to
   ask before it sends. An empty `elicitation` object still means form, the way
   `elicitation` read before the split.

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -302,6 +302,13 @@ extension type Result._(Map<String, Object?> _value) {
   /// value is reported here as "complete".
   String get resultType =>
       _value[Keys.resultType] as String? ?? ResultTypes.complete;
+
+  /// Whether the server asked for more input before it can answer, which makes
+  /// this an [InputRequiredResult].
+  ///
+  /// An `is` check cannot tell that apart, because these are just extension
+  /// types and they share the runtime type `Map<String, Object?>`.
+  bool get isInputRequired => resultType == ResultTypes.inputRequired;
 }
 
 /// A response that indicates success but carries no data.

--- a/pkgs/dart_mcp/lib/src/api/input_required.dart
+++ b/pkgs/dart_mcp/lib/src/api/input_required.dart
@@ -93,7 +93,7 @@ extension type InputRequest._(Map<String, Object?> _value) {
 ///
 /// From the 2026-07-28 revision.
 extension type InputRequiredResult.fromMap(Map<String, Object?> _value)
-    implements Result {
+    implements CallToolResponse, GetPromptResponse, ReadResourceResponse {
   factory InputRequiredResult({
     Map<String, InputRequest>? inputRequests,
     String? requestState,

--- a/pkgs/dart_mcp/lib/src/api/prompts.dart
+++ b/pkgs/dart_mcp/lib/src/api/prompts.dart
@@ -81,7 +81,13 @@ extension type GetPromptRequest.fromMap(Map<String, Object?> _value)
 /// This type is not intended to be constructed directly and thus has no public
 /// constructor.
 extension type GetPromptResponse._fromMap(Map<String, Object?> _value)
-    implements Result {}
+    implements Result {
+  /// A complete result with no input required.
+  static const getPromptResult = GetPromptResult.new;
+
+  /// A result that requires further input from the client.
+  static const inputRequiredResult = InputRequiredResult.new;
+}
 
 /// The server's completed response to a prompts/get request from the client.
 extension type GetPromptResult.fromMap(Map<String, Object?> _value)

--- a/pkgs/dart_mcp/lib/src/api/prompts.dart
+++ b/pkgs/dart_mcp/lib/src/api/prompts.dart
@@ -73,9 +73,19 @@ extension type GetPromptRequest.fromMap(Map<String, Object?> _value)
       (_value[Keys.arguments] as Map?)?.cast<String, Object?>();
 }
 
-/// The server's response to a prompts/get request from the client.
+/// A response to a `prompts/get` request, which is either a [GetPromptResult]
+/// or an [InputRequiredResult].
+///
+/// Check [isInputRequired] and then cast to one of those.
+///
+/// This type is not intended to be constructed directly and thus has no public
+/// constructor.
+extension type GetPromptResponse._fromMap(Map<String, Object?> _value)
+    implements Result {}
+
+/// The server's completed response to a prompts/get request from the client.
 extension type GetPromptResult.fromMap(Map<String, Object?> _value)
-    implements Result {
+    implements GetPromptResponse {
   factory GetPromptResult({
     String? description,
     required List<PromptMessage> messages,

--- a/pkgs/dart_mcp/lib/src/api/resources.dart
+++ b/pkgs/dart_mcp/lib/src/api/resources.dart
@@ -107,9 +107,19 @@ extension type ReadResourceRequest.fromMap(Map<String, Object?> _value)
   }
 }
 
-/// The server's response to a resources/read request from the client.
+/// A response to a `resources/read` request, which is either a
+/// [ReadResourceResult] or an [InputRequiredResult].
+///
+/// Check [isInputRequired] and then cast to one of those.
+///
+/// This type is not intended to be constructed directly and thus has no public
+/// constructor.
+extension type ReadResourceResponse._fromMap(Map<String, Object?> _value)
+    implements Result {}
+
+/// The server's completed response to a resources/read request from the client.
 extension type ReadResourceResult.fromMap(Map<String, Object?> _value)
-    implements CacheableResult {
+    implements CacheableResult, ReadResourceResponse {
   factory ReadResourceResult({
     required List<ResourceContents> contents,
     int? ttlMs,

--- a/pkgs/dart_mcp/lib/src/api/resources.dart
+++ b/pkgs/dart_mcp/lib/src/api/resources.dart
@@ -115,7 +115,13 @@ extension type ReadResourceRequest.fromMap(Map<String, Object?> _value)
 /// This type is not intended to be constructed directly and thus has no public
 /// constructor.
 extension type ReadResourceResponse._fromMap(Map<String, Object?> _value)
-    implements Result {}
+    implements Result {
+  /// A complete result with no input required.
+  static const readResourceResult = ReadResourceResult.new;
+
+  /// A result that requires further input from the client.
+  static const inputRequiredResult = InputRequiredResult.new;
+}
 
 /// The server's completed response to a resources/read request from the client.
 extension type ReadResourceResult.fromMap(Map<String, Object?> _value)

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -45,7 +45,17 @@ extension type ListToolsResult.fromMap(Map<String, Object?> _value)
   }
 }
 
-/// The server's response to a tool call.
+/// A response to a `tools/call` request, which is either a [CallToolResult]
+/// or an [InputRequiredResult].
+///
+/// Check [isInputRequired] and then cast to one of those.
+///
+/// This type is not intended to be constructed directly and thus has no public
+/// constructor.
+extension type CallToolResponse._fromMap(Map<String, Object?> _value)
+    implements Result {}
+
+/// The server's completed response to a tool call.
 ///
 /// Any errors that originate from the tool SHOULD be reported inside the result
 /// object, with `isError` set to true, _not_ as an MCP protocol-level error
@@ -56,7 +66,7 @@ extension type ListToolsResult.fromMap(Map<String, Object?> _value)
 /// server does not support tool calls, or any other exceptional conditions,
 /// should be reported as an MCP error response.
 extension type CallToolResult.fromMap(Map<String, Object?> _value)
-    implements Result {
+    implements CallToolResponse {
   factory CallToolResult({
     Meta? meta,
     required List<Content> content,

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -53,7 +53,13 @@ extension type ListToolsResult.fromMap(Map<String, Object?> _value)
 /// This type is not intended to be constructed directly and thus has no public
 /// constructor.
 extension type CallToolResponse._fromMap(Map<String, Object?> _value)
-    implements Result {}
+    implements Result {
+  /// A complete result with no input required.
+  static const callToolResult = CallToolResult.new;
+
+  /// A result that requires further input from the client.
+  static const inputRequiredResult = InputRequiredResult.new;
+}
 
 /// The server's completed response to a tool call.
 ///

--- a/pkgs/dart_mcp/lib/src/server/prompts_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/prompts_support.dart
@@ -18,7 +18,7 @@ base mixin PromptsSupport on MCPServer {
   final Map<String, Prompt> _prompts = {};
 
   /// The added prompt implementations by name.
-  final Map<String, FutureOr<GetPromptResult> Function(GetPromptRequest)>
+  final Map<String, FutureOr<GetPromptResponse> Function(GetPromptRequest)>
   _promptImpls = {};
 
   @override
@@ -38,7 +38,7 @@ base mixin PromptsSupport on MCPServer {
 
   /// Gets the response for a given prompt.
   @mustCallSuper
-  FutureOr<GetPromptResult> getPrompt(GetPromptRequest request) {
+  FutureOr<GetPromptResponse> getPrompt(GetPromptRequest request) {
     final impl = _promptImpls[request.name];
     if (impl == null) {
       throw ArgumentError.value(request.name, 'name', 'Prompt not found');
@@ -49,7 +49,7 @@ base mixin PromptsSupport on MCPServer {
   /// Adds a prompt and notifies clients that the list has changed.
   void addPrompt(
     Prompt prompt,
-    FutureOr<GetPromptResult> Function(GetPromptRequest) impl,
+    FutureOr<GetPromptResponse> Function(GetPromptRequest) impl,
   ) {
     if (_prompts.containsKey(prompt.name)) {
       throw StateError(

--- a/pkgs/dart_mcp/lib/src/server/resources_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/resources_support.dart
@@ -5,7 +5,7 @@
 part of 'server.dart';
 
 typedef ReadResourceHandler =
-    FutureOr<ReadResourceResult?> Function(ReadResourceRequest);
+    FutureOr<ReadResourceResponse?> Function(ReadResourceRequest);
 
 /// A mixin for MCP servers which support the `resources` capability.
 ///
@@ -104,7 +104,7 @@ base mixin ResourcesSupport on MCPServer {
   /// same name.
   void addResource(
     Resource resource,
-    FutureOr<ReadResourceResult> Function(ReadResourceRequest) impl,
+    FutureOr<ReadResourceResponse> Function(ReadResourceRequest) impl,
   ) {
     if (_resources.containsKey(resource.uri)) {
       throw StateError(
@@ -168,7 +168,7 @@ base mixin ResourcesSupport on MCPServer {
   /// Throws a [StateError] if [resource] does not exist.
   void updateResource(
     Resource resource, {
-    FutureOr<ReadResourceResult> Function(ReadResourceRequest)? impl,
+    FutureOr<ReadResourceResponse> Function(ReadResourceRequest)? impl,
   }) {
     if (!_resources.containsKey(resource.uri)) {
       throw StateError(
@@ -207,7 +207,9 @@ base mixin ResourcesSupport on MCPServer {
   /// `data.uri`. Earlier revisions asked for `-32002` here, which this package
   /// has never sent.
   @mustCallSuper
-  FutureOr<ReadResourceResult> readResource(ReadResourceRequest request) async {
+  FutureOr<ReadResourceResponse> readResource(
+    ReadResourceRequest request,
+  ) async {
     final impl = _resourceImpls[request.uri];
     if (impl == null) {
       // Check if it matches any resource template.

--- a/pkgs/dart_mcp/lib/src/server/tools_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/tools_support.dart
@@ -25,7 +25,7 @@ base mixin ToolsSupport on MCPServer {
   );
 
   /// The registered tool implementations by name.
-  final Map<String, FutureOr<CallToolResult> Function(CallToolRequest)>
+  final Map<String, FutureOr<CallToolResponse> Function(CallToolRequest)>
   _registeredToolImpls = {};
 
   /// Invoked during server feature registration.
@@ -56,7 +56,7 @@ base mixin ToolsSupport on MCPServer {
   /// validated against the [tool]s input schema.
   void registerTool(
     Tool tool,
-    FutureOr<CallToolResult> Function(CallToolRequest) impl, {
+    FutureOr<CallToolResponse> Function(CallToolRequest) impl, {
     bool validateArguments = true,
   }) {
     if (_registeredTools.containsKey(tool.name)) {
@@ -115,7 +115,7 @@ base mixin ToolsSupport on MCPServer {
 
   /// Invoked when one of the registered tools is called.
   @mustCallSuper
-  Future<CallToolResult> callTool(CallToolRequest request) async {
+  Future<CallToolResponse> callTool(CallToolRequest request) async {
     final impl = _registeredToolImpls[request.name];
     if (impl == null) {
       return CallToolResult(

--- a/pkgs/dart_mcp/test/api/api_test.dart
+++ b/pkgs/dart_mcp/test/api/api_test.dart
@@ -225,6 +225,19 @@ void main() {
         'streaming',
       );
     });
+    test('isInputRequired is true only for input_required results', () {
+      expect((<String, Object?>{} as Result).isInputRequired, false);
+      expect(
+        (<String, Object?>{'resultType': 'input_required'} as Result)
+            .isInputRequired,
+        true,
+      );
+      expect(
+        (<String, Object?>{'resultType': 'streaming'} as Result)
+            .isInputRequired,
+        false,
+      );
+    });
     test('cacheable result fields default when absent and parse known '
         'values', () {
       final empty = <String, Object?>{} as CacheableResult;

--- a/pkgs/dart_mcp/test/api/prompts_test.dart
+++ b/pkgs/dart_mcp/test/api/prompts_test.dart
@@ -88,14 +88,11 @@ void main() {
       (_) => InputRequiredResult(requestState: 'waiting'),
     );
 
-    expect(
-      await server.getPrompt(GetPromptRequest(name: 'needs input')),
-      isA<InputRequiredResult>().having(
-        (result) => result.requestState,
-        'requestState',
-        'waiting',
-      ),
+    final result = await server.getPrompt(
+      GetPromptRequest(name: 'needs input'),
     );
+    expect(result.isInputRequired, true);
+    expect((result as InputRequiredResult).requestState, 'waiting');
 
     await environment.shutdown();
   });

--- a/pkgs/dart_mcp/test/api/prompts_test.dart
+++ b/pkgs/dart_mcp/test/api/prompts_test.dart
@@ -75,6 +75,30 @@ void main() {
     // keep the test active.
     await environment.shutdown();
   });
+  test('a prompt handler can answer with an input-required result', () async {
+    final environment = TestEnvironment(
+      TestMCPClient(),
+      TestMCPServerWithPrompts.new,
+    );
+    await environment.initializeServer();
+
+    final server = environment.server;
+    server.addPrompt(
+      Prompt(name: 'needs input'),
+      (_) => InputRequiredResult(requestState: 'waiting'),
+    );
+
+    expect(
+      await server.getPrompt(GetPromptRequest(name: 'needs input')),
+      isA<InputRequiredResult>().having(
+        (result) => result.requestState,
+        'requestState',
+        'waiting',
+      ),
+    );
+
+    await environment.shutdown();
+  });
 }
 
 final class TestMCPServerWithPrompts extends TestMCPServer with PromptsSupport {

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -1510,11 +1510,7 @@ final class _DispatcherTestServer extends TestMCPServer
     );
     registerTool(
       Tool(name: 'interim', inputSchema: ObjectSchema()),
-      (_) => CallToolResult.fromMap({
-        Keys.content: [TextContent(text: 'waiting')],
-        Keys.resultType: ResultTypes.inputRequired,
-        Keys.requestState: 'waiting',
-      }),
+      (_) => InputRequiredResult(requestState: 'waiting'),
     );
     for (final entry
         in {
@@ -1559,13 +1555,9 @@ final class _DispatcherTestServer extends TestMCPServer
     // Registered directly, not by mixing in `PromptsSupport`: the guard
     // dispatches on the method, and the mixin would also change what this
     // server advertises. Other tests here assert on those capabilities.
-    registerRequestHandler<GetPromptRequest, GetPromptResult>(
+    registerRequestHandler<GetPromptRequest, GetPromptResponse>(
       GetPromptRequest.methodName,
-      (_) => GetPromptResult.fromMap({
-        Keys.messages: <Object?>[],
-        Keys.resultType: ResultTypes.inputRequired,
-        Keys.requestState: 'waiting',
-      }),
+      (_) => InputRequiredResult(requestState: 'waiting'),
     );
     registerTool(
       Tool(name: 'bad_meta', inputSchema: ObjectSchema()),

--- a/pkgs/dart_mcp/test/server/resources_support_test.dart
+++ b/pkgs/dart_mcp/test/server/resources_support_test.dart
@@ -259,6 +259,28 @@ void main() {
       ),
     );
   });
+
+  test('a resource handler can answer with an input-required result', () async {
+    final environment = TestEnvironment(
+      TestMCPClient(),
+      TestMCPServerWithResources.new,
+    );
+    await environment.initializeServer();
+
+    final server = environment.server;
+    server.addResource(
+      Resource(name: 'needs input', uri: 'needs://input'),
+      (_) => InputRequiredResult(requestState: 'waiting'),
+    );
+
+    final result = await server.readResource(
+      ReadResourceRequest(uri: 'needs://input'),
+    );
+    expect(result.isInputRequired, true);
+    expect((result as InputRequiredResult).requestState, 'waiting');
+
+    await environment.shutdown();
+  });
 }
 
 final class TestMCPServerWithResources extends TestMCPServer


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

https://github.com/dart-lang/ai/pull/622 left the handler return types alone. A server still cannot answer `tools/call`, `prompts/get` or `resources/read` with an `InputRequiredResult`. This widens the three of them to `CallToolResponse`, `GetPromptResponse` and `ReadResourceResponse`, which the completed result and `InputRequiredResult` both implement.

Rust names the same three. I kept the supertypes constructorless so `_fromMap` stays private. Extension types cannot be told apart by `is`, so `Result.isInputRequired` reads the result type instead.

It is a breaking change, and the handler parameters widen with it. Callers on 2025-11-25 see no difference, because what they already return satisfies the wider type. The `dart_mcp_server` package resolves the published 0.5.x, so its six sites move when 0.6.0 lands.
