### PR TITLE
route server-to-client requests on older revisions

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -4,6 +4,9 @@
   schemas built from sets or lazy iterables can be JSON encoded.
 - Split the Streamable HTTP implementation into client and server libraries
   without changing its public API.
+- Let `handleRequestScopedMessage` route server-to-client requests through an
+  `onRequest` callback on revisions before 2026-07-28. Missing callbacks and
+  invalid callback responses fail the server request without leaving it open.
 - **BREAKING**:
   - `MCPBase` (including the `MCPServer.fromStreamChannel` and
     `ServerConnection.fromStreamChannel` constructors),

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -75,15 +75,12 @@ typedef MCPServerFactory =
 /// [onNotification] are reported as uncaught errors and do not fail the
 /// exchange.
 ///
-/// Requests from the server back to the client, such as `roots/list`, cannot
-/// be answered within a single-message exchange: they fail with an
-/// [RpcException] inside their handler, or with a [StateError] if the exchange
-/// has already been torn down. When the negotiated revision does not have one,
-/// [MCPServer.listRoots], [MCPServer.createMessage], and
-/// [ElicitationRequestSupport.elicit] refuse it before it gets this far.
-/// 2026-07-28 has none of the three. It dropped `ping` as well, and
-/// [MCPBase.ping] does not read the revision, so a ping still fails inside its
-/// handler.
+/// On revisions before 2026-07-28, requests from the server back to the client
+/// are passed to [onRequest]. Its response must be a JSON-RPC response carrying
+/// the request id. A callback error or an invalid response fails the server's
+/// request with an internal error. A response completed after the exchange has
+/// closed is discarded. Without [onRequest], server requests fail immediately.
+/// The callback is not used on 2026-07-28.
 ///
 /// If [beforeDispatch] is given, it receives the initialized server and runs
 /// before [message] is delivered. A non-`null` result stops dispatch: requests
@@ -96,13 +93,13 @@ typedef MCPServerFactory =
 /// request-scoped is the transport's job. Errors thrown by [serverFactory] or
 /// by [MCPServer.initialize] propagate to the caller; a server that was
 /// created is shut down first.
-// TODO: Route server-to-client requests on revisions before 2026-07-28.
-// https://github.com/dart-lang/ai/issues/162
 Future<Map<String, Object?>?> handleRequestScopedMessage(
   Map<String, Object?> message,
   MCPServerInitialization initialization,
   MCPServerFactory serverFactory, {
   void Function(Map<String, Object?> notification)? onNotification,
+  FutureOr<Map<String, Object?>> Function(Map<String, Object?> request)?
+  onRequest,
   FutureOr<RpcException?> Function(MCPServer server)? beforeDispatch,
 }) async {
   final object = JsonRpc2Object.fromMap(message);
@@ -137,6 +134,14 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
     );
   }
 
+  final routeServerRequests = switch (initialization.protocolVersion) {
+    ProtocolVersion.v2024_11_05 => true,
+    ProtocolVersion.v2025_03_26 => true,
+    ProtocolVersion.v2025_06_18 => true,
+    ProtocolVersion.v2025_11_25 => true,
+    ProtocolVersion.v2026_07_28 => false,
+  };
+
   // The message is delivered over an in-memory channel so the exchange runs
   // through the same Peer validation and dispatch path as a wire connection.
   final inbound = StreamController<Map<String, Object?>>();
