### PR TITLE
exercise listen streams from the conformance probe

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -403,6 +403,7 @@
     `progressToken` when they are given, see
     https://modelcontextprotocol.io/specification/2026-07-28/server/discover.
 - Add a local MCP conformance probe under `tool/`.
+- Add list-change subscriptions to the local conformance probe.
 
 ## 0.5.2
 

--- a/pkgs/dart_mcp/test/conformance_server_test.dart
+++ b/pkgs/dart_mcp/test/conformance_server_test.dart
@@ -9,6 +9,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:async/async.dart';
 import 'package:test/test.dart';
 
 const _protocolVersion = '2026-07-28';
@@ -19,6 +20,9 @@ const _inputTamperedTool = 'test_input_required_result_tampered_state';
 const _templateUri = 'test://template/{id}/data';
 const _expandedTemplateUri = 'test://template/123/data';
 const _simplePrompt = 'test_simple_prompt';
+const _toolChangeTool = 'test_trigger_tool_change';
+const _promptChangeTool = 'test_trigger_prompt_change';
+const _subscriptionIdMeta = 'io.modelcontextprotocol/subscriptionId';
 const _formElicitationCapabilities = <String, Object?>{
   'elicitation': <String, Object?>{'form': <String, Object?>{}},
 };
@@ -229,10 +233,101 @@ void main() {
         contains('failed integrity validation'),
       );
     });
+
+    test('delivers a list change from another request on a listen '
+        'stream', () async {
+      final client = HttpClient();
+      addTearDown(() => client.close(force: true));
+      final request = await client.postUrl(endpoint);
+      request.headers
+        ..set(HttpHeaders.contentTypeHeader, 'application/json')
+        ..set(HttpHeaders.acceptHeader, 'application/json, text/event-stream')
+        ..set('Mcp-Protocol-Version', _protocolVersion)
+        ..set('Mcp-Method', 'subscriptions/listen');
+      request.write(
+        jsonEncode({
+          'jsonrpc': '2.0',
+          'id': 7,
+          'method': 'subscriptions/listen',
+          'params': {
+            'notifications': {
+              'toolsListChanged': true,
+              'promptsListChanged': true,
+            },
+            '_meta': {
+              'io.modelcontextprotocol/protocolVersion': _protocolVersion,
+              'io.modelcontextprotocol/clientCapabilities': <String, Object?>{},
+            },
+          },
+        }),
+      );
+      final response = await request.close();
+      expect(response.statusCode, HttpStatus.ok);
+      expect(response.headers.contentType?.mimeType, 'text/event-stream');
+      final events = StreamQueue(
+        response
+            .transform(utf8.decoder)
+            .transform(const LineSplitter())
+            .where((line) => line.startsWith('data: '))
+            .map(
+              (line) =>
+                  jsonDecode(line.substring('data: '.length))
+                      as Map<String, Object?>,
+            ),
+      );
+      // Cancel immediately. A plain cancel waits for the pending request.
+      addTearDown(() => events.cancel(immediate: true));
+
+      final acknowledgement = await _next(events);
+      expect(
+        acknowledgement['method'],
+        'notifications/subscriptions/acknowledged',
+      );
+      // The subscription is named by the id of the request opening it.
+      expect(_meta(acknowledgement), containsPair(_subscriptionIdMeta, 7));
+
+      // Two more requests, each answered by its own server. Neither one holds
+      // the stream open. The changes reach it through the transport.
+      for (final trigger in [_toolChangeTool, _promptChangeTool]) {
+        final triggered = await _post(
+          endpoint,
+          'tools/call',
+          params: {'name': trigger, 'arguments': <String, Object?>{}},
+        );
+        expect(
+          (triggered['result'] as Map<String, Object?>)['isError'],
+          isNot(true),
+        );
+      }
+
+      final changes = [await _next(events), await _next(events)];
+      expect(changes.map((change) => change['method']), [
+        'notifications/tools/list_changed',
+        'notifications/prompts/list_changed',
+      ]);
+      for (final change in changes) {
+        expect(_meta(change), containsPair(_subscriptionIdMeta, 7));
+      }
+    });
     // `Platform.resolvedExecutable` is this test's own binary once it is
     // compiled, so it cannot start the server the way it does on the VM.
   }, testOn: '!exe');
 }
