### PR TITLE
add a local mcp conformance probe

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.6.0-wip
 
+- Add a local HTTP probe for the MCP conformance suite.
 - **BREAKING**:
   - `MCPBase` (including the `MCPServer.fromStreamChannel` and
     `ServerConnection.fromStreamChannel` constructors),

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -330,6 +330,7 @@
     reserved keys the schema makes required, plus `clientInfo`, `logLevel` and
     `progressToken` when they are given, see
     https://modelcontextprotocol.io/specification/2026-07-28/server/discover.
+- Add a local MCP conformance probe under `tool/`.
 
 ## 0.5.2
 

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## 0.6.0-wip
 
-- Add a local HTTP probe for the MCP conformance suite.
 - **BREAKING**:
   - `MCPBase` (including the `MCPServer.fromStreamChannel` and
     `ServerConnection.fromStreamChannel` constructors),

--- a/pkgs/dart_mcp/bin/conformance_server.dart
+++ b/pkgs/dart_mcp/bin/conformance_server.dart
@@ -1,0 +1,771 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_mcp/server.dart';
+import 'package:dart_mcp/streamable_http.dart';
+import 'package:json_rpc_2/json_rpc_2.dart';
+
+const _path = '/mcp';
+const _imageMimeType = 'image/png';
+const _audioMimeType = 'audio/wav';
+const _textMimeType = 'text/plain';
+const _jsonMimeType = 'application/json';
+const _imageData =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ'
+    'AAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==';
+const _audioData =
+    'UklGRiYAAABXQVZFZm10IBAAAAABAAEAQB8AAAB9AAACABAAZGF0YQIAAAA=';
+
+const _simpleTextTool = 'test_simple_text';
+const _imageTool = 'test_image_content';
+const _audioTool = 'test_audio_content';
+const _embeddedResourceTool = 'test_embedded_resource';
+const _mixedContentTool = 'test_multiple_content_types';
+const _errorTool = 'test_error_handling';
+const _progressTool = 'test_tool_with_progress';
+const _missingCapabilityTool = 'test_missing_capability';
+const _jsonSchemaTool = 'json_schema_2020_12_tool';
+const _inputElicitationTool = 'test_input_required_result_elicitation';
+const _inputSamplingTool = 'test_input_required_result_sampling';
+const _inputRootsTool = 'test_input_required_result_list_roots';
+const _inputStateTool = 'test_input_required_result_request_state';
+const _inputMultipleTool = 'test_input_required_result_multiple_inputs';
+const _inputMultiRoundTool = 'test_input_required_result_multi_round';
+const _inputTamperedTool = 'test_input_required_result_tampered_state';
+const _inputCapabilitiesTool = 'test_input_required_result_capabilities';
+
+const _staticTextUri = 'test://static-text';
+const _staticBinaryUri = 'test://static-binary';
+const _templateUri = 'test://template/{id}/data';
+
+const _simplePrompt = 'test_simple_prompt';
+const _argumentsPrompt = 'test_prompt_with_arguments';
+const _embeddedResourcePrompt = 'test_prompt_with_embedded_resource';
+const _imagePrompt = 'test_prompt_with_image';
+const _inputPrompt = 'test_input_required_result_prompt';
+
+const _requestState = 'request-state';
+const _multipleRequestState = 'multiple-request-state';
+const _roundOneState = 'round-one-state';
+const _roundTwoState = 'round-two-state';
+const _tamperState = 'tamper-state';
+
+final _headerToolSchema = ObjectSchema.fromMap({
+  'type': 'object',
+  'properties': {
+    'name': {'type': 'string', 'x-mcp-header': 'Name'},
+  },
+});
+
+final _jsonSchema = ObjectSchema.fromMap({
+  r'$schema': 'https://json-schema.org/draft/2020-12/schema',
+  'type': 'object',
+  r'$defs': {
+    'address': {
+      r'$anchor': 'addressDef',
+      'type': 'object',
+      'properties': {
+        'street': {'type': 'string'},
+        'city': {'type': 'string'},
+      },
+    },
+  },
+  'properties': {
+    'name': {'type': 'string'},
+    'address': {r'$ref': r'#/$defs/address'},
+    'contactMethod': {
+      'type': 'string',
+      'enum': ['phone', 'email'],
+    },
+    'phone': {'type': 'string'},
+    'email': {'type': 'string'},
+  },
+  'allOf': [
+    {
+      'anyOf': [
+        {
+          'required': ['phone'],
+        },
+        {
+          'required': ['email'],
+        },
+      ],
+    },
+  ],
+  'if': {
+    'properties': {
+      'contactMethod': {'const': 'phone'},
+    },
+    'required': ['contactMethod'],
+  },
+  'then': {
+    'required': ['phone'],
+  },
+  'else': {
+    'required': ['email'],
+  },
+  'additionalProperties': false,
+});
+
+/// Runs the server fixture used by the MCP conformance suite.
+Future<void> main(List<String> arguments) async {
+  final port = arguments.isEmpty ? 0 : int.parse(arguments.single);
+  final httpServer = await HttpServer.bind(InternetAddress.loopbackIPv4, port);
+  final endpoint = Uri(
+    scheme: 'http',
+    host: httpServer.address.host,
+    port: httpServer.port,
+    path: _path,
+  );
+
+  stdout.writeln(endpoint);
+  httpServer.listen((request) => unawaited(_handleRequest(request)));
+}
+
+Future<void> _handleRequest(HttpRequest request) async {
+  if (request.uri.path != _path) {
+    request.response
+      ..statusCode = HttpStatus.notFound
+      ..contentLength = 0;
+    await request.response.close();
+    return;
+  }
+
+  if (!_hasLocalTarget(request)) {
+    request.response
+      ..statusCode = HttpStatus.forbidden
+      ..contentLength = 0;
+    await request.response.close();
+    return;
+  }
+
+  try {
+    await handleStreamableHttpRequest(request, _ConformanceServer.new);
+  } catch (error, stackTrace) {
+    stderr
+      ..writeln(error)
+      ..writeln(stackTrace);
+  }
+}
+
+bool _hasLocalTarget(HttpRequest request) {
+  final hosts = request.headers[HttpHeaders.hostHeader];
+  if (hosts == null ||
+      hosts.length != 1 ||
+      !_isLocalUri(Uri.tryParse('http://${hosts.single}'))) {
+    return false;
+  }
+
+  final origins = request.headers['origin'];
+  return origins == null ||
+      (origins.length == 1 && _isLocalUri(Uri.tryParse(origins.single)));
+}
+
+bool _isLocalUri(Uri? uri) =>
+    uri != null &&
+    (uri.host.toLowerCase() == 'localhost' ||
+        uri.host == InternetAddress.loopbackIPv4.address ||
+        uri.host == InternetAddress.loopbackIPv6.address);
+
+base class _ConformanceServer extends MCPServer
+    with ToolsSupport, ResourcesSupport, PromptsSupport, CompletionsSupport {
+  _ConformanceServer(super.channel)
+    : super.fromStreamChannel(
+        implementation: Implementation(
+          name: 'dart_mcp conformance server',
+          version: '0.1.0',
+        ),
+      ) {
+    _registerTools();
+    _registerResources();
+    _registerPrompts();
+  }
+
+  void _registerTools() {
+    registerTool(
+      Tool(
+        name: _simpleTextTool,
+        description: _simpleTextTool,
+        inputSchema: _headerToolSchema,
+      ),
+      (_) => CallToolResult(
+        content: [
+          TextContent(text: 'This is a simple text response for testing.'),
+        ],
+      ),
+    );
+    registerTool(
+      Tool(
+        name: _imageTool,
+        description: _imageTool,
+        inputSchema: ObjectSchema(),
+      ),
+      (_) => CallToolResult(
+        content: [ImageContent(data: _imageData, mimeType: _imageMimeType)],
+      ),
+    );
+    registerTool(
+      Tool(
+        name: _audioTool,
+        description: _audioTool,
+        inputSchema: ObjectSchema(),
+      ),
+      (_) => CallToolResult(
+        content: [AudioContent(data: _audioData, mimeType: _audioMimeType)],
+      ),
+    );
+    registerTool(
+      Tool(
+        name: _embeddedResourceTool,
+        description: _embeddedResourceTool,
+        inputSchema: ObjectSchema(),
+      ),
+      (_) => CallToolResult(
+        content: [
+          EmbeddedResource(
+            resource: TextResourceContents(
+              uri: 'test://embedded-resource',
+              mimeType: _textMimeType,
+              text: 'This is an embedded resource content.',
+            ),
+          ),
+        ],
+      ),
+    );
+    registerTool(
+      Tool(
+        name: _mixedContentTool,
+        description: _mixedContentTool,
+        inputSchema: ObjectSchema(),
+      ),
+      (_) => CallToolResult(
+        content: [
+          TextContent(text: 'Multiple content types test:'),
+          ImageContent(data: _imageData, mimeType: _imageMimeType),
+          EmbeddedResource(
+            resource: TextResourceContents(
+              uri: 'test://mixed-content-resource',
+              mimeType: _jsonMimeType,
+              text: jsonEncode({'test': 'data', 'value': 123}),
+            ),
+          ),
+        ],
+      ),
+    );
+    registerTool(
+      Tool(
+        name: _errorTool,
+        description: _errorTool,
+        inputSchema: ObjectSchema(),
+      ),
+      (_) =>
+          throw StateError(
+            'This tool intentionally returns an error for testing',
+          ),
+    );
+    registerTool(
+      Tool(
+        name: _progressTool,
+        description: _progressTool,
+        inputSchema: ObjectSchema(),
+      ),
+      _reportProgress,
+    );
+    registerTool(
+      Tool(
+        name: _missingCapabilityTool,
+        description: _missingCapabilityTool,
+        inputSchema: ObjectSchema(),
+      ),
+      _requireSampling,
+    );
+    registerTool(
+      Tool(
+        name: _inputElicitationTool,
+        description: _inputElicitationTool,
+        inputSchema: ObjectSchema(),
+      ),
+      _requestElicitationInput,
+    );
+    registerTool(
+      Tool(
+        name: _inputSamplingTool,
+        description: _inputSamplingTool,
+        inputSchema: ObjectSchema(),
+      ),
+      _requestSamplingInput,
+    );
+    registerTool(
+      Tool(
+        name: _inputRootsTool,
+        description: _inputRootsTool,
+        inputSchema: ObjectSchema(),
+      ),
+      _requestRootsInput,
+    );
+    registerTool(
+      Tool(
+        name: _inputStateTool,
+        description: _inputStateTool,
+        inputSchema: ObjectSchema(),
+      ),
+      _requestStateInput,
+    );
+    registerTool(
+      Tool(
+        name: _inputMultipleTool,
+        description: _inputMultipleTool,
+        inputSchema: ObjectSchema(),
+      ),
+      _requestMultipleInputs,
+    );
+    registerTool(
+      Tool(
+        name: _inputMultiRoundTool,
+        description: _inputMultiRoundTool,
+        inputSchema: ObjectSchema(),
+      ),
+      _requestMultiRoundInput,
+    );
+    registerTool(
+      Tool(
+        name: _inputTamperedTool,
+        description: _inputTamperedTool,
+        inputSchema: ObjectSchema(),
+      ),
+      _requestTamperCheckedInput,
+    );
+    registerTool(
+      Tool(
+        name: _inputCapabilitiesTool,
+        description: _inputCapabilitiesTool,
+        inputSchema: ObjectSchema(),
+      ),
+      _requestCapabilityInputs,
+    );
+    registerTool(
+      Tool(
+        name: _jsonSchemaTool,
+        description: _jsonSchemaTool,
+        inputSchema: _jsonSchema,
+      ),
+      (_) => CallToolResult(content: [TextContent(text: _jsonSchemaTool)]),
+      validateArguments: false,
+    );
+  }
+
+  Future<CallToolResult> _reportProgress(CallToolRequest request) async {
+    final progressToken = request.meta?.progressToken;
+    if (progressToken != null) {
+      for (final progress in [0, 50, 100]) {
+        notifyProgress(
+          ProgressNotification(
+            progressToken: progressToken,
+            progress: progress,
+            total: 100,
+          ),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+      }
+    }
+    return CallToolResult(content: [TextContent(text: '$progressToken')]);
+  }
+
+  void _registerResources() {
+    addResource(
+      Resource(
+        uri: _staticTextUri,
+        name: 'static-text',
+        description: _staticTextUri,
+        mimeType: _textMimeType,
+      ),
+      (_) => ReadResourceResult(
+        contents: [
+          TextResourceContents(
+            uri: _staticTextUri,
+            mimeType: _textMimeType,
+            text: 'This is the content of the static text resource.',
+          ),
+        ],
+      ),
+    );
+    addResource(
+      Resource(
+        uri: _staticBinaryUri,
+        name: 'static-binary',
+        description: _staticBinaryUri,
+        mimeType: _imageMimeType,
+      ),
+      (_) => ReadResourceResult(
+        contents: [
+          BlobResourceContents(
+            uri: _staticBinaryUri,
+            mimeType: _imageMimeType,
+            blob: _imageData,
+          ),
+        ],
+      ),
+    );
+    addResourceTemplate(
+      ResourceTemplate(
+        uriTemplate: _templateUri,
+        name: 'template',
+        description: _templateUri,
+        mimeType: _jsonMimeType,
+      ),
+      _readTemplate,
+    );
+  }
+
+  Future<CallToolResult> _requireSampling(CallToolRequest _) async {
+    if (!supportsSampling) {
+      await createMessage(CreateMessageRequest(messages: [], maxTokens: 1));
+    }
+    return CallToolResult(content: [TextContent(text: 'Success')]);
+  }
+
+  ReadResourceResult? _readTemplate(ReadResourceRequest request) {
+    final uri = Uri.tryParse(request.uri);
+    if (uri == null ||
+        uri.scheme != 'test' ||
+        uri.host != 'template' ||
+        uri.pathSegments.length != 2 ||
+        uri.pathSegments.last != 'data') {
+      return null;
+    }
+    final id = uri.pathSegments.first;
+    return ReadResourceResult(
+      contents: [
+        TextResourceContents(
+          uri: request.uri,
+          mimeType: _jsonMimeType,
+          text: jsonEncode({
+            'id': id,
+            'templateTest': true,
+            'data': 'Data for ID: $id',
+          }),
+        ),
+      ],
+    );
+  }
+
+  CallToolResult _requestElicitationInput(CallToolRequest request) {
+    if (_inputResponse(request, 'user_name') != null) {
+      return _completeTool('Hello');
+    }
+    return _toolInputRequired(
+      InputRequiredResult(
+        inputRequests: {
+          'user_name': _elicitString(
+            message: 'What is your name?',
+            property: 'name',
+          ),
+        },
+      ),
+    );
+  }
+
+  CallToolResult _requestSamplingInput(CallToolRequest request) {
+    if (_inputResponse(request, 'capital_question') != null) {
+      return _completeTool('Sampling complete');
+    }
+    return _toolInputRequired(
+      InputRequiredResult(
+        inputRequests: {
+          'capital_question': _sample(
+            'What is the capital of France?',
+            maxTokens: 100,
+          ),
+        },
+      ),
+    );
+  }
+
+  CallToolResult _requestRootsInput(CallToolRequest request) {
+    if (_inputResponse(request, 'client_roots') != null) {
+      return _completeTool('Roots received');
+    }
+    return _toolInputRequired(
+      InputRequiredResult(
+        inputRequests: {
+          'client_roots': InputRequest.listRoots(ListRootsRequest()),
+        },
+      ),
+    );
+  }
+
+  CallToolResult _requestStateInput(CallToolRequest request) {
+    if (_inputResponse(request, 'confirm') != null &&
+        request.requestState == _requestState) {
+      return _completeTool('state-ok');
+    }
+    return _toolInputRequired(
+      InputRequiredResult(
+        inputRequests: {
+          'confirm': _elicitBool(message: 'Please confirm', property: 'ok'),
+        },
+        requestState: _requestState,
+      ),
+    );
+  }
+
+  CallToolResult _requestMultipleInputs(CallToolRequest request) {
+    if (_inputResponse(request, 'user_name') != null &&
+        _inputResponse(request, 'greeting') != null &&
+        _inputResponse(request, 'client_roots') != null &&
+        request.requestState == _multipleRequestState) {
+      return _completeTool('Multiple inputs received');
+    }
+    return _toolInputRequired(
+      InputRequiredResult(
+        inputRequests: {
+          'user_name': _elicitString(
+            message: 'What is your name?',
+            property: 'name',
+          ),
+          'greeting': _sample('Write a short greeting', maxTokens: 50),
+          'client_roots': InputRequest.listRoots(ListRootsRequest()),
+        },
+        requestState: _multipleRequestState,
+      ),
+    );
+  }
+
+  CallToolResult _requestMultiRoundInput(CallToolRequest request) {
+    if (_inputResponse(request, 'step2') != null &&
+        request.requestState == _roundTwoState) {
+      return _completeTool('Two rounds complete');
+    }
+    if (_inputResponse(request, 'step1') != null &&
+        request.requestState == _roundOneState) {
+      return _toolInputRequired(
+        InputRequiredResult(
+          inputRequests: {
+            'step2': _elicitString(
+              message: 'What is your favorite color?',
+              property: 'color',
+            ),
+          },
+          requestState: _roundTwoState,
+        ),
+      );
+    }
+    return _toolInputRequired(
+      InputRequiredResult(
+        inputRequests: {
+          'step1': _elicitString(
+            message: 'What is your name?',
+            property: 'name',
+          ),
+        },
+        requestState: _roundOneState,
+      ),
+    );
+  }
+
+  CallToolResult _requestTamperCheckedInput(CallToolRequest request) {
+    if (_inputResponse(request, 'confirm') != null) {
+      if (request.requestState != _tamperState) {
+        throw RpcException.invalidParams(
+          'Received requestState "${request.requestState}". '
+          'Expected "$_tamperState".',
+        );
+      }
+      return _completeTool('State accepted');
+    }
+    return _toolInputRequired(
+      InputRequiredResult(
+        inputRequests: {
+          'confirm': _elicitBool(message: 'Please confirm', property: 'ok'),
+        },
+        requestState: _tamperState,
+      ),
+    );
+  }
+
+  CallToolResult _requestCapabilityInputs(CallToolRequest _) {
+    final requests = <String, InputRequest>{};
+    if (clientCapabilities.sampling != null) {
+      requests['sampling'] = _sample('Say hello', maxTokens: 20);
+    }
+    if (clientCapabilities.elicitation != null) {
+      requests['elicitation'] = _elicitString(
+        message: 'What is your name?',
+        property: 'name',
+      );
+    }
+    if (clientCapabilities.roots != null) {
+      requests['roots'] = InputRequest.listRoots(ListRootsRequest());
+    }
+    if (requests.isEmpty) return _completeTool('No inputs requested');
+    return _toolInputRequired(InputRequiredResult(inputRequests: requests));
+  }
+
+  Result? _inputResponse(WithInputResponses request, String key) {
+    final responses = request.inputResponses;
+    if (responses == null || !responses.containsKey(key)) return null;
+    return responses[key];
+  }
+
+  CallToolResult _completeTool(String text) =>
+      CallToolResult(content: [TextContent(text: text)]);
+
+  CallToolResult _toolInputRequired(InputRequiredResult result) =>
+      CallToolResult.fromMap(result as Map<String, Object?>);
+
+  GetPromptResult _promptInputRequired(InputRequiredResult result) =>
+      GetPromptResult.fromMap(result as Map<String, Object?>);
+
+  InputRequest _elicitString({
+    required String message,
+    required String property,
+  }) => InputRequest.elicit(
+    ElicitRequest.form(
+      message: message,
+      requestedSchema: ObjectSchema(
+        properties: {property: Schema.string()},
+        required: [property],
+      ),
+    ),
+  );
+
+  InputRequest _elicitBool({
+    required String message,
+    required String property,
+  }) => InputRequest.elicit(
+    ElicitRequest.form(
+      message: message,
+      requestedSchema: ObjectSchema(
+        properties: {property: Schema.bool()},
+        required: [property],
+      ),
+    ),
+  );
+
+  InputRequest _sample(String text, {required int maxTokens}) =>
+      InputRequest.sample(
+        CreateMessageRequest(
+          messages: [
+            SamplingMessage(role: Role.user, content: TextContent(text: text)),
+          ],
+          maxTokens: maxTokens,
+        ),
+      );
+
+  void _registerPrompts() {
+    addPrompt(
+      Prompt(name: _simplePrompt, description: _simplePrompt),
+      (_) => GetPromptResult(
+        messages: [
+          PromptMessage(
+            role: Role.user,
+            content: TextContent(text: 'This is a simple prompt for testing.'),
+          ),
+        ],
+      ),
+    );
+    addPrompt(
+      Prompt(
+        name: _argumentsPrompt,
+        description: _argumentsPrompt,
+        arguments: [
+          PromptArgument(name: 'arg1', required: true),
+          PromptArgument(name: 'arg2', required: true),
+        ],
+      ),
+      (request) {
+        final arguments = request.arguments ?? const <String, Object?>{};
+        return GetPromptResult(
+          messages: [
+            PromptMessage(
+              role: Role.user,
+              content: TextContent(
+                text:
+                    "Prompt with arguments: arg1='${arguments['arg1']}', "
+                    "arg2='${arguments['arg2']}'",
+              ),
+            ),
+          ],
+        );
+      },
+    );
+    addPrompt(
+      Prompt(
+        name: _embeddedResourcePrompt,
+        description: _embeddedResourcePrompt,
+        arguments: [PromptArgument(name: 'resourceUri', required: true)],
+      ),
+      (request) {
+        final resourceUri = request.arguments!['resourceUri'] as String;
+        return GetPromptResult(
+          messages: [
+            PromptMessage(
+              role: Role.user,
+              content: EmbeddedResource(
+                resource: TextResourceContents(
+                  uri: resourceUri,
+                  mimeType: _textMimeType,
+                  text: 'Embedded resource content for testing.',
+                ),
+              ),
+            ),
+            PromptMessage(
+              role: Role.user,
+              content: TextContent(
+                text: 'Please process the embedded resource above.',
+              ),
+            ),
+          ],
+        );
+      },
+    );
+    addPrompt(
+      Prompt(name: _imagePrompt, description: _imagePrompt),
+      (_) => GetPromptResult(
+        messages: [
+          PromptMessage(
+            role: Role.user,
+            content: ImageContent(data: _imageData, mimeType: _imageMimeType),
+          ),
+          PromptMessage(
+            role: Role.user,
+            content: TextContent(text: 'Please analyze the image above.'),
+          ),
+        ],
+      ),
+    );
+    addPrompt(Prompt(name: _inputPrompt, description: _inputPrompt), (request) {
+      if (_inputResponse(request, 'user_context') != null) {
+        return GetPromptResult(
+          messages: [
+            PromptMessage(
+              role: Role.user,
+              content: TextContent(text: 'Context received'),
+            ),
+          ],
+        );
+      }
+      return _promptInputRequired(
+        InputRequiredResult(
+          inputRequests: {
+            'user_context': _elicitString(
+              message: 'Please provide context',
+              property: 'context',
+            ),
+          },
+        ),
+      );
+    });
+  }
+
+  @override
+  FutureOr<CompleteResult> handleComplete(CompleteRequest request) =>
+      CompleteResult(
+        completion: Completion(values: const [], total: 0, hasMore: false),
+      );
+}

--- a/pkgs/dart_mcp/bin/conformance_server.dart
+++ b/pkgs/dart_mcp/bin/conformance_server.dart
@@ -2,10 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: depend_on_referenced_packages
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math';
 
+import 'package:crypto/crypto.dart';
 import 'package:dart_mcp/server.dart';
 import 'package:dart_mcp/streamable_http.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';
@@ -29,6 +33,7 @@ const _mixedContentTool = 'test_multiple_content_types';
 const _errorTool = 'test_error_handling';
 const _progressTool = 'test_tool_with_progress';
 const _missingCapabilityTool = 'test_missing_capability';
+const _headerTool = 'test_x_mcp_header';
 const _jsonSchemaTool = 'json_schema_2020_12_tool';
 const _inputElicitationTool = 'test_input_required_result_elicitation';
 const _inputSamplingTool = 'test_input_required_result_sampling';
@@ -49,16 +54,21 @@ const _embeddedResourcePrompt = 'test_prompt_with_embedded_resource';
 const _imagePrompt = 'test_prompt_with_image';
 const _inputPrompt = 'test_input_required_result_prompt';
 
-const _requestState = 'request-state';
-const _multipleRequestState = 'multiple-request-state';
-const _roundOneState = 'round-one-state';
-const _roundTwoState = 'round-two-state';
-const _tamperState = 'tamper-state';
+final _stateRandom = Random.secure();
+final _stateKey = List<int>.unmodifiable(
+  List<int>.generate(32, (_) => _stateRandom.nextInt(256)),
+);
+final _stateHmac = Hmac(sha256, _stateKey);
 
 final _headerToolSchema = ObjectSchema.fromMap({
   'type': 'object',
   'properties': {
-    'name': {'type': 'string', 'x-mcp-header': 'Name'},
+    'region': {
+      'type': 'string',
+      'description': 'mirrored into Mcp-Param-Region',
+      'x-mcp-header': 'Region',
+    },
+    'level': {'type': 'integer', 'description': 'non-mirrored argument'},
   },
 });
 
@@ -191,11 +201,25 @@ base class _ConformanceServer extends MCPServer
       Tool(
         name: _simpleTextTool,
         description: _simpleTextTool,
-        inputSchema: _headerToolSchema,
+        inputSchema: ObjectSchema(),
       ),
       (_) => CallToolResult(
         content: [
           TextContent(text: 'This is a simple text response for testing.'),
+        ],
+      ),
+    );
+    registerTool(
+      Tool(
+        name: _headerTool,
+        description: _headerTool,
+        inputSchema: _headerToolSchema,
+      ),
+      (request) => CallToolResult(
+        content: [
+          TextContent(
+            text: 'region=${request.arguments?['region'] ?? '<none>'}',
+          ),
         ],
       ),
     );
