### PR TITLE
wait before a retry that carries no input requests

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -191,7 +191,10 @@
   elicitation, sampling and roots handlers, then send the original request
   again, through the new `ServerConnection.sendRequestWithInputs`. The spec
   bounds the rounds nowhere, so `ServerConnection.maxInputRequiredRounds`
-  stops them, at ten unless a caller moves it or clears it with `null`.
+  stops them, at ten unless a caller moves it or clears it with `null`. A
+  retry that carries no input requests, including an empty map, waits
+  `ServerConnection.inputRequiredRetryDelay` first, 250 milliseconds unless
+  a caller moves it or clears it with `null`.
 - Add `MCPBase.sendRequestKeepingProgress` and `MCPBase.closeProgress`.
   `sendRequest` closes a progress stream once its request is done, and this
   pair splits that apart so a retry loop can hold one token across rounds.

--- a/pkgs/dart_mcp/lib/src/client/client.dart
+++ b/pkgs/dart_mcp/lib/src/client/client.dart
@@ -157,6 +157,12 @@ base class ServerConnection extends MCPBase {
   /// server that never stops asking.
   int? maxInputRequiredRounds = 10;
 
+  /// How long [sendRequestWithInputs] waits before a retry that carries no
+  /// input requests, including an empty map, or `null` for no wait.
+  ///
+  /// The spec allows an immediate retry. This one only avoids a tight loop.
+  Duration? inputRequiredRetryDelay = const Duration(milliseconds: 250);
+
   @override
   String get name => serverInfo?.name ?? super.name;
 
@@ -517,9 +523,7 @@ base class ServerConnection extends MCPBase {
           '`${Keys.inputRequests}` or `${Keys.requestState}`.',
         );
       }