+
+/// The `_meta` envelope of [notification]'s params.
+Map<String, Object?> _meta(Map<String, Object?> notification) =>
+    (notification['params'] as Map<String, Object?>)['_meta']
+        as Map<String, Object?>;
+
+/// The next event on [events]. Fails the test when the server never sends
+/// one.
+///
+/// Fails with a message before the runner's 30 second default.
+Future<Map<String, Object?>> _next(StreamQueue<Map<String, Object?>> events) =>
+    events.next.timeout(
+      const Duration(seconds: 20),
+      onTimeout: () => fail('The listen stream sent no further event'),
+    );
 
 Future<Map<String, Object?>> _post(
   Uri endpoint,

--- a/pkgs/dart_mcp/test/conformance_server_test.dart
+++ b/pkgs/dart_mcp/test/conformance_server_test.dart
@@ -22,6 +22,8 @@ const _expandedTemplateUri = 'test://template/123/data';
 const _simplePrompt = 'test_simple_prompt';
 const _toolChangeTool = 'test_trigger_tool_change';
 const _promptChangeTool = 'test_trigger_prompt_change';
+const _addedTool = 'test_added_tool';
+const _addedPrompt = 'test_added_prompt';
 const _subscriptionIdMeta = 'io.modelcontextprotocol/subscriptionId';
 const _formElicitationCapabilities = <String, Object?>{
   'elicitation': <String, Object?>{'form': <String, Object?>{}},
@@ -308,6 +310,14 @@ void main() {
       for (final change in changes) {
         expect(_meta(change), containsPair(_subscriptionIdMeta, 7));
       }
+
+      final tools = await _post(endpoint, 'tools/list');
+      final toolList = (tools['result'] as Map<String, Object?>)['tools'];
+      expect(toolList, contains(containsPair('name', _addedTool)));
+
+      final prompts = await _post(endpoint, 'prompts/list');
+      final promptList = (prompts['result'] as Map<String, Object?>)['prompts'];
+      expect(promptList, contains(containsPair('name', _addedPrompt)));
     });
     // `Platform.resolvedExecutable` is this test's own binary once it is
     // compiled, so it cannot start the server the way it does on the VM.

--- a/pkgs/dart_mcp/tool/conformance_server.dart
+++ b/pkgs/dart_mcp/tool/conformance_server.dart
@@ -43,6 +43,12 @@ Future<void> main(List<String> arguments) async {
 /// reads back the ones its acknowledged filter selects.
 final _subscriptionNotifications =
     StreamController<Map<String, Object?>>.broadcast();
+final _fixtureState = _FixtureState();
+
+final class _FixtureState {
+  bool toolAdded = false;
+  bool promptAdded = false;
+}
 
 const _path = '/mcp';
 const _imageMimeType = 'image/png';
@@ -231,6 +237,8 @@ base class _ConformanceServer extends MCPServer
     _registerTools();
     _registerResources();
     _registerPrompts();
+    if (_fixtureState.toolAdded) _registerAddedTool();
+    if (_fixtureState.promptAdded) _registerAddedPrompt();
   }
 
   // Tools named by the tools-call-* and input-required-result-* scenarios.
@@ -428,14 +436,15 @@ base class _ConformanceServer extends MCPServer
         inputSchema: ObjectSchema(),
       ),
       (_) {
-        registerTool(
-          Tool(
-            name: _addedTool,
-            description: _addedTool,
-            inputSchema: ObjectSchema(),
-          ),
-          (_) => CallToolResult(content: [TextContent(text: _addedTool)]),
-        );
+        if (!_fixtureState.toolAdded) {
+          _registerAddedTool();
+          _fixtureState.toolAdded = true;
+        } else {
+          sendNotification(
+            ToolListChangedNotification.methodName,
+            ToolListChangedNotification(),
+          );
+        }
         return CallToolResult(content: [TextContent(text: _addedTool)]);
       },
     );
@@ -446,19 +455,42 @@ base class _ConformanceServer extends MCPServer
         inputSchema: ObjectSchema(),
       ),
       (_) {
-        addPrompt(
-          Prompt(name: _addedPrompt, description: _addedPrompt),
-          (_) => GetPromptResult(
-            messages: [
-              PromptMessage(
-                role: Role.user,
-                content: TextContent(text: _addedPrompt),
-              ),
-            ],
-          ),
-        );
+        if (!_fixtureState.promptAdded) {
+          _registerAddedPrompt();
+          _fixtureState.promptAdded = true;
+        } else {
+          sendNotification(
+            PromptListChangedNotification.methodName,
+            PromptListChangedNotification(),
+          );
+        }
         return CallToolResult(content: [TextContent(text: _addedPrompt)]);
       },
+    );
+  }
+
+  void _registerAddedTool() {
+    registerTool(
+      Tool(
+        name: _addedTool,
+        description: _addedTool,
+        inputSchema: ObjectSchema(),
+      ),
+      (_) => CallToolResult(content: [TextContent(text: _addedTool)]),
+    );
+  }
+
+  void _registerAddedPrompt() {
+    addPrompt(
+      Prompt(name: _addedPrompt, description: _addedPrompt),
+      (_) => GetPromptResult(
+        messages: [
+          PromptMessage(
+            role: Role.user,
+            content: TextContent(text: _addedPrompt),
+          ),
+        ],
+      ),
     );
   }
 

--- a/pkgs/dart_mcp/tool/conformance_server.dart
+++ b/pkgs/dart_mcp/tool/conformance_server.dart
@@ -34,6 +34,16 @@ Future<void> main(List<String> arguments) async {
   httpServer.listen((request) => unawaited(_handleRequest(request)));
 }
 