@@ -455,8 +479,9 @@ base class _ConformanceServer extends MCPServer
   }
 
   CallToolResult _requestElicitationInput(CallToolRequest request) {
-    if (_inputResponse(request, 'user_name') != null) {
-      return _completeTool('Hello');
+    final name = _acceptedString(request, 'user_name', 'name');
+    if (name != null) {
+      return _completeTool('Hello, $name!');
     }
     return _toolInputRequired(
       InputRequiredResult(
@@ -471,8 +496,9 @@ base class _ConformanceServer extends MCPServer
   }
 
   CallToolResult _requestSamplingInput(CallToolRequest request) {
-    if (_inputResponse(request, 'capital_question') != null) {
-      return _completeTool('Sampling complete');
+    final text = _sampledText(request, 'capital_question');
+    if (text != null) {
+      return _completeTool('Sampling response: $text');
     }
     return _toolInputRequired(
       InputRequiredResult(
@@ -487,8 +513,10 @@ base class _ConformanceServer extends MCPServer
   }
 
   CallToolResult _requestRootsInput(CallToolRequest request) {
-    if (_inputResponse(request, 'client_roots') != null) {
-      return _completeTool('Roots received');
+    final roots = _rootsResponse(request, 'client_roots');
+    if (roots != null) {
+      final uris = roots.map((root) => root['uri']).join(', ');
+      return _completeTool('Client exposed ${roots.length} root(s): $uris');
     }
     return _toolInputRequired(
       InputRequiredResult(
@@ -500,26 +528,32 @@ base class _ConformanceServer extends MCPServer
   }
 
   CallToolResult _requestStateInput(CallToolRequest request) {
-    if (_inputResponse(request, 'confirm') != null &&
-        request.requestState == _requestState) {
-      return _completeTool('state-ok');
+    final confirmation = _acceptedBool(request, 'confirm', 'ok');
+    if (confirmation != null) {
+      _verifyState(request.requestState, expectedTool: _inputStateTool);
+      return _completeTool(
+        'state-ok: requestState verified and confirmation received',
+      );
     }
     return _toolInputRequired(
       InputRequiredResult(
         inputRequests: {
           'confirm': _elicitBool(message: 'Please confirm', property: 'ok'),
         },
-        requestState: _requestState,
+        requestState: _mintState({'tool': _inputStateTool}),
       ),
     );
   }
 
   CallToolResult _requestMultipleInputs(CallToolRequest request) {
-    if (_inputResponse(request, 'user_name') != null &&
-        _inputResponse(request, 'greeting') != null &&
-        _inputResponse(request, 'client_roots') != null &&
-        request.requestState == _multipleRequestState) {
-      return _completeTool('Multiple inputs received');
+    if (request.requestState != null) {
+      _verifyState(request.requestState, expectedTool: _inputMultipleTool);
+    }
+    final name = _acceptedString(request, 'user_name', 'name');
+    final greeting = _sampledText(request, 'greeting');
+    final roots = _rootsResponse(request, 'client_roots');
+    if (name != null && greeting != null && roots != null) {
+      return _completeTool('$greeting $name, ${roots.length} root(s) visible');
     }
     return _toolInputRequired(
       InputRequiredResult(
@@ -528,88 +562,279 @@ base class _ConformanceServer extends MCPServer
             message: 'What is your name?',
             property: 'name',
           ),
-          'greeting': _sample('Write a short greeting', maxTokens: 50),
+          'greeting': _sample('Generate a greeting', maxTokens: 50),
           'client_roots': InputRequest.listRoots(ListRootsRequest()),
         },
-        requestState: _multipleRequestState,
+        requestState: _mintState({'tool': _inputMultipleTool}),
       ),
     );
   }
 
   CallToolResult _requestMultiRoundInput(CallToolRequest request) {
-    if (_inputResponse(request, 'step2') != null &&
-        request.requestState == _roundTwoState) {
-      return _completeTool('Two rounds complete');
-    }
-    if (_inputResponse(request, 'step1') != null &&
-        request.requestState == _roundOneState) {
+    if (request.requestState == null) {
       return _toolInputRequired(
         InputRequiredResult(
           inputRequests: {
-            'step2': _elicitString(
-              message: 'What is your favorite color?',
-              property: 'color',
+            'step1': _elicitString(
+              message: 'Step 1: What is your name?',
+              property: 'name',
             ),
           },
-          requestState: _roundTwoState,
+          requestState: _mintState({'tool': _inputMultiRoundTool, 'round': 1}),
         ),
       );
     }
-    return _toolInputRequired(
-      InputRequiredResult(
-        inputRequests: {
-          'step1': _elicitString(
-            message: 'What is your name?',
-            property: 'name',
-          ),
-        },
-        requestState: _roundOneState,
-      ),
+    final state = _verifyState(
+      request.requestState,
+      expectedTool: _inputMultiRoundTool,
     );
+    switch (state['round']) {
+      case 1:
+        final name = _acceptedString(request, 'step1', 'name');
+        if (name == null) {
+          return _toolInputRequired(
+            InputRequiredResult(
+              inputRequests: {
+                'step1': _elicitString(
+                  message: 'Step 1: What is your name?',
+                  property: 'name',
+                ),
+              },
+              requestState: request.requestState,
+            ),
+          );
+        }
+        return _toolInputRequired(
+          InputRequiredResult(
+            inputRequests: {
+              'step2': _elicitString(
+                message: 'Step 2: What is your favorite color?',
+                property: 'color',
+              ),
+            },
+            requestState: _mintState({
+              'tool': _inputMultiRoundTool,
+              'round': 2,
+              'name': name,
+            }),
+          ),
+        );
+      case 2:
+        final color = _acceptedString(request, 'step2', 'color');
+        if (color == null) {
+          return _toolInputRequired(
+            InputRequiredResult(
+              inputRequests: {
+                'step2': _elicitString(
+                  message: 'Step 2: What is your favorite color?',
+                  property: 'color',
+                ),
+              },
+              requestState: request.requestState,
+            ),
+          );
+        }
+        return _completeTool(
+          'Multi-round complete: ${state['name']} likes $color',
+        );
+      default:
+        throw RpcException.invalidParams(
+          'Received requestState with round "${state['round']}". '
+          'Expected round 1 or 2.',
+        );
+    }
   }
 
   CallToolResult _requestTamperCheckedInput(CallToolRequest request) {
-    if (_inputResponse(request, 'confirm') != null) {
-      if (request.requestState != _tamperState) {
-        throw RpcException.invalidParams(
-          'Received requestState "${request.requestState}". '
-          'Expected "$_tamperState".',
-        );
+    if (request.requestState != null) {
+      _verifyState(request.requestState, expectedTool: _inputTamperedTool);
+      if (_acceptedBool(request, 'confirm', 'ok') != null) {
+        return _completeTool('integrity-ok: requestState verified');
       }
-      return _completeTool('State accepted');
     }
     return _toolInputRequired(
       InputRequiredResult(
         inputRequests: {
           'confirm': _elicitBool(message: 'Please confirm', property: 'ok'),
         },
-        requestState: _tamperState,
+        requestState: _mintState({'tool': _inputTamperedTool}),
       ),
     );
   }
 
-  CallToolResult _requestCapabilityInputs(CallToolRequest _) {
+  CallToolResult _requestCapabilityInputs(CallToolRequest request) {
+    if (request.inputResponses != null) {
+      return _completeTool('Capability-aware input requests fulfilled');
+    }
     final requests = <String, InputRequest>{};
     if (clientCapabilities.sampling != null) {
-      requests['sampling'] = _sample('Say hello', maxTokens: 20);
+      requests['greeting'] = _sample(
+        'Generate a short greeting',
+        maxTokens: 50,
+      );
     }
     if (clientCapabilities.elicitation != null) {
-      requests['elicitation'] = _elicitString(
+      requests['user_name'] = _elicitString(
         message: 'What is your name?',
         property: 'name',
       );
     }
     if (clientCapabilities.roots != null) {
-      requests['roots'] = InputRequest.listRoots(ListRootsRequest());
+      requests['client_roots'] = InputRequest.listRoots(ListRootsRequest());
     }
-    if (requests.isEmpty) return _completeTool('No inputs requested');
+    if (requests.isEmpty) {
+      return _completeTool(
+        'No declared client capability supports an in-band input request',
+      );
+    }
     return _toolInputRequired(InputRequiredResult(inputRequests: requests));
   }
 
-  Result? _inputResponse(WithInputResponses request, String key) {
-    final responses = request.inputResponses;
-    if (responses == null || !responses.containsKey(key)) return null;
-    return responses[key];
+  Map<String, Object?>? _inputResponse(WithInputResponses request, String key) {
+    final values = request as Map<String, Object?>;
+    final responses = values['inputResponses'];
+    if (responses is! Map || !responses.containsKey(key)) return null;
+    final response = responses[key];
+    return response is Map ? response.cast<String, Object?>() : null;
+  }
+
+  String? _acceptedString(
+    WithInputResponses request,
+    String key,
+    String property,
+  ) {
+    final content = _acceptedContent(request, key);
+    final value = content?[property];
+    return value is String ? value : null;
+  }
+
+  bool? _acceptedBool(WithInputResponses request, String key, String property) {
+    final content = _acceptedContent(request, key);
+    final value = content?[property];
+    return value is bool ? value : null;
+  }
+
+  Map<String, Object?>? _acceptedContent(
+    WithInputResponses request,
+    String key,
+  ) {
+    final response = _inputResponse(request, key);
+    if (response?['action'] != 'accept') return null;
+    final content = response?['content'];
+    return content is Map ? content.cast<String, Object?>() : null;
+  }
+
+  String? _sampledText(WithInputResponses request, String key) {
+    final response = _inputResponse(request, key);
+    final content = response?['content'];
+    if (content is! Map) return null;
+    final values = content.cast<String, Object?>();
+    final text = values['text'];
+    return values['type'] == 'text' && text is String ? text : null;
+  }
+
+  List<Map<String, Object?>>? _rootsResponse(
+    WithInputResponses request,
+    String key,
+  ) {
+    final response = _inputResponse(request, key);
+    final roots = response?['roots'];
+    if (roots is! List) return null;
+    final result = <Map<String, Object?>>[];
+    for (final root in roots) {
+      if (root is! Map) return null;
+      final values = root.cast<String, Object?>();
+      if (values['uri'] is! String) return null;
+      result.add(values);
+    }
+    return result;
+  }
+
+  String _mintState(Map<String, Object?> state) {
+    final envelope = {
+      'p': {
+        ...state,
+        'nonce': base64UrlEncode(
+          List<int>.generate(16, (_) => _stateRandom.nextInt(256)),
+        ),
+      },
+      'exp':
+          DateTime.now().millisecondsSinceEpoch ~/
+              Duration.millisecondsPerSecond +
+          600,
+    };
+    final body = base64UrlEncode(
+      utf8.encode(jsonEncode(envelope)),
+    ).replaceAll('=', '');
+    final signature = base64UrlEncode(
+      _stateHmac.convert(utf8.encode('v1.$body')).bytes,
+    ).replaceAll('=', '');
+    return 'v1.$body.$signature';
+  }
+
+  Map<String, Object?> _verifyState(
+    String? state, {
+    required String expectedTool,
+  }) {
+    try {
+      if (state == null) throw const FormatException('Missing state');
+      final signatureSeparator = state.lastIndexOf('.');
+      if (!state.startsWith('v1.') || signatureSeparator <= 3) {
+        throw const FormatException('Invalid state');
+      }
+      final body = state.substring(3, signatureSeparator);
+      final expectedSignature = base64UrlEncode(
+        _stateHmac.convert(utf8.encode('v1.$body')).bytes,
+      ).replaceAll('=', '');
+      if (!_constantTimeEquals(
+        state.substring(signatureSeparator + 1),
+        expectedSignature,
+      )) {
+        throw const FormatException('Invalid signature');
+      }
+      final decoded = jsonDecode(
+        utf8.decode(base64Url.decode(_withBase64Padding(body))),
+      );
+      if (decoded is! Map) throw const FormatException('Invalid envelope');
+      final envelope = decoded.cast<String, Object?>();
+      final expiresAt = envelope['exp'];
+      final now =
+          DateTime.now().millisecondsSinceEpoch ~/
+          Duration.millisecondsPerSecond;
+      if (expiresAt is! num || expiresAt < now) {
+        throw const FormatException('Expired state');
+      }
+      final statePayload = envelope['p'];
+      if (statePayload is! Map) {
+        throw const FormatException('Invalid payload');
+      }
+      final payload = statePayload.cast<String, Object?>();
+      if (payload['tool'] != expectedTool) {
+        throw const FormatException('Invalid tool');
+      }
+      return payload;
+    } on FormatException {
+      throw RpcException.invalidParams(
+        'Received a requestState that failed integrity validation. '
+        'Expected an unmodified state issued by this server.',
+      );
+    }
+  }
+
+  String _withBase64Padding(String value) {
+    final padding = (4 - value.length % 4) % 4;
+    return value.padRight(value.length + padding, '=');
+  }
+
+  bool _constantTimeEquals(String left, String right) {
+    var difference = left.length ^ right.length;
+    final length = max(left.length, right.length);
+    for (var index = 0; index < length; index++) {
+      final leftCode = index < left.length ? left.codeUnitAt(index) : 0;
+      final rightCode = index < right.length ? right.codeUnitAt(index) : 0;
+      difference |= leftCode ^ rightCode;
+    }
+    return difference == 0;
   }
 
   CallToolResult _completeTool(String text) =>
@@ -740,12 +965,13 @@ base class _ConformanceServer extends MCPServer
       ),
     );
     addPrompt(Prompt(name: _inputPrompt, description: _inputPrompt), (request) {
-      if (_inputResponse(request, 'user_context') != null) {
+      final context = _acceptedString(request, 'user_context', 'context');
+      if (context != null) {
         return GetPromptResult(
           messages: [
             PromptMessage(
               role: Role.user,
-              content: TextContent(text: 'Context received'),
+              content: TextContent(text: 'Use the following context: $context'),
             ),
           ],
         );
@@ -754,7 +980,7 @@ base class _ConformanceServer extends MCPServer
         InputRequiredResult(
           inputRequests: {
             'user_context': _elicitString(
-              message: 'Please provide context',
+              message: 'What context should the prompt use?',
               property: 'context',
             ),
           },

--- a/pkgs/dart_mcp/pubspec.yaml
+++ b/pkgs/dart_mcp/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   stream_transform: ^2.1.1
 
 dev_dependencies:
+  crypto: ^3.0.7
   dart_flutter_team_lints: ^3.2.1
   # TODO: Remove upper bound https://github.com/dart-lang/test/issues/2688
   test: '>=1.25.15 <1.31.0'

--- a/pkgs/dart_mcp/test/conformance_server_test.dart
+++ b/pkgs/dart_mcp/test/conformance_server_test.dart
@@ -1,0 +1,133 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+const _protocolVersion = '2026-07-28';
+const _simpleTextTool = 'test_simple_text';
+const _templateUri = 'test://template/{id}/data';
+const _expandedTemplateUri = 'test://template/123/data';
+
+void main() {
+  test(
+    'conformance server advertises and serves its tool and resource fixtures',
+    () async {
+      final process = await Process.start(Platform.resolvedExecutable, [
+        'bin/conformance_server.dart',
+      ], workingDirectory: Directory.current.path);
+      final errors = StringBuffer();
+      final errorSubscription = process.stderr
+          .transform(utf8.decoder)
+          .listen(errors.write);
+      addTearDown(() async {
+        process.kill();
+        await process.exitCode.timeout(const Duration(seconds: 10));
+        await errorSubscription.cancel();
+      });
+
+      final endpoint = Uri.parse(
+        await process.stdout
+            .transform(utf8.decoder)
+            .transform(const LineSplitter())
+            .first
+            .timeout(
+              const Duration(seconds: 30),
+              onTimeout:
+                  () => fail('Server did not report an endpoint: $errors'),
+            ),
+      );
+
+      final tools = await _post(endpoint, 'tools/list');
+      final toolsResult = tools['result'] as Map<String, Object?>;
+      final toolList = toolsResult['tools'] as List<Object?>;
+      expect(toolList, contains(containsPair('name', _simpleTextTool)));
+
+      final tool = await _post(
+        endpoint,
+        'tools/call',
+        params: {'name': _simpleTextTool, 'arguments': <String, Object?>{}},
+      );
+      final toolResult = tool['result'] as Map<String, Object?>;
+      expect(toolResult['isError'], isNot(true));
+      final toolContent = toolResult['content'] as List<Object?>;
+      expect(toolContent, hasLength(1));
+      expect(toolContent.single, {
+        'type': 'text',
+        'text': 'This is a simple text response for testing.',
+      });
+
+      final templates = await _post(endpoint, 'resources/templates/list');
+      final result = templates['result'] as Map<String, Object?>;
+      final resourceTemplates = result['resourceTemplates'] as List<Object?>;
+      expect(resourceTemplates, hasLength(1));
+      expect(
+        resourceTemplates.single,
+        containsPair('uriTemplate', _templateUri),
+      );
+
+      final resource = await _post(
+        endpoint,
+        'resources/read',
+        params: {'uri': _expandedTemplateUri},
+      );
+      final resourceResult = resource['result'] as Map<String, Object?>;
+      final contents = resourceResult['contents'] as List<Object?>;
+      final content = contents.single as Map<String, Object?>;
+      expect(content['uri'], _expandedTemplateUri);
+      expect(jsonDecode(content['text'] as String), {
+        'id': '123',
+        'templateTest': true,
+        'data': 'Data for ID: 123',
+      });
+    },
+  );
+}
+
+Future<Map<String, Object?>> _post(
+  Uri endpoint,
+  String method, {
+  Map<String, Object?> params = const {},
+}) async {
+  final client = HttpClient();
+  try {
+    final request = await client.postUrl(endpoint);
+    request.headers
+      ..set(HttpHeaders.contentTypeHeader, 'application/json')
+      ..set(HttpHeaders.acceptHeader, 'application/json, text/event-stream')
+      ..set('Mcp-Protocol-Version', _protocolVersion)
+      ..set('Mcp-Method', method);
+    final name = params['name'] ?? params['uri'];
+    if (name is String) {
+      request.headers.set('Mcp-Name', name);
+    }
+    request.write(
+      jsonEncode({
+        'jsonrpc': '2.0',
+        'id': 1,
+        'method': method,
+        'params': {
+          ...params,
+          '_meta': {
+            'io.modelcontextprotocol/protocolVersion': _protocolVersion,
+            'io.modelcontextprotocol/clientCapabilities':
+                const <String, Object?>{},
+          },
+        },
+      }),
+    );
+
+    final response = await request.close();
+    final responseText = await utf8.decodeStream(response);
+    expect(response.statusCode, HttpStatus.ok, reason: responseText);
+    return jsonDecode(responseText) as Map<String, Object?>;
+  } finally {
+    client.close(force: true);
+  }
+}

--- a/pkgs/dart_mcp/test/conformance_server_test.dart
+++ b/pkgs/dart_mcp/test/conformance_server_test.dart
@@ -12,82 +12,129 @@ import 'package:test/test.dart';
 
 const _protocolVersion = '2026-07-28';
 const _simpleTextTool = 'test_simple_text';
+const _inputElicitationTool = 'test_input_required_result_elicitation';
+const _inputStateTool = 'test_input_required_result_request_state';
 const _templateUri = 'test://template/{id}/data';
 const _expandedTemplateUri = 'test://template/123/data';
+const _simplePrompt = 'test_simple_prompt';
 
 void main() {
-  test(
-    'conformance server advertises and serves its tool and resource fixtures',
-    () async {
-      final process = await Process.start(Platform.resolvedExecutable, [
-        'bin/conformance_server.dart',
-      ], workingDirectory: Directory.current.path);
-      final errors = StringBuffer();
-      final errorSubscription = process.stderr
+  test('conformance server advertises and serves fixture contracts', () async {
+    final process = await Process.start(Platform.resolvedExecutable, [
+      'tool/conformance_server.dart',
+    ], workingDirectory: Directory.current.path);
+    final errors = StringBuffer();
+    final errorSubscription = process.stderr
+        .transform(utf8.decoder)
+        .listen(errors.write);
+    addTearDown(() async {
+      process.kill();
+      await process.exitCode.timeout(const Duration(seconds: 10));
+      await errorSubscription.cancel();
+    });
+
+    final endpoint = Uri.parse(
+      await process.stdout
           .transform(utf8.decoder)
-          .listen(errors.write);
-      addTearDown(() async {
-        process.kill();
-        await process.exitCode.timeout(const Duration(seconds: 10));
-        await errorSubscription.cancel();
-      });
+          .transform(const LineSplitter())
+          .first
+          .timeout(
+            const Duration(seconds: 30),
+            onTimeout: () => fail('Server did not report an endpoint: $errors'),
+          ),
+    );
 
-      final endpoint = Uri.parse(
-        await process.stdout
-            .transform(utf8.decoder)
-            .transform(const LineSplitter())
-            .first
-            .timeout(
-              const Duration(seconds: 30),
-              onTimeout:
-                  () => fail('Server did not report an endpoint: $errors'),
-            ),
-      );
+    final tools = await _post(endpoint, 'tools/list');
+    final toolsResult = tools['result'] as Map<String, Object?>;
+    final toolList = toolsResult['tools'] as List<Object?>;
+    expect(toolList, contains(containsPair('name', _simpleTextTool)));
+    expect(toolList, contains(containsPair('name', _inputElicitationTool)));
+    expect(toolList, contains(containsPair('name', _inputStateTool)));
 
-      final tools = await _post(endpoint, 'tools/list');
-      final toolsResult = tools['result'] as Map<String, Object?>;
-      final toolList = toolsResult['tools'] as List<Object?>;
-      expect(toolList, contains(containsPair('name', _simpleTextTool)));
+    final tool = await _post(
+      endpoint,
+      'tools/call',
+      params: {'name': _simpleTextTool, 'arguments': <String, Object?>{}},
+    );
+    final toolResult = tool['result'] as Map<String, Object?>;
+    expect(toolResult['isError'], isNot(true));
+    final toolContent = toolResult['content'] as List<Object?>;
+    expect(toolContent, hasLength(1));
+    expect(toolContent.single, {
+      'type': 'text',
+      'text': 'This is a simple text response for testing.',
+    });
 
-      final tool = await _post(
-        endpoint,
-        'tools/call',
-        params: {'name': _simpleTextTool, 'arguments': <String, Object?>{}},
-      );
-      final toolResult = tool['result'] as Map<String, Object?>;
-      expect(toolResult['isError'], isNot(true));
-      final toolContent = toolResult['content'] as List<Object?>;
-      expect(toolContent, hasLength(1));
-      expect(toolContent.single, {
+    final templates = await _post(endpoint, 'resources/templates/list');
+    final result = templates['result'] as Map<String, Object?>;
+    final resourceTemplates = result['resourceTemplates'] as List<Object?>;
+    expect(resourceTemplates, hasLength(1));
+    expect(resourceTemplates.single, containsPair('uriTemplate', _templateUri));
+
+    final resource = await _post(
+      endpoint,
+      'resources/read',
+      params: {'uri': _expandedTemplateUri},
+    );
+    final resourceResult = resource['result'] as Map<String, Object?>;
+    final contents = resourceResult['contents'] as List<Object?>;
+    final content = contents.single as Map<String, Object?>;
+    expect(content['uri'], _expandedTemplateUri);
+    expect(jsonDecode(content['text'] as String), {
+      'id': '123',
+      'templateTest': true,
+      'data': 'Data for ID: 123',
+    });
+
+    final prompts = await _post(endpoint, 'prompts/list');
+    final promptsResult = prompts['result'] as Map<String, Object?>;
+    final promptList = promptsResult['prompts'] as List<Object?>;
+    expect(promptList, contains(containsPair('name', _simplePrompt)));
+
+    final prompt = await _post(
+      endpoint,
+      'prompts/get',
+      params: {'name': _simplePrompt},
+    );
+    final promptResult = prompt['result'] as Map<String, Object?>;
+    final messages = promptResult['messages'] as List<Object?>;
+    expect(messages, hasLength(1));
+    expect(messages.single, {
+      'role': 'user',
+      'content': {
         'type': 'text',
-        'text': 'This is a simple text response for testing.',
-      });
+        'text': 'This is a simple prompt for testing.',
+      },
+    });
 
-      final templates = await _post(endpoint, 'resources/templates/list');
-      final result = templates['result'] as Map<String, Object?>;
-      final resourceTemplates = result['resourceTemplates'] as List<Object?>;
-      expect(resourceTemplates, hasLength(1));
-      expect(
-        resourceTemplates.single,
-        containsPair('uriTemplate', _templateUri),
-      );
+    final elicitation = await _post(
+      endpoint,
+      'tools/call',
+      params: {'name': _inputElicitationTool, 'arguments': <String, Object?>{}},
+    );
+    final elicitationResult = elicitation['result'] as Map<String, Object?>;
+    final inputRequests =
+        elicitationResult['inputRequests'] as Map<String, Object?>;
+    expect(
+      inputRequests['user_name'],
+      containsPair('method', 'elicitation/create'),
+    );
 
-      final resource = await _post(
-        endpoint,
-        'resources/read',
-        params: {'uri': _expandedTemplateUri},
-      );
-      final resourceResult = resource['result'] as Map<String, Object?>;
-      final contents = resourceResult['contents'] as List<Object?>;
-      final content = contents.single as Map<String, Object?>;
-      expect(content['uri'], _expandedTemplateUri);
-      expect(jsonDecode(content['text'] as String), {
-        'id': '123',
-        'templateTest': true,
-        'data': 'Data for ID: 123',
-      });
-    },
-  );
+    final state = await _post(
+      endpoint,
+      'tools/call',
+      params: {'name': _inputStateTool, 'arguments': <String, Object?>{}},
+    );
+    final stateResult = state['result'] as Map<String, Object?>;
+    expect(
+      stateResult['requestState'],
+      isA<String>().having(
+        (value) => value.startsWith('v1.'),
+        'prefix',
+        isTrue,
+      ),
+    );
+  });
 }
 
 Future<Map<String, Object?>> _post(

--- a/pkgs/dart_mcp/test/conformance_server_test.dart
+++ b/pkgs/dart_mcp/test/conformance_server_test.dart
@@ -36,16 +36,22 @@ void main() {
       await errorSubscription.cancel();
     });
 
-    final endpoint = Uri.parse(
-      await process.stdout
-          .transform(utf8.decoder)
-          .transform(const LineSplitter())
-          .first
-          .timeout(
-            const Duration(seconds: 30),
-            onTimeout: () => fail('Server did not report an endpoint: $errors'),
-          ),
-    );
+    // Take a list instead of the first element, since a server that exits
+    // before printing closes the stream empty, and reading the first element
+    // of an empty stream throws past the timeout below with stderr lost.
+    final reported = await process.stdout
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .take(1)
+        .toList()
+        .timeout(
+          const Duration(seconds: 30),
+          onTimeout: () => fail('Server did not report an endpoint: $errors'),
+        );
+    if (reported.isEmpty) {
+      fail('Server exited before reporting an endpoint: $errors');
+    }
+    final endpoint = Uri.parse(reported.single);
 
     final tools = await _post(endpoint, 'tools/list');
     final toolsResult = tools['result'] as Map<String, Object?>;

--- a/pkgs/dart_mcp/test/conformance_server_test.dart
+++ b/pkgs/dart_mcp/test/conformance_server_test.dart
@@ -15,6 +15,7 @@ const _protocolVersion = '2026-07-28';
 const _simpleTextTool = 'test_simple_text';
 const _inputElicitationTool = 'test_input_required_result_elicitation';
 const _inputStateTool = 'test_input_required_result_request_state';
+const _inputTamperedTool = 'test_input_required_result_tampered_state';
 const _templateUri = 'test://template/{id}/data';
 const _expandedTemplateUri = 'test://template/123/data';
 const _simplePrompt = 'test_simple_prompt';
@@ -187,6 +188,47 @@ void main() {
         ),
       );
     });
+
+    test('refuses a request state whose signature was changed', () async {
+      final issued = await _post(
+        endpoint,
+        'tools/call',
+        params: {'name': _inputTamperedTool, 'arguments': <String, Object?>{}},
+        capabilities: _formElicitationCapabilities,
+      );
+      final requestState =
+          (issued['result'] as Map<String, Object?>)['requestState'] as String;
+      final separator = requestState.lastIndexOf('.');
+      final signature = requestState.substring(separator + 1);
+      final tampered =
+          requestState.substring(0, separator + 1) +
+          (signature[0] == 'A' ? 'B' : 'A') +
+          signature.substring(1);
+
+      final refused = await _post(
+        endpoint,
+        'tools/call',
+        params: {
+          'name': _inputTamperedTool,
+          'arguments': <String, Object?>{},
+          'inputResponses': {
+            'confirm': {
+              'action': 'accept',
+              'content': {'ok': true},
+            },
+          },
+          'requestState': tampered,
+        },
+        capabilities: _formElicitationCapabilities,
+        expectedStatus: HttpStatus.badRequest,
+      );
+
+      expect(refused['result'], isNull);
+      expect(
+        (refused['error'] as Map<String, Object?>)['message'],
+        contains('failed integrity validation'),
+      );
+    });
     // `Platform.resolvedExecutable` is this test's own binary once it is
     // compiled, so it cannot start the server the way it does on the VM.
   }, testOn: '!exe');
@@ -197,6 +239,7 @@ Future<Map<String, Object?>> _post(
   String method, {
   Map<String, Object?> params = const {},
   Map<String, Object?> capabilities = const {},
+  int expectedStatus = HttpStatus.ok,
 }) async {
   final client = HttpClient();
   try {
@@ -227,7 +270,7 @@ Future<Map<String, Object?>> _post(
 
     final response = await request.close();
     final responseText = await utf8.decodeStream(response);
-    expect(response.statusCode, HttpStatus.ok, reason: responseText);
+    expect(response.statusCode, expectedStatus, reason: responseText);
     return jsonDecode(responseText) as Map<String, Object?>;
   } finally {
     client.close(force: true);

--- a/pkgs/dart_mcp/test/conformance_server_test.dart
+++ b/pkgs/dart_mcp/test/conformance_server_test.dart
@@ -165,7 +165,9 @@ void main() {
         'state-ok: requestState verified and confirmation received',
       ),
     );
-  });
+    // `Platform.resolvedExecutable` is this test's own binary once it is
+    // compiled, so it cannot start the server the way it does on the VM.
+  }, testOn: '!exe');
 }
 
 Future<Map<String, Object?>> _post(

--- a/pkgs/dart_mcp/test/conformance_server_test.dart
+++ b/pkgs/dart_mcp/test/conformance_server_test.dart
@@ -126,12 +126,31 @@ void main() {
       params: {'name': _inputStateTool, 'arguments': <String, Object?>{}},
     );
     final stateResult = state['result'] as Map<String, Object?>;
+    final requestState = stateResult['requestState'] as String;
+    final completedState = await _post(
+      endpoint,
+      'tools/call',
+      params: {
+        'name': _inputStateTool,
+        'arguments': <String, Object?>{},
+        'inputResponses': {
+          'confirm': {
+            'action': 'accept',
+            'content': {'ok': true},
+          },
+        },
+        'requestState': requestState,
+      },
+    );
+    final completedStateResult =
+        completedState['result'] as Map<String, Object?>;
+    final completedStateContent =
+        completedStateResult['content'] as List<Object?>;
     expect(
-      stateResult['requestState'],
-      isA<String>().having(
-        (value) => value.startsWith('v1.'),
-        'prefix',
-        isTrue,
+      completedStateContent.single,
+      containsPair(
+        'text',
+        'state-ok: requestState verified and confirmation received',
       ),
     );
   });

--- a/pkgs/dart_mcp/test/conformance_server_test.dart
+++ b/pkgs/dart_mcp/test/conformance_server_test.dart
@@ -17,6 +17,9 @@ const _inputStateTool = 'test_input_required_result_request_state';
 const _templateUri = 'test://template/{id}/data';
 const _expandedTemplateUri = 'test://template/123/data';
 const _simplePrompt = 'test_simple_prompt';
+const _formElicitationCapabilities = <String, Object?>{
+  'elicitation': <String, Object?>{'form': <String, Object?>{}},
+};
 
 void main() {
   test('conformance server advertises and serves fixture contracts', () async {
@@ -111,6 +114,7 @@ void main() {
       endpoint,
       'tools/call',
       params: {'name': _inputElicitationTool, 'arguments': <String, Object?>{}},
+      capabilities: _formElicitationCapabilities,
     );
     final elicitationResult = elicitation['result'] as Map<String, Object?>;
     final inputRequests =
@@ -124,6 +128,7 @@ void main() {
       endpoint,
       'tools/call',
       params: {'name': _inputStateTool, 'arguments': <String, Object?>{}},
+      capabilities: _formElicitationCapabilities,
     );
     final stateResult = state['result'] as Map<String, Object?>;
     final requestState = stateResult['requestState'] as String;
@@ -141,6 +146,7 @@ void main() {
         },
         'requestState': requestState,
       },
+      capabilities: _formElicitationCapabilities,
     );
     final completedStateResult =
         completedState['result'] as Map<String, Object?>;
@@ -160,6 +166,7 @@ Future<Map<String, Object?>> _post(
   Uri endpoint,
   String method, {
   Map<String, Object?> params = const {},
+  Map<String, Object?> capabilities = const {},
 }) async {
   final client = HttpClient();
   try {
@@ -182,8 +189,7 @@ Future<Map<String, Object?>> _post(
           ...params,
           '_meta': {
             'io.modelcontextprotocol/protocolVersion': _protocolVersion,
-            'io.modelcontextprotocol/clientCapabilities':
-                const <String, Object?>{},
+            'io.modelcontextprotocol/clientCapabilities': capabilities,
           },
         },
       }),

--- a/pkgs/dart_mcp/test/conformance_server_test.dart
+++ b/pkgs/dart_mcp/test/conformance_server_test.dart
@@ -5,6 +5,7 @@
 @TestOn('vm')
 library;
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -22,149 +23,170 @@ const _formElicitationCapabilities = <String, Object?>{
 };
 
 void main() {
-  test('conformance server advertises and serves fixture contracts', () async {
-    final process = await Process.start(Platform.resolvedExecutable, [
-      'tool/conformance_server.dart',
-    ], workingDirectory: Directory.current.path);
-    final errors = StringBuffer();
-    final errorSubscription = process.stderr
-        .transform(utf8.decoder)
-        .listen(errors.write);
-    addTearDown(() async {
+  group('conformance server', () {
+    late Process process;
+    late StreamSubscription<String> errorSubscription;
+    late Uri endpoint;
+
+    setUpAll(() async {
+      process = await Process.start(Platform.resolvedExecutable, [
+        'tool/conformance_server.dart',
+      ], workingDirectory: Directory.current.path);
+      final errors = StringBuffer();
+      errorSubscription = process.stderr
+          .transform(utf8.decoder)
+          .listen(errors.write);
+
+      // Take a list instead of the first element, since a server that exits
+      // before printing closes the stream empty, and reading the first element
+      // of an empty stream throws past the timeout below with stderr lost.
+      final reported = await process.stdout
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          .take(1)
+          .toList()
+          .timeout(
+            const Duration(seconds: 30),
+            onTimeout: () => fail('Server did not report an endpoint: $errors'),
+          );
+      if (reported.isEmpty) {
+        fail('Server exited before reporting an endpoint: $errors');
+      }
+      endpoint = Uri.parse(reported.single);
+    });
+
+    tearDownAll(() async {
       process.kill();
       await process.exitCode.timeout(const Duration(seconds: 10));
       await errorSubscription.cancel();
     });
 
-    // Take a list instead of the first element, since a server that exits
-    // before printing closes the stream empty, and reading the first element
-    // of an empty stream throws past the timeout below with stderr lost.
-    final reported = await process.stdout
-        .transform(utf8.decoder)
-        .transform(const LineSplitter())
-        .take(1)
-        .toList()
-        .timeout(
-          const Duration(seconds: 30),
-          onTimeout: () => fail('Server did not report an endpoint: $errors'),
-        );
-    if (reported.isEmpty) {
-      fail('Server exited before reporting an endpoint: $errors');
-    }
-    final endpoint = Uri.parse(reported.single);
+    test('lists and calls its tool fixtures', () async {
+      final tools = await _post(endpoint, 'tools/list');
+      final toolsResult = tools['result'] as Map<String, Object?>;
+      final toolList = toolsResult['tools'] as List<Object?>;
+      expect(toolList, contains(containsPair('name', _simpleTextTool)));
+      expect(toolList, contains(containsPair('name', _inputElicitationTool)));
+      expect(toolList, contains(containsPair('name', _inputStateTool)));
 
-    final tools = await _post(endpoint, 'tools/list');
-    final toolsResult = tools['result'] as Map<String, Object?>;
-    final toolList = toolsResult['tools'] as List<Object?>;
-    expect(toolList, contains(containsPair('name', _simpleTextTool)));
-    expect(toolList, contains(containsPair('name', _inputElicitationTool)));
-    expect(toolList, contains(containsPair('name', _inputStateTool)));
-
-    final tool = await _post(
-      endpoint,
-      'tools/call',
-      params: {'name': _simpleTextTool, 'arguments': <String, Object?>{}},
-    );
-    final toolResult = tool['result'] as Map<String, Object?>;
-    expect(toolResult['isError'], isNot(true));
-    final toolContent = toolResult['content'] as List<Object?>;
-    expect(toolContent, hasLength(1));
-    expect(toolContent.single, {
-      'type': 'text',
-      'text': 'This is a simple text response for testing.',
-    });
-
-    final templates = await _post(endpoint, 'resources/templates/list');
-    final result = templates['result'] as Map<String, Object?>;
-    final resourceTemplates = result['resourceTemplates'] as List<Object?>;
-    expect(resourceTemplates, hasLength(1));
-    expect(resourceTemplates.single, containsPair('uriTemplate', _templateUri));
-
-    final resource = await _post(
-      endpoint,
-      'resources/read',
-      params: {'uri': _expandedTemplateUri},
-    );
-    final resourceResult = resource['result'] as Map<String, Object?>;
-    final contents = resourceResult['contents'] as List<Object?>;
-    final content = contents.single as Map<String, Object?>;
-    expect(content['uri'], _expandedTemplateUri);
-    expect(jsonDecode(content['text'] as String), {
-      'id': '123',
-      'templateTest': true,
-      'data': 'Data for ID: 123',
-    });
-
-    final prompts = await _post(endpoint, 'prompts/list');
-    final promptsResult = prompts['result'] as Map<String, Object?>;
-    final promptList = promptsResult['prompts'] as List<Object?>;
-    expect(promptList, contains(containsPair('name', _simplePrompt)));
-
-    final prompt = await _post(
-      endpoint,
-      'prompts/get',
-      params: {'name': _simplePrompt},
-    );
-    final promptResult = prompt['result'] as Map<String, Object?>;
-    final messages = promptResult['messages'] as List<Object?>;
-    expect(messages, hasLength(1));
-    expect(messages.single, {
-      'role': 'user',
-      'content': {
+      final tool = await _post(
+        endpoint,
+        'tools/call',
+        params: {'name': _simpleTextTool, 'arguments': <String, Object?>{}},
+      );
+      final toolResult = tool['result'] as Map<String, Object?>;
+      expect(toolResult['isError'], isNot(true));
+      final toolContent = toolResult['content'] as List<Object?>;
+      expect(toolContent, hasLength(1));
+      expect(toolContent.single, {
         'type': 'text',
-        'text': 'This is a simple prompt for testing.',
-      },
+        'text': 'This is a simple text response for testing.',
+      });
     });
 
-    final elicitation = await _post(
-      endpoint,
-      'tools/call',
-      params: {'name': _inputElicitationTool, 'arguments': <String, Object?>{}},
-      capabilities: _formElicitationCapabilities,
-    );
-    final elicitationResult = elicitation['result'] as Map<String, Object?>;
-    final inputRequests =
-        elicitationResult['inputRequests'] as Map<String, Object?>;
-    expect(
-      inputRequests['user_name'],
-      containsPair('method', 'elicitation/create'),
-    );
+    test('lists and reads its resource template fixture', () async {
+      final templates = await _post(endpoint, 'resources/templates/list');
+      final result = templates['result'] as Map<String, Object?>;
+      final resourceTemplates = result['resourceTemplates'] as List<Object?>;
+      expect(resourceTemplates, hasLength(1));
+      expect(
+        resourceTemplates.single,
+        containsPair('uriTemplate', _templateUri),
+      );
 
-    final state = await _post(
-      endpoint,
-      'tools/call',
-      params: {'name': _inputStateTool, 'arguments': <String, Object?>{}},
-      capabilities: _formElicitationCapabilities,
-    );
-    final stateResult = state['result'] as Map<String, Object?>;
-    final requestState = stateResult['requestState'] as String;
-    final completedState = await _post(
-      endpoint,
-      'tools/call',
-      params: {
-        'name': _inputStateTool,
-        'arguments': <String, Object?>{},
-        'inputResponses': {
-          'confirm': {
-            'action': 'accept',
-            'content': {'ok': true},
-          },
+      final resource = await _post(
+        endpoint,
+        'resources/read',
+        params: {'uri': _expandedTemplateUri},
+      );
+      final resourceResult = resource['result'] as Map<String, Object?>;
+      final contents = resourceResult['contents'] as List<Object?>;
+      final content = contents.single as Map<String, Object?>;
+      expect(content['uri'], _expandedTemplateUri);
+      expect(jsonDecode(content['text'] as String), {
+        'id': '123',
+        'templateTest': true,
+        'data': 'Data for ID: 123',
+      });
+    });
+
+    test('lists and renders its prompt fixture', () async {
+      final prompts = await _post(endpoint, 'prompts/list');
+      final promptsResult = prompts['result'] as Map<String, Object?>;
+      final promptList = promptsResult['prompts'] as List<Object?>;
+      expect(promptList, contains(containsPair('name', _simplePrompt)));
+
+      final prompt = await _post(
+        endpoint,
+        'prompts/get',
+        params: {'name': _simplePrompt},
+      );
+      final promptResult = prompt['result'] as Map<String, Object?>;
+      final messages = promptResult['messages'] as List<Object?>;
+      expect(messages, hasLength(1));
+      expect(messages.single, {
+        'role': 'user',
+        'content': {
+          'type': 'text',
+          'text': 'This is a simple prompt for testing.',
         },
-        'requestState': requestState,
-      },
-      capabilities: _formElicitationCapabilities,
-    );
-    final completedStateResult =
-        completedState['result'] as Map<String, Object?>;
-    final completedStateContent =
-        completedStateResult['content'] as List<Object?>;
-    expect(
-      completedStateContent.single,
-      containsPair(
-        'text',
-        'state-ok: requestState verified and confirmation received',
-      ),
-    );
+      });
+    });
+
+    test('answers with input requests and honours the retry', () async {
+      final elicitation = await _post(
+        endpoint,
+        'tools/call',
+        params: {
+          'name': _inputElicitationTool,
+          'arguments': <String, Object?>{},
+        },
+        capabilities: _formElicitationCapabilities,
+      );
+      final elicitationResult = elicitation['result'] as Map<String, Object?>;
+      final inputRequests =
+          elicitationResult['inputRequests'] as Map<String, Object?>;
+      expect(
+        inputRequests['user_name'],
+        containsPair('method', 'elicitation/create'),
+      );
+
+      final state = await _post(
+        endpoint,
+        'tools/call',
+        params: {'name': _inputStateTool, 'arguments': <String, Object?>{}},
+        capabilities: _formElicitationCapabilities,
+      );
+      final stateResult = state['result'] as Map<String, Object?>;
+      final requestState = stateResult['requestState'] as String;
+      final completedState = await _post(
+        endpoint,
+        'tools/call',
+        params: {
+          'name': _inputStateTool,
+          'arguments': <String, Object?>{},
+          'inputResponses': {
+            'confirm': {
+              'action': 'accept',
+              'content': {'ok': true},
+            },
+          },
+          'requestState': requestState,
+        },
+        capabilities: _formElicitationCapabilities,
+      );
+      final completedStateResult =
+          completedState['result'] as Map<String, Object?>;
+      final completedStateContent =
+          completedStateResult['content'] as List<Object?>;
+      expect(
+        completedStateContent.single,
+        containsPair(
+          'text',
+          'state-ok: requestState verified and confirmation received',
+        ),
+      );
+    });
     // `Platform.resolvedExecutable` is this test's own binary once it is
     // compiled, so it cannot start the server the way it does on the VM.
   }, testOn: '!exe');

--- a/pkgs/dart_mcp/tool/conformance_server.dart
+++ b/pkgs/dart_mcp/tool/conformance_server.dart
@@ -17,6 +17,8 @@ const _imageMimeType = 'image/png';
 const _audioMimeType = 'audio/wav';
 const _textMimeType = 'text/plain';
 const _jsonMimeType = 'application/json';
+// 1x1 PNG and a silent WAV. tools-call-image and tools-call-audio only
+// require a valid payload of the declared mime type.
 const _imageData =
     'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ'
     'AAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==';
@@ -52,12 +54,15 @@ const _embeddedResourcePrompt = 'test_prompt_with_embedded_resource';
 const _imagePrompt = 'test_prompt_with_image';
 const _inputPrompt = 'test_input_required_result_prompt';
 
+// HMAC-SHA256 over an opaque requestState so
+// input-required-result-tampered-state can detect a modified payload.
 final _stateRandom = Random.secure();
 final _stateKey = List<int>.unmodifiable(
   List<int>.generate(32, (_) => _stateRandom.nextInt(256)),
 );
 final _stateHmac = Hmac(sha256, _stateKey);
 
+// http-header-validation. Only `region` is annotated with `x-mcp-header`.
 final _headerToolSchema = ObjectSchema.fromMap({
   'type': 'object',
   'properties': {
@@ -70,6 +75,9 @@ final _headerToolSchema = ObjectSchema.fromMap({
   },
 });
 
+// json-schema-2020-12 round-trips `$schema`, `$defs`, `$ref`, `$anchor`,
+// `allOf`/`anyOf`, and `if`/`then`/`else`. The package validator does not
+// implement that draft, so the tool registers with validateArguments: false.
 final _jsonSchema = ObjectSchema.fromMap({
   r'$schema': 'https://json-schema.org/draft/2020-12/schema',
   'type': 'object',
@@ -154,13 +162,13 @@ Future<void> _handleRequest(HttpRequest request) async {
 
   try {
     await handleStreamableHttpRequest(request, _ConformanceServer.new);
-  } catch (error, stackTrace) {
-    stderr
-      ..writeln(error)
-      ..writeln(stackTrace);
+  } catch (error) {
+    stderr.writeln(error);
   }
 }
 
+// dns-rebinding-protection. Host must be loopback. Origin, if sent, must be
+// too.
 bool _hasLocalTarget(HttpRequest request) {
   final hosts = request.headers[HttpHeaders.hostHeader];
   if (hosts == null ||
@@ -194,6 +202,7 @@ base class _ConformanceServer extends MCPServer
     _registerPrompts();
   }
 
+  // Tools named by the tools-call-* and input-required-result-* scenarios.
   void _registerTools() {
     registerTool(
       Tool(
@@ -398,6 +407,8 @@ base class _ConformanceServer extends MCPServer
     return CallToolResult(content: [TextContent(text: '$progressToken')]);
   }
 
+  // Resources named by resources-read-text, resources-read-binary, and
+  // resources-templates-read.
   void _registerResources() {
     addResource(
       Resource(
@@ -890,6 +901,7 @@ base class _ConformanceServer extends MCPServer
         ),
       );
 
+  // Prompts named by prompts-get-* and input-required-result-non-tool-request.
   void _registerPrompts() {
     addPrompt(
       Prompt(name: _simplePrompt, description: _simplePrompt),
@@ -997,6 +1009,8 @@ base class _ConformanceServer extends MCPServer
     });
   }
 
+  // completion-complete only needs the method to answer. Empty values are
+  // enough.
   @override
   FutureOr<CompleteResult> handleComplete(CompleteRequest request) =>
       CompleteResult(

--- a/pkgs/dart_mcp/tool/conformance_server.dart
+++ b/pkgs/dart_mcp/tool/conformance_server.dart
@@ -151,23 +151,23 @@ Future<void> main(List<String> arguments) async {
 }
 
 Future<void> _handleRequest(HttpRequest request) async {
-  if (request.uri.path != _path) {
-    request.response
-      ..statusCode = HttpStatus.notFound
-      ..contentLength = 0;
-    await request.response.close();
-    return;
-  }
-
-  if (!_hasLocalTarget(request)) {
-    request.response
-      ..statusCode = HttpStatus.forbidden
-      ..contentLength = 0;
-    await request.response.close();
-    return;
-  }
-
   try {
+    if (request.uri.path != _path) {
+      request.response
+        ..statusCode = HttpStatus.notFound
+        ..contentLength = 0;
+      await request.response.close();
+      return;
+    }
+
+    if (!_hasLocalTarget(request)) {
+      request.response
+        ..statusCode = HttpStatus.forbidden
+        ..contentLength = 0;
+      await request.response.close();
+      return;
+    }
+
     await handleStreamableHttpRequest(request, _ConformanceServer.new);
   } catch (error) {
     stderr.writeln(error);

--- a/pkgs/dart_mcp/tool/conformance_server.dart
+++ b/pkgs/dart_mcp/tool/conformance_server.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: depend_on_referenced_packages
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/pkgs/dart_mcp/tool/conformance_server.dart
+++ b/pkgs/dart_mcp/tool/conformance_server.dart
@@ -12,6 +12,28 @@ import 'package:dart_mcp/server.dart';
 import 'package:dart_mcp/streamable_http.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';
 
+/// Runs the server fixture used by the MCP conformance suite.
+///
+/// This prints an endpoint to stdout. Run the suite against that endpoint with
+///
+/// ```sh
+/// npx @modelcontextprotocol/conformance@0.2.0-alpha.11 \
+///   server --url ENDPOINT --requirements 2026-07-28
+/// ```
+Future<void> main(List<String> arguments) async {
+  final port = arguments.isEmpty ? 0 : int.parse(arguments.single);
+  final httpServer = await HttpServer.bind(InternetAddress.loopbackIPv4, port);
+  final endpoint = Uri(
+    scheme: 'http',
+    host: httpServer.address.host,
+    port: httpServer.port,
+    path: _path,
+  );
+
+  stdout.writeln(endpoint);
+  httpServer.listen((request) => unawaited(_handleRequest(request)));
+}
+
 const _path = '/mcp';
 const _imageMimeType = 'image/png';
 const _audioMimeType = 'audio/wav';
@@ -127,28 +149,6 @@ final _jsonSchema = ObjectSchema.fromMap({
   },
   'additionalProperties': false,
 });
-
-/// Runs the server fixture used by the MCP conformance suite.
-///
-/// This prints an endpoint to stdout. Run the suite against that endpoint with
-///
-/// ```sh
-/// npx @modelcontextprotocol/conformance@0.2.0-alpha.11 \
-///   server --url ENDPOINT --requirements 2026-07-28
-/// ```
-Future<void> main(List<String> arguments) async {
-  final port = arguments.isEmpty ? 0 : int.parse(arguments.single);
-  final httpServer = await HttpServer.bind(InternetAddress.loopbackIPv4, port);
-  final endpoint = Uri(
-    scheme: 'http',
-    host: httpServer.address.host,
-    port: httpServer.port,
-    path: _path,
-  );
-
-  stdout.writeln(endpoint);
-  httpServer.listen((request) => unawaited(_handleRequest(request)));
-}
 
 Future<void> _handleRequest(HttpRequest request) async {
   try {

--- a/pkgs/dart_mcp/tool/conformance_server.dart
+++ b/pkgs/dart_mcp/tool/conformance_server.dart
@@ -129,6 +129,13 @@ final _jsonSchema = ObjectSchema.fromMap({
 });
 
 /// Runs the server fixture used by the MCP conformance suite.
+///
+/// This prints an endpoint to stdout. Run the suite against that endpoint with
+///
+/// ```sh
+/// npx @modelcontextprotocol/conformance@0.2.0-alpha.11 \
+///   server --url ENDPOINT --requirements 2026-07-28
+/// ```
 Future<void> main(List<String> arguments) async {
   final port = arguments.isEmpty ? 0 : int.parse(arguments.single);
   final httpServer = await HttpServer.bind(InternetAddress.loopbackIPv4, port);

--- a/pkgs/dart_mcp/tool/conformance_server.dart
+++ b/pkgs/dart_mcp/tool/conformance_server.dart
@@ -444,11 +444,21 @@ base class _ConformanceServer extends MCPServer
     );
   }
 
-  Future<CallToolResult> _requireSampling(CallToolRequest _) async {
-    if (!supportsSampling) {
-      await createMessage(CreateMessageRequest(messages: [], maxTokens: 1));
+  CallToolResult _requireSampling(CallToolRequest request) {
+    final text = _sampledText(request, 'capability_sample');
+    if (text != null) {
+      return _completeTool('Success');
     }
-    return CallToolResult(content: [TextContent(text: 'Success')]);
+    return _toolInputRequired(
+      InputRequiredResult(
+        inputRequests: {
+          'capability_sample': _sample(
+            'Need sampling to continue',
+            maxTokens: 1,
+          ),
+        },
+      ),
+    );
   }
 
   ReadResourceResult? _readTemplate(ReadResourceRequest request) {

--- a/pkgs/dart_mcp/tool/conformance_server.dart
+++ b/pkgs/dart_mcp/tool/conformance_server.dart
@@ -866,6 +866,10 @@ base class _ConformanceServer extends MCPServer
   CallToolResult _completeTool(String text) =>
       CallToolResult(content: [TextContent(text: text)]);
 
+  // A handler's return type does not admit an `InputRequiredResult` yet, so
+  // the tool goes through the map the two extension types share. The wire
+  // shape is the one the spec asks for either way, and these two lines are
+  // where a widened signature would let the tool return the result directly.
   CallToolResult _toolInputRequired(InputRequiredResult result) =>
       CallToolResult.fromMap(result as Map<String, Object?>);
 


### PR DESCRIPTION
Closes https://github.com/dart-lang/ai/issues/491

#572 shipped Streamable HTTP. The blocker named in that issue is gone. I added a local HTTP probe under tool/ as development tooling, not package API.

crypto is a dev_dependency used only to HMAC opaque requestState. The suite runs from Node, and the integration guide offers a reusable Action instead of requiring one. I left the bots alone.

Against `@modelcontextprotocol/conformance@0.2.0-alpha.11`, `--requirements 2026-07-28` is 37/37 and `--suite all --spec-version 2026-07-28` is 40/40. Thirteen more scenarios run without scoring, ten of them the tasks extension this package does not implement. The other three are pending and pass.
