### PR TITLE
make schema iterables JSON encodable

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.6.0-wip
 
+- Convert schema enum values and multi-select defaults to fixed-length lists so
+  schemas built from sets or lazy iterables can be JSON encoded.
 - Split the Streamable HTTP implementation into client and server libraries
   without changing its public API.
 - **BREAKING**:

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -1140,7 +1140,7 @@ extension type const StringSchema.fromMap(Map<String, Object?> _value)
     if (pattern != null) Keys.pattern: pattern,
     if (defaultValue != null) Keys.default_: defaultValue,
     if (format != null) Keys.format: format.name,
-    if (enumValues != null) Keys.enum_: enumValues,
+    if (enumValues != null) Keys.enum_: enumValues.toList(growable: false),
   });
 
   /// The minimum allowed length of this String.
@@ -1312,7 +1312,7 @@ extension type UntitledSingleSelectEnumSchema.fromMap(
     if (title != null) Keys.title: title,
     if (description != null) Keys.description: description,
     if (defaultValue != null) Keys.default_: defaultValue,
-    Keys.enum_: values,
+    Keys.enum_: values.toList(growable: false),
   });
 
   /// The allowed enum values.
@@ -1342,7 +1342,7 @@ extension type TitledSingleSelectEnumSchema.fromMap(Map<String, Object?> _value)
     if (title != null) Keys.title: title,
     if (description != null) Keys.description: description,
     if (defaultValue != null) Keys.default_: defaultValue,
-    Keys.oneOf: values,
+    Keys.oneOf: values.toList(growable: false),
   });
 
   Iterable<EnumValueWithTitle> get values {
@@ -1388,10 +1388,14 @@ extension type UntitledMultiSelectEnumSchema.fromMap(
     Keys.type: JsonType.list.typeName,
     if (title != null) Keys.title: title,
     if (description != null) Keys.description: description,
-    if (defaultValue != null) Keys.default_: defaultValue,
+    if (defaultValue != null)
+      Keys.default_: defaultValue.toList(growable: false),
     if (minItems != null) Keys.minItems: minItems,
     if (maxItems != null) Keys.maxItems: maxItems,
-    Keys.items: {Keys.enum_: values, Keys.type: JsonType.string.typeName},
+    Keys.items: {
+      Keys.enum_: values.toList(growable: false),
+      Keys.type: JsonType.string.typeName,
+    },
   });
 
   /// The allowed enum values.
@@ -1424,10 +1428,11 @@ extension type TitledMultiSelectEnumSchema.fromMap(Map<String, Object?> _value)
     Keys.type: JsonType.list.typeName,
     if (title != null) Keys.title: title,
     if (description != null) Keys.description: description,
-    if (defaultValue != null) Keys.default_: defaultValue,
+    if (defaultValue != null)
+      Keys.default_: defaultValue.toList(growable: false),
     if (minItems != null) Keys.minItems: minItems,
     if (maxItems != null) Keys.maxItems: maxItems,
-    Keys.items: {Keys.anyOf: values},
+    Keys.items: {Keys.anyOf: values.toList(growable: false)},
   });
 
   /// The allowed enum values.

--- a/pkgs/dart_mcp/test/api/tools_test.dart
+++ b/pkgs/dart_mcp/test/api/tools_test.dart
@@ -243,6 +243,31 @@ void main() {
     });
 
     group('EnumSchema', () {
+      test('schema iterables cross the JSON boundary', () {
+        Iterable<EnumValueWithTitle> titledValues() => ['a', 'b'].map(
+          (value) =>
+              EnumValueWithTitle(constValue: value, title: value.toUpperCase()),
+        );
+
+        final schemas = <Schema>[
+          StringSchema(enumValues: {'a', 'b'}),
+          UntitledSingleSelectEnumSchema(values: {'a', 'b'}),
+          TitledSingleSelectEnumSchema(values: titledValues()),
+          UntitledMultiSelectEnumSchema(
+            defaultValue: {'a'},
+            values: {'a', 'b'},
+          ),
+          TitledMultiSelectEnumSchema(
+            defaultValue: {'a'},
+            values: titledValues(),
+          ),
+        ];
+
+        for (final schema in schemas) {
+          expect(jsonDecode(jsonEncode(schema)), schema);
+        }
+      });
+
       test('UntitledSingleSelect', () {
         final schema = EnumSchema.untitledSingleSelect(
           title: 'Foo',


### PR DESCRIPTION
Sets and lazy iterables in seven schema fields made `jsonEncode` fail. This follows up on [the issue I noted in #603](https://github.com/dart-lang/ai/pull/603#discussion_r3792311104) now that it has landed.

With no matching package precedent, I think the constructor is the natural boundary for converting each value to a fixed-length list. A compact table test covers all seven fields through `jsonEncode`.
