### PR TITLE
stop telling a 2026-07-28 server the roots list changed

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -4,6 +4,8 @@
   schemas built from sets or lazy iterables can be JSON encoded.
 - Split the Streamable HTTP implementation into client and server libraries
   without changing its public API.
+- Stop sending `notifications/roots/list_changed` to a server that speaks
+  2026-07-28. An unsettled connection still gets it.
 - **BREAKING**:
   - `MCPBase` (including the `MCPServer.fromStreamChannel` and
     `ServerConnection.fromStreamChannel` constructors),

--- a/pkgs/dart_mcp/lib/src/client/roots_support.dart
+++ b/pkgs/dart_mcp/lib/src/client/roots_support.dart
@@ -29,8 +29,8 @@ base mixin RootsSupport on MCPClient {
   /// Returns `true` if [root] was added, and `false` if a [Root] with
   /// the same URI was already present.
   ///
-  /// Notifies all connected servers of the change to the list of roots, if the
-  /// [root] was added.
+  /// Notifies the connected servers, other than those on a revision that
+  /// dropped the notification, if the [root] was added.
   bool addRoot(Root root) {
     final changed = _roots.add(root);
     if (changed) _notifyRootsListChanged();
@@ -42,8 +42,8 @@ base mixin RootsSupport on MCPClient {
   /// Returns `true` if [root] was removed, and `false` if no [Root] with
   /// a matching URI was present.
   ///
-  /// Notifies all connected servers of the change to the list of roots, if
-  /// a root was in fact removed.
+  /// Notifies the connected servers, other than those on a revision that
+  /// dropped the notification, if a root was in fact removed.
   bool removeRoot(Root root) {
     final removed = _roots.remove(root);
     if (removed) _notifyRootsListChanged();
@@ -52,8 +52,18 @@ base mixin RootsSupport on MCPClient {
 
   /// Called whenever the list of roots changes, it is the job of the server to
   /// then ask for the list of roots.
+  ///
+  /// A server that settled on a revision without the notification hears
+  /// nothing. 2026-07-28 is one, and carries a [ListRootsRequest] in an
+  /// [InputRequiredResult] instead. A server that has not settled yet is
+  /// still told.
   void _notifyRootsListChanged() {
     for (var server in connections) {
+      final version = server.protocolVersion;
+      if (version != null &&
+          !version.methodIsValid(RootsListChangedNotification.methodName)) {
+        continue;
+      }
       server.sendNotification(
         RootsListChangedNotification.methodName,
         RootsListChangedNotification(),

--- a/pkgs/dart_mcp/test/api/roots_test.dart
+++ b/pkgs/dart_mcp/test/api/roots_test.dart
@@ -65,6 +65,87 @@ void main() {
     // complete.
     await environment.shutdown();
   });
+
+  test('skips a 2026-07-28 server', () async {
+    final environment = TestEnvironment(
+      TestMCPClientWithRoots(),
+      TestMCPServer.new,
+    );
+    await environment.initializeServer();
+
+    final events = <RootsListChangedNotification?>[];
+    final subscription = environment.server.rootsListChanged!.listen(
+      events.add,
+    );
+    addTearDown(subscription.cancel);
+
+    // The version is assignable because a transport can settle it outside the
+    // handshake.
+    environment.serverConnection.protocolVersion = ProtocolVersion.v2026_07_28;
+    expect(
+      environment.client.addRoot(Root(uri: 'test://a', name: 'a')),
+      isTrue,
+    );
+    await pumpEventQueue();
+    expect(events, isEmpty, reason: 'the revision dropped this notification');
+
+    environment.serverConnection.protocolVersion = ProtocolVersion.v2025_11_25;
+    expect(
+      environment.client.addRoot(Root(uri: 'test://b', name: 'b')),
+      isTrue,
+    );
+    await pumpEventQueue();
+    expect(events, hasLength(1));
+  });
+
+  test('tells a server with no settled version', () async {
+    final environment = TestEnvironment(
+      TestMCPClientWithRoots(),
+      TestMCPServer.new,
+    );
+    await environment.initializeServer();
+
+    final events = <RootsListChangedNotification?>[];
+    final subscription = environment.server.rootsListChanged!.listen(
+      events.add,
+    );
+    addTearDown(subscription.cancel);
+
+    environment.serverConnection.protocolVersion = null;
+    expect(
+      environment.client.addRoot(Root(uri: 'test://a', name: 'a')),
+      isTrue,
+    );
+    await pumpEventQueue();
+
+    expect(events, hasLength(1));
+  });
+
+  test('carries on past a server it skips', () async {
+    final client = TestMCPClientWithRoots();
+    final one = TestEnvironment(client, TestMCPServer.new);
+    await one.initializeServer();
+    final two = TestEnvironment(client, TestMCPServer.new);
+    await two.initializeServer();
+
+    // Skip the first connection the loop walks. A send that stops on a
+    // skipped one never reaches the second.
+    final (left, told) =
+        client.connections.first == one.serverConnection
+            ? (one, two)
+            : (two, one);
+
+    final events = <RootsListChangedNotification?>[];
+    final subscription = told.server.rootsListChanged!.listen(events.add);
+    addTearDown(subscription.cancel);
+
+    left.serverConnection.protocolVersion = ProtocolVersion.v2026_07_28;
+    expect(told.serverConnection.protocolVersion, ProtocolVersion.v2025_11_25);
+    expect(client.addRoot(Root(uri: 'test://a', name: 'a')), isTrue);
+    await pumpEventQueue();
+
+    expect(events, hasLength(1));
+  });
 }
 
 final class TestMCPClientWithRoots extends TestMCPClient with RootsSupport {}


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

The 2026-07-28 revision removed `notifications/roots/list_changed`, and https://github.com/dart-lang/ai/pull/631 stopped the server sending the three input requests it removed. But `RootsSupport` just kept sending this one from the client side. I added the check inside the loop that sends it.

Until a connection settles on a revision, it still gets the notification. This does not drop the client's `roots.listChanged`.
