### PR TITLE
reject real whitespace in a create template

### DIFF
--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.1.2-dev
 
+- Reject a `create` template carrying a newline, a tab or a carriage return.
 - Track `AGENT_PLUGIN` environment variable in analytics events.
 - Add missing license headers.
 

--- a/pkgs/dart_mcp_server/CHANGELOG.md
+++ b/pkgs/dart_mcp_server/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.1.2-dev
 
-- Reject a `create` template carrying a newline, a tab or a carriage return.
+- Reject a `create` template carrying whitespace, a non-breaking space
+  included.
 - Track `AGENT_PLUGIN` environment variable in analytics events.
 - Add missing license headers.
 

--- a/pkgs/dart_mcp_server/lib/src/mixins/dash_cli.dart
+++ b/pkgs/dart_mcp_server/lib/src/mixins/dash_cli.dart
@@ -188,9 +188,7 @@ base mixin DashCliSupport on ToolsSupport, LoggingSupport, RootsTrackingSupport
 
     final template = args[ParameterNames.template] as String?;
     if (template != null &&
-        (template.startsWith('-') ||
-            template.contains(' ') ||
-            template.contains('\\n'))) {
+        (template.startsWith('-') || RegExp(r'\s').hasMatch(template))) {
       errors.add(
         ValidationError(
           ValidationErrorType.custom,

--- a/pkgs/dart_mcp_server/test/tools/dart_cli_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dart_cli_test.dart
@@ -458,6 +458,27 @@ dependencies:
         expect(testProcessManager.commandsRan, isEmpty);
       });
 
+      test('fails if template contains whitespace', () async {
+        testHarness.mcpClient.addRoot(dartCliAppRoot);
+        final request = CallToolRequest(
+          name: createProjectTool.name,
+          arguments: {
+            ParameterNames.root: dartCliAppRoot.uri,
+            ParameterNames.directory: 'new_app',
+            ParameterNames.projectType: 'dart',
+            ParameterNames.template: 'console\nfull',
+          },
+        );
+        final result = await testHarness.callTool(request, expectError: true);
+
+        expect(result.isError, isTrue);
+        expect(
+          (result.content.first as TextContent).text,
+          contains('contain whitespace'),
+        );
+        expect(testProcessManager.commandsRan, isEmpty);
+      });
+
       test('requires a root to be passed', () async {
         testHarness.mcpClient.addRoot(dartCliAppRoot);
         final request = CallToolRequest(

--- a/pkgs/dart_mcp_server/test/tools/dart_cli_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dart_cli_test.dart
@@ -458,6 +458,33 @@ dependencies:
         expect(testProcessManager.commandsRan, isEmpty);
       });
 
+      test('accepts a template with a literal backslash', () async {
+        testHarness.mcpClient.addRoot(dartCliAppRoot);
+        final request = CallToolRequest(
+          name: createProjectTool.name,
+          arguments: {
+            ParameterNames.root: dartCliAppRoot.uri,
+            ParameterNames.directory: 'new_app',
+            ParameterNames.projectType: 'dart',
+            ParameterNames.template: r'console\nfull',
+          },
+        );
+        await testHarness.callToolWithRetry(request);
+
+        expect(testProcessManager.commandsRan, [
+          equalsCommand((
+            command: [
+              endsWith(dartExecutableName),
+              'create',
+              '--template',
+              r'console\nfull',
+              'new_app',
+            ],
+            workingDirectory: dartCliAppRoot.path,
+          )),
+        ]);
+      });
+
       test('fails if template contains whitespace', () async {
         testHarness.mcpClient.addRoot(dartCliAppRoot);
         for (final template in [

--- a/pkgs/dart_mcp_server/test/tools/dart_cli_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dart_cli_test.dart
@@ -485,6 +485,27 @@ dependencies:
         ]);
       });
 
+      test('fails if template starts with a dash', () async {
+        testHarness.mcpClient.addRoot(dartCliAppRoot);
+        final request = CallToolRequest(
+          name: createProjectTool.name,
+          arguments: {
+            ParameterNames.root: dartCliAppRoot.uri,
+            ParameterNames.directory: 'new_app',
+            ParameterNames.projectType: 'dart',
+            ParameterNames.template: '--force',
+          },
+        );
+        final result = await testHarness.callTool(request, expectError: true);
+
+        expect(result.isError, isTrue);
+        expect(
+          (result.content.first as TextContent).text,
+          contains('must not start with'),
+        );
+        expect(testProcessManager.commandsRan, isEmpty);
+      });
+
       test('fails if template contains whitespace', () async {
         testHarness.mcpClient.addRoot(dartCliAppRoot);
         for (final template in [

--- a/pkgs/dart_mcp_server/test/tools/dart_cli_test.dart
+++ b/pkgs/dart_mcp_server/test/tools/dart_cli_test.dart
@@ -460,23 +460,29 @@ dependencies:
 
       test('fails if template contains whitespace', () async {
         testHarness.mcpClient.addRoot(dartCliAppRoot);
-        final request = CallToolRequest(
-          name: createProjectTool.name,
-          arguments: {
-            ParameterNames.root: dartCliAppRoot.uri,
-            ParameterNames.directory: 'new_app',
-            ParameterNames.projectType: 'dart',
-            ParameterNames.template: 'console\nfull',
-          },
-        );
-        final result = await testHarness.callTool(request, expectError: true);
+        for (final template in [
+          'console\nfull',
+          'console\tfull',
+          'console\rfull',
+        ]) {
+          final request = CallToolRequest(
+            name: createProjectTool.name,
+            arguments: {
+              ParameterNames.root: dartCliAppRoot.uri,
+              ParameterNames.directory: 'new_app',
+              ParameterNames.projectType: 'dart',
+              ParameterNames.template: template,
+            },
+          );
+          final result = await testHarness.callTool(request, expectError: true);
 
-        expect(result.isError, isTrue);
-        expect(
-          (result.content.first as TextContent).text,
-          contains('contain whitespace'),
-        );
-        expect(testProcessManager.commandsRan, isEmpty);
+          expect(result.isError, isTrue);
+          expect(
+            (result.content.first as TextContent).text,
+            contains('contain whitespace'),
+          );
+          expect(testProcessManager.commandsRan, isEmpty);
+        }
       });
 
       test('requires a root to be passed', () async {


### PR DESCRIPTION
The create tool accepted a template carrying a newline or a tab. The check
looked for a literal backslash-n. Only a space was caught, and the message
already promised more than that.

I just swapped both string checks for one whitespace pattern. The message now
matches what the code does. A template carrying a literal backslash-n gets
through now, and one carrying a non-breaking space does not.