+/// Carries the changes one request's server makes to the listen streams open
+/// on other requests.
+///
+/// A request-scoped server lives for one message. A `tools/call` that
+/// mutates a list and a `subscriptions/listen` holding a stream open are two
+/// different servers. Every notification goes in here, and each listen request
+/// reads back the ones its acknowledged filter selects.
+final _subscriptionNotifications =
+    StreamController<Map<String, Object?>>.broadcast();
+
 const _path = '/mcp';
 const _imageMimeType = 'image/png';
 const _audioMimeType = 'audio/wav';
@@ -57,6 +67,10 @@ const _progressTool = 'test_tool_with_progress';
 const _missingCapabilityTool = 'test_missing_capability';
 const _headerTool = 'test_x_mcp_header';
 const _jsonSchemaTool = 'json_schema_2020_12_tool';
+const _toolChangeTool = 'test_trigger_tool_change';
+const _promptChangeTool = 'test_trigger_prompt_change';
+const _addedTool = 'test_added_tool';
+const _addedPrompt = 'test_added_prompt';
 const _inputElicitationTool = 'test_input_required_result_elicitation';
 const _inputSamplingTool = 'test_input_required_result_sampling';
 const _inputRootsTool = 'test_input_required_result_list_roots';
@@ -168,7 +182,12 @@ Future<void> _handleRequest(HttpRequest request) async {
       return;
     }
 
-    await handleStreamableHttpRequest(request, _ConformanceServer.new);
+    await handleStreamableHttpRequest(
+      request,
+      _ConformanceServer.new,
+      onNotification: _subscriptionNotifications.add,
+      subscriptionNotifications: _subscriptionNotifications.stream,
+    );
   } catch (error) {
     stderr.writeln(error);
   }
@@ -196,7 +215,12 @@ bool _isLocalUri(Uri? uri) =>
         uri.host == InternetAddress.loopbackIPv6.address);
 
 base class _ConformanceServer extends MCPServer
-    with ToolsSupport, ResourcesSupport, PromptsSupport, CompletionsSupport {
+    with
+        ToolsSupport,
+        ResourcesSupport,
+        PromptsSupport,
+        CompletionsSupport,
+        SubscriptionsSupport {
   _ConformanceServer(super.channel)
     : super.fromStreamChannel(
         implementation: Implementation(
@@ -394,6 +418,47 @@ base class _ConformanceServer extends MCPServer
       ),
       (_) => CallToolResult(content: [TextContent(text: _jsonSchemaTool)]),
       validateArguments: false,
+    );
+    // server-stateless calls these two on a second request to change a list
+    // while it holds a subscriptions/listen stream open on the first.
+    registerTool(
+      Tool(
+        name: _toolChangeTool,
+        description: _toolChangeTool,
+        inputSchema: ObjectSchema(),
+      ),
+      (_) {
+        registerTool(
+          Tool(
+            name: _addedTool,
+            description: _addedTool,
+            inputSchema: ObjectSchema(),
+          ),
+          (_) => CallToolResult(content: [TextContent(text: _addedTool)]),
+        );
+        return CallToolResult(content: [TextContent(text: _addedTool)]);
+      },
+    );
+    registerTool(
+      Tool(
+        name: _promptChangeTool,
+        description: _promptChangeTool,
+        inputSchema: ObjectSchema(),
+      ),
+      (_) {
+        addPrompt(
+          Prompt(name: _addedPrompt, description: _addedPrompt),
+          (_) => GetPromptResult(
+            messages: [
+              PromptMessage(
+                role: Role.user,
+                content: TextContent(text: _addedPrompt),
+              ),
+            ],
+          ),
+        );
+        return CallToolResult(content: [TextContent(text: _addedPrompt)]);
+      },
     );
   }
 

--- a/pkgs/dart_mcp/tool/conformance_server.dart
+++ b/pkgs/dart_mcp/tool/conformance_server.dart
@@ -45,6 +45,10 @@ final _subscriptionNotifications =
     StreamController<Map<String, Object?>>.broadcast();
 final _fixtureState = _FixtureState();
 
+/// Carries fixture mutations between request-scoped servers.
+///
+/// Mutation handlers write the flags. Later servers read them so capabilities
+/// added by one request remain visible to subsequent requests.
 final class _FixtureState {
   bool toolAdded = false;
   bool promptAdded = false;


### PR DESCRIPTION
Without `SubscriptionsSupport`, the probe that #640 added answered `server/discover` with the four subscription bits stripped, and the suite skipped five server-stateless checks. I mixed it in and added the two tools that the scenario calls to change a list. The transport now gets the broadcast stream that its docs already describe.

Against 2026-07-28 the server-stateless checks go from 25 passed with five skipped to 30 passed with none. The stream has a test in the package too, since CI does not run the suite.