@@ -152,12 +157,13 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
       try {
         switch (JsonRpc2Object.fromMap(data).kind) {
           case JsonRpc2Kind.request:
-            // A request from the server to the client. Nothing can answer it
-            // in a single-message exchange, so fail it back to the server
-            // instead of leaving its handler waiting forever. Late requests
-            // from work which outlives the exchange find the connection
-            // already closed.
-            if (!inbound.isClosed) {
+            if (routeServerRequests && onRequest != null) {
+              unawaited(
+                _answerServerRequest(data, onRequest).then((answer) {
+                  if (!inbound.isClosed) inbound.add(answer);
+                }),
+              );
+            } else if (!inbound.isClosed) {
               inbound.add(
                 _errorResponse(
                   JsonRpc2Request.fromMap(data).id,
@@ -266,6 +272,40 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
     await server.done;
     await subscription.cancel();
   }
+}
+
+/// Returns the answer for a server [request], or an internal error carrying
+/// its id when [onRequest] fails or returns an invalid response.
+Future<Map<String, Object?>> _answerServerRequest(
+  Map<String, Object?> request,
+  FutureOr<Map<String, Object?>> Function(Map<String, Object?> request)
+  onRequest,
+) async {
+  final id = JsonRpc2Request.fromMap(request).id;
+  try {
+    final response = await onRequest(request);
+    if (_isResponseFor(response, id)) return response;
+    return _errorResponse(
+      id,
+      'The client request handler returned an invalid response',
+    );
+  } catch (_) {
+    return _errorResponse(id, 'The client request handler failed');
+  }
+}
+
+/// Whether [response] is a JSON-RPC response for [id].
+bool _isResponseFor(Map<String, Object?> response, Object? id) {
+  if (response[Keys.jsonrpc] != '2.0' || response[Keys.id] != id) return false;
+  if (response.containsKey(Keys.method)) return false;
+  final hasResult = response.containsKey(Keys.result);
+  final hasError = response.containsKey(Keys.error);
+  if (hasResult == hasError) return false;
+  if (!hasError) return true;
+  final error = response[Keys.error];
+  return error is Map<String, Object?> &&
+      error[Keys.code] is int &&
+      error[Keys.message] is String;
 }
 
 /// A JSON-RPC error response to the request with the given [id], carrying the

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -289,7 +289,8 @@ Future<Map<String, Object?>> _answerServerRequest(
       id,
       'The client request handler returned an invalid response',
     );
-  } catch (_) {
+  } catch (error, stackTrace) {
+    Zone.current.handleUncaughtError(error, stackTrace);
     return _errorResponse(id, 'The client request handler failed');
   }
 }

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -515,19 +515,160 @@ void main() {
       expect(legacy![Keys.result], isNotNull);
     });
 
-    test('rejects a 2025-11-25 roots request instead of hanging', () async {
+    test('routes the four legacy client request methods', () async {
+      final cases =
+          <({String tool, String method, Map<String, Object?> result})>[
+            (
+              tool: 'roots',
+              method: ListRootsRequest.methodName,
+              result: <String, Object?>{
+                Keys.roots: [Root(uri: 'file:///workspace')],
+              },
+            ),
+            (
+              tool: 'sample',
+              method: CreateMessageRequest.methodName,
+              result: <String, Object?>{
+                Keys.role: Role.assistant.name,
+                Keys.content: Content.text(text: 'sampled'),
+                Keys.model: 'test-model',
+              },
+            ),
+            (
+              tool: 'elicit',
+              method: ElicitRequest.methodName,
+              result: <String, Object?>{
+                Keys.action: ElicitationAction.accept.name,
+              },
+            ),
+            (
+              tool: 'ping',
+              method: PingRequest.methodName,
+              result: <String, Object?>{},
+            ),
+          ];
+      final methods = <String>[];
+
+      for (final requestCase in cases) {
+        final response = await handleRequestScopedMessage(
+          _callTool(requestCase.tool),
+          _legacyInitialization(),
+          _LegacyRequestServer.new,
+          onRequest: (request) {
+            methods.add(request[Keys.method] as String);
+            return _responseFor(request, requestCase.result);
+          },
+        ).timeout(const Duration(seconds: 1));
+
+        final result = CallToolResult.fromMap(_result(response));
+        expect((result.content.single as TextContent).text, 'ok');
+      }
+      expect(methods, [for (final requestCase in cases) requestCase.method]);
+    });
+
+    test('fails fast when the legacy request callback is absent', () async {
       final harness = _DispatcherHarness();
-      final response = await harness.dispatch(
-        _callTool('roots'),
-        _initialization(
-          capabilities: ClientCapabilities(roots: RootsCapabilities()),
-          protocolVersion: ProtocolVersion.v2025_11_25,
-        ),
-      );
+      final response = await harness
+          .dispatch(_callTool('roots'), _legacyInitialization())
+          .timeout(const Duration(seconds: 1));
 
       final error = response![Keys.error] as Map<String, Object?>;
       expect(error[Keys.code], error_code.INTERNAL_ERROR);
       expect(error[Keys.message], contains('request-scoped transport'));
+    });
+
+    test('does not route a request on 2026-07-28', () async {
+      var calls = 0;
+      final response = await handleRequestScopedMessage(
+        _callTool('ping'),
+        _initialization(),
+        _LegacyRequestServer.new,
+        onRequest: (request) {
+          calls++;
+          return _responseFor(request, <String, Object?>{});
+        },
+      ).timeout(const Duration(seconds: 1));
+
+      expect(calls, 0);
+      expect(
+        (response![Keys.error] as Map<String, Object?>)[Keys.code],
+        error_code.INTERNAL_ERROR,
+      );
+    });
+
+    test('answers a callback error on the server request id', () async {
+      final response = await handleRequestScopedMessage(
+        _callTool('roots'),
+        _legacyInitialization(),
+        _LegacyRequestServer.new,
+        onRequest: (_) => throw StateError('callback failed'),
+      ).timeout(const Duration(seconds: 1));
+
+      final error = response![Keys.error] as Map<String, Object?>;
+      expect(error[Keys.code], error_code.INTERNAL_ERROR);
+      expect(error[Keys.message], 'The client request handler failed');
+    });
+
+    test('answers a malformed callback response on the request id', () async {
+      final response = await handleRequestScopedMessage(
+        _callTool('roots'),
+        _legacyInitialization(),
+        _LegacyRequestServer.new,
+        onRequest:
+            (request) => {Keys.jsonrpc: '2.0', Keys.id: request[Keys.id]},
+      ).timeout(const Duration(seconds: 1));
+
+      final error = response![Keys.error] as Map<String, Object?>;
+      expect(error[Keys.code], error_code.INTERNAL_ERROR);
+      expect(
+        error[Keys.message],
+        'The client request handler returned an invalid response',
+      );
+    });
+
+    test('answers a mismatched callback response on the request id', () async {
+      final response = await handleRequestScopedMessage(
+        _callTool('roots'),
+        _legacyInitialization(),
+        _LegacyRequestServer.new,
+        onRequest:
+            (request) => {
+              Keys.jsonrpc: '2.0',
+              Keys.id: '${request[Keys.id]}-other',
+              Keys.result: <String, Object?>{Keys.roots: <Object>[]},
+            },
+      ).timeout(const Duration(seconds: 1));
+
+      final error = response![Keys.error] as Map<String, Object?>;
+      expect(error[Keys.code], error_code.INTERNAL_ERROR);
+      expect(
+        error[Keys.message],
+        'The client request handler returned an invalid response',
+      );
+    });
+
+    test('discards a callback response after the exchange closes', () async {
+      final started = Completer<Map<String, Object?>>();
+      final pending = Completer<Map<String, Object?>>();
+      final dispatch = handleRequestScopedMessage(
+        {
+          Keys.jsonrpc: '2.0',
+          Keys.method: _DispatcherTestServer.testNotification,
+        },
+        _legacyInitialization(),
+        _RootsTrackingDispatcherServer.new,
+        onRequest: (request) {
+          started.complete(request);
+          return pending.future;
+        },
+      );
+
+      final request = await started.future.timeout(const Duration(seconds: 1));
+      expect(await dispatch.timeout(const Duration(seconds: 1)), isNull);
+      pending.complete(
+        _responseFor(request, <String, Object?>{Keys.roots: <Object>[]}),
+      );
+      await Future<void>.delayed(Duration.zero);
     });
 
     test('refuses input_required on a request it is not allowed on', () async {
@@ -1442,6 +1583,8 @@ final class _DispatcherHarness {
     Map<String, Object?> message,
     MCPServerInitialization initialization, {
     void Function(Map<String, Object?> notification)? onNotification,
+    FutureOr<Map<String, Object?>> Function(Map<String, Object?> request)?
+    onRequest,
     FutureOr<RpcException?> Function(MCPServer server)? beforeDispatch,
   }) => handleRequestScopedMessage(
     message,
@@ -1453,6 +1596,7 @@ final class _DispatcherHarness {
       return server;
     },
     onNotification: onNotification,
+    onRequest: onRequest,
     beforeDispatch: beforeDispatch,
   );
 }
@@ -1615,6 +1759,35 @@ final class _RootsTrackingDispatcherServer extends TestMCPServer
   _RootsTrackingDispatcherServer(super.channel);
 }
 
+/// A server exercising every client request retained by legacy revisions.
+final class _LegacyRequestServer extends TestMCPServer
+    with LoggingSupport, ToolsSupport, ElicitationRequestSupport {
+  _LegacyRequestServer(super.channel);
+
+  @override
+  FutureOr<void> initialize(MCPServerInitialization initialization) {
+    registerTool(Tool(name: 'roots', inputSchema: ObjectSchema()), (_) async {
+      await listRoots();
+      return _okToolResult;
+    });
+    registerTool(Tool(name: 'sample', inputSchema: ObjectSchema()), (_) async {
+      await createMessage(CreateMessageRequest(messages: [], maxTokens: 1));
+      return _okToolResult;
+    });
+    registerTool(Tool(name: 'elicit', inputSchema: ObjectSchema()), (_) async {
+      await elicit(
+        ElicitRequest.form(message: 'Choose', requestedSchema: ObjectSchema()),
+      );
+      return _okToolResult;
+    });
+    registerTool(Tool(name: 'ping', inputSchema: ObjectSchema()), (_) async {
+      if (!await ping()) throw StateError('ping failed');
+      return _okToolResult;
+    });
+    return super.initialize(initialization);
+  }
+}
+
 /// A server carrying a `resources` capability field this package does not
 /// know, standing in for one a later revision adds.
 final class _ExtraResourceFieldServer extends TestMCPServer
@@ -1746,6 +1919,22 @@ MCPServerInitialization _initialization({
   clientCapabilities: capabilities ?? ClientCapabilities(),
   logLevel: logLevel,
 );
+
+MCPServerInitialization _legacyInitialization() => _initialization(
+  capabilities: ClientCapabilities(
+    roots: RootsCapabilities(),
+    sampling: {},
+    elicitation: ElicitationCapability(form: {}),
+  ),
+  protocolVersion: ProtocolVersion.v2025_11_25,
+);
+
+final _okToolResult = CallToolResult(content: [TextContent(text: 'ok')]);
+
+Map<String, Object?> _responseFor(
+  Map<String, Object?> request,
+  Map<String, Object?> result,
+) => {Keys.jsonrpc: '2.0', Keys.id: request[Keys.id], Keys.result: result};
 
 Map<String, Object?> _result(Map<String, Object?>? response) =>
     response![Keys.result] as Map<String, Object?>;

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -597,16 +597,21 @@ void main() {
     });
 
     test('answers a callback error on the server request id', () async {
-      final response = await handleRequestScopedMessage(
-        _callTool('roots'),
-        _legacyInitialization(),
-        _LegacyRequestServer.new,
-        onRequest: (_) => throw StateError('callback failed'),
-      ).timeout(const Duration(seconds: 1));
+      final callbackErrors = <Object>[];
+      Map<String, Object?>? response;
+      await runZonedGuarded(() async {
+        response = await handleRequestScopedMessage(
+          _callTool('roots'),
+          _legacyInitialization(),
+          _LegacyRequestServer.new,
+          onRequest: (_) => throw StateError('callback failed'),
+        ).timeout(const Duration(seconds: 1));
+      }, (error, _) => callbackErrors.add(error));
 
       final error = response![Keys.error] as Map<String, Object?>;
       expect(error[Keys.code], error_code.INTERNAL_ERROR);
       expect(error[Keys.message], 'The client request handler failed');
+      expect(callbackErrors, contains(isA<StateError>()));
     });
 
     test('answers a malformed callback response on the request id', () async {
@@ -1423,9 +1428,11 @@ void main() {
       final harness = _DispatcherHarness();
       final response = await harness.dispatch(_discover(), _initialization());
 
-      expect(DiscoverResult.fromMap(_result(response)).supportedVersions, [
-        ProtocolVersion.v2026_07_28.versionString,
-      ], reason: 'earlier revisions negotiate with the initialize handshake');
+      expect(
+        DiscoverResult.fromMap(_result(response)).supportedVersions,
+        [ProtocolVersion.v2026_07_28.versionString],
+        reason: 'earlier revisions negotiate with the initialize handshake',
+      );
     });
 
     test('advertises the capabilities initialization registered', () async {

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -1428,11 +1428,9 @@ void main() {
       final harness = _DispatcherHarness();
       final response = await harness.dispatch(_discover(), _initialization());
 
-      expect(
-        DiscoverResult.fromMap(_result(response)).supportedVersions,
-        [ProtocolVersion.v2026_07_28.versionString],
-        reason: 'earlier revisions negotiate with the initialize handshake',
-      );
+      expect(DiscoverResult.fromMap(_result(response)).supportedVersions, [
+        ProtocolVersion.v2026_07_28.versionString,
+      ], reason: 'earlier revisions negotiate with the initialize handshake');
     });
 
     test('advertises the capabilities initialization registered', () async {


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

On revisions before 2026-07-28 the dispatcher answered a server-originated request with `-32603`, since a single-message exchange had nowhere to send it. It now takes an optional router and writes the matching response back, so the waiting peer completes.

Only those exchanges route, and the guard is explicit because a `ping` can produce a request before the version is read. Without a router I just kept the old fail-fast. A response with the wrong shape or id becomes an internal error, and one arriving after the exchange closes is dropped.

This is what the `#162` TODO in the dispatcher was waiting on.