-      // TODO: Delay a retry that carries no input requests.
-      // https://github.com/dart-lang/ai/issues/162
-      if (inputRequests != null) {
+      if (inputRequests != null && inputRequests.isNotEmpty) {
         // Resolve every handler before running any, so a request this client
         // cannot serve stops the round before a partial dispatch.
         final handlers = [
@@ -528,6 +532,11 @@ base class ServerConnection extends MCPBase {
         ];
         for (final handler in handlers) {
           responses[handler.key] = await handler.value();
+        }
+      } else {
+        final delay = inputRequiredRetryDelay;
+        if (delay != null) {
+          await Future<void>.delayed(delay);
         }
       }
       final retryRequest =

--- a/pkgs/dart_mcp/test/client/input_required_test.dart
+++ b/pkgs/dart_mcp/test/client/input_required_test.dart
@@ -8,6 +8,9 @@ import 'package:dart_mcp/client.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
 
+/// Timers can fire a little early where the platform clock is coarse.
+const _timerSlack = Duration(milliseconds: 15);
+
 void main() {
   test('does not interpret input-required results before 2026-07-28', () async {
     final client = MCPClient(
@@ -796,7 +799,7 @@ void main() {
 
     await harness.connection.callTool(CallToolRequest(name: 'task'));
 
-    expect(stopwatch.elapsed, greaterThanOrEqualTo(delay));
+    expect(stopwatch.elapsed, greaterThanOrEqualTo(delay - _timerSlack));
     expect(harness.requests, hasLength(2));
   });
 
@@ -822,7 +825,7 @@ void main() {
 
     await harness.connection.callTool(CallToolRequest(name: 'task'));
 
-    expect(stopwatch.elapsed, greaterThanOrEqualTo(delay));
+    expect(stopwatch.elapsed, greaterThanOrEqualTo(delay - _timerSlack));
     expect(stopwatch.elapsed, lessThan(const Duration(milliseconds: 200)));
     expect(harness.requests, hasLength(2));
   });
@@ -909,7 +912,7 @@ void main() {
 
       await harness.connection.callTool(CallToolRequest(name: 'task'));
 
-      expect(stopwatch.elapsed, greaterThanOrEqualTo(delay));
+      expect(stopwatch.elapsed, greaterThanOrEqualTo(delay - _timerSlack));
       expect(harness.requests, hasLength(2));
       expect(_params(harness.requests.last), isNot(contains('inputResponses')));
     },

--- a/pkgs/dart_mcp/test/client/input_required_test.dart
+++ b/pkgs/dart_mcp/test/client/input_required_test.dart
@@ -773,6 +773,148 @@ void main() {
     expect(harness.requests, hasLength(13));
   });
 
+  test('waits before a retry that carries no input requests', () async {
+    final harness = _WireHarness(
+      MCPClient(Implementation(name: 'test client', version: '0.1.0')),
+      (request, requestNumber) =>
+          requestNumber == 1
+              ? {
+                'resultType': 'input_required',
+                'requestState': 'still-waiting',
+              }
+              : {
+                'resultType': 'complete',
+                'content': [
+                  {'type': 'text', 'text': 'done'},
+                ],
+              },
+      keepRetryDelay: true,
+    );
+    final delay = const Duration(milliseconds: 250);
+    expect(harness.connection.inputRequiredRetryDelay, delay);
+    final stopwatch = Stopwatch()..start();
+
+    await harness.connection.callTool(CallToolRequest(name: 'task'));
+
+    expect(stopwatch.elapsed, greaterThanOrEqualTo(delay));
+    expect(harness.requests, hasLength(2));
+  });
+
+  test('waits the delay a caller moved', () async {
+    final harness = _WireHarness(
+      MCPClient(Implementation(name: 'test client', version: '0.1.0')),
+      (request, requestNumber) =>
+          requestNumber == 1
+              ? {
+                'resultType': 'input_required',
+                'requestState': 'still-waiting',
+              }
+              : {
+                'resultType': 'complete',
+                'content': [
+                  {'type': 'text', 'text': 'done'},
+                ],
+              },
+    );
+    final delay = const Duration(milliseconds: 50);
+    harness.connection.inputRequiredRetryDelay = delay;
+    final stopwatch = Stopwatch()..start();
+
+    await harness.connection.callTool(CallToolRequest(name: 'task'));
+
+    expect(stopwatch.elapsed, greaterThanOrEqualTo(delay));
+    expect(stopwatch.elapsed, lessThan(const Duration(milliseconds: 200)));
+    expect(harness.requests, hasLength(2));
+  });
+
+  test('does not wait when the retry delay is null', () async {
+    final harness = _WireHarness(
+      MCPClient(Implementation(name: 'test client', version: '0.1.0')),
+      (request, requestNumber) =>
+          requestNumber == 1
+              ? {
+                'resultType': 'input_required',
+                'requestState': 'still-waiting',
+              }
+              : {
+                'resultType': 'complete',
+                'content': [
+                  {'type': 'text', 'text': 'done'},
+                ],
+              },
+    );
+    expect(harness.connection.inputRequiredRetryDelay, isNull);
+    final stopwatch = Stopwatch()..start();
+
+    await harness.connection.callTool(CallToolRequest(name: 'task'));
+    stopwatch.stop();
+
+    expect(stopwatch.elapsed, lessThan(const Duration(milliseconds: 50)));
+    expect(harness.requests, hasLength(2));
+  });
+
+  test('does not wait before a retry that carries input requests', () async {
+    final client =
+        _InputClient()
+          ..addRoot(Root(uri: 'file:///workspace', name: 'workspace'));
+    final harness = _WireHarness(client, (request, requestNumber) {
+      if (requestNumber == 1) {
+        return {
+          'resultType': 'input_required',
+          'inputRequests': {
+            'roots': {'method': 'roots/list', 'params': <String, Object?>{}},
+          },
+        };
+      }
+      return {
+        'resultType': 'complete',
+        'content': [
+          {'type': 'text', 'text': 'done'},
+        ],
+      };
+    });
+    final delay = const Duration(milliseconds: 400);
+    harness.connection.inputRequiredRetryDelay = delay;
+    final stopwatch = Stopwatch()..start();
+
+    await harness.connection.callTool(CallToolRequest(name: 'task'));
+
+    expect(stopwatch.elapsed, lessThan(delay));
+    expect(harness.requests, hasLength(2));
+    expect(client.handled, ['roots/list']);
+  });
+
+  test(
+    'waits before a retry that carries an empty input request map',
+    () async {
+      final harness = _WireHarness(
+        MCPClient(Implementation(name: 'test client', version: '0.1.0')),
+        (request, requestNumber) =>
+            requestNumber == 1
+                ? {
+                  'resultType': 'input_required',
+                  'inputRequests': <String, Object?>{},
+                  'requestState': 'still-waiting',
+                }
+                : {
+                  'resultType': 'complete',
+                  'content': [
+                    {'type': 'text', 'text': 'done'},
+                  ],
+                },
+      );
+      final delay = const Duration(milliseconds: 50);
+      harness.connection.inputRequiredRetryDelay = delay;
+      final stopwatch = Stopwatch()..start();
+
+      await harness.connection.callTool(CallToolRequest(name: 'task'));
+
+      expect(stopwatch.elapsed, greaterThanOrEqualTo(delay));
+      expect(harness.requests, hasLength(2));
+      expect(_params(harness.requests.last), isNot(contains('inputResponses')));
+    },
+  );
+
   test('reports progress from every round under the original token', () async {
     final harness = _WireHarness(
       MCPClient(Implementation(name: 'test client', version: '0.1.0')),
@@ -911,11 +1053,15 @@ final class _WireHarness {
     ProtocolVersion? protocolVersion = ProtocolVersion.v2026_07_28,
     this.sendProgress = false,
     bool withServerInfo = true,
+    bool keepRetryDelay = false,
   }) {
     connection = client.connectServer(
       StreamChannel.withGuarantees(_incoming.stream, _outgoing.sink),
     );
     connection.protocolVersion = protocolVersion;
+    if (!keepRetryDelay) {
+      connection.inputRequiredRetryDelay = null;
+    }
     if (protocolVersion != null && withServerInfo) {
       connection.serverInfo = Implementation(name: 'wire server', version: '1');
     }


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

Nothing paced the leg the TODO named, so the client could retry the moment the server answered. `ServerConnection.inputRequiredRetryDelay` now holds it off for 250 ms, and `null` disables that. An empty map waits too, since it asks for nothing. Where the server does hand back work, resolving it already costs time, so those rounds are untouched.

The number comes from `packages/core-internal/src/shared/inputRequiredDriver.ts` in the TypeScript SDK, which sleeps a flat 250 ms there. Python caps a backoff at the same figure. I took the flat wait, since a constant pause on each of these rounds keeps the loop off the wire.
