### PR TITLE
accept the multi-select answers this package asks for

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -403,6 +403,10 @@
     `progressToken` when they are given, see
     https://modelcontextprotocol.io/specification/2026-07-28/server/discover.
 - Add a local MCP conformance probe under `tool/`.
+- Accept a multi-select enum as an elicitation property.
+  `UntitledMultiSelectEnumSchema` and `TitledMultiSelectEnumSchema` build the
+  two schemas the spec lists, and an array with `items` matching neither is
+  refused.
 
 ## 0.5.2
 

--- a/pkgs/dart_mcp/lib/src/api/elicitation.dart
+++ b/pkgs/dart_mcp/lib/src/api/elicitation.dart
@@ -121,8 +121,35 @@ extension type ElicitRequest._fromMap(Map<String, Object?> _value)
         case JsonType
             .enumeration: // ignore: deprecated_member_use_from_same_package
           break;
-        case JsonType.object:
         case JsonType.list:
+          // A multi-select enum is the one array the spec lists. [EnumSchema]
+          // already names its two schemas, and what it leaves open is whether
+          // the values inside are the ones the spec asks for.
+          final enumeration = EnumSchema.fromMap(propertySchema._value);
+          final items = propertySchema._value[Keys.items];
+          if (items is! Map) return false;
+          if (enumeration.isUntitledMultiSelect) {
+            if (items[Keys.type] != JsonType.string.typeName) return false;
+            final untitled = items[Keys.enum_];
+            if (untitled is! Iterable) return false;
+            for (final value in untitled) {
+              if (value is! String) return false;
+            }
+          } else if (enumeration.isTitledMultiSelect) {
+            final titled = items[Keys.anyOf];
+            if (titled is! Iterable) return false;
+            for (final value in titled) {
+              if (value is! Map ||
+                  value[Keys.const_] is! String ||
+                  value[Keys.title] is! String) {
+                return false;
+              }
+            }
+          } else {
+            return false;
+          }
+          break;
+        case JsonType.object:
         case JsonType.nil:
         case null:
           // Disallowed, or no type specified.

--- a/pkgs/dart_mcp/lib/src/api/elicitation.dart
+++ b/pkgs/dart_mcp/lib/src/api/elicitation.dart
@@ -122,32 +122,10 @@ extension type ElicitRequest._fromMap(Map<String, Object?> _value)
             .enumeration: // ignore: deprecated_member_use_from_same_package
           break;
         case JsonType.list:
-          // A multi-select enum is the one array the spec lists. [EnumSchema]
-          // already names its two schemas, and what it leaves open is whether
-          // the values inside are the ones the spec asks for.
+          // A multi-select enum is the one array the spec lists, and
+          // [EnumSchema] already knows both of its shapes.
           final enumeration = EnumSchema.fromMap(propertySchema._value);
-          final items = propertySchema._value[Keys.items];
-          if (items is! Map) return false;
-          if (enumeration.isUntitledMultiSelect) {
-            if (items[Keys.type] != JsonType.string.typeName) return false;
-            final untitled = items[Keys.enum_];
-            if (untitled is! Iterable) return false;
-            for (final value in untitled) {
-              if (value is! String) return false;
-            }
-          } else if (enumeration.isTitledMultiSelect) {
-            final titled = items[Keys.anyOf];
-            if (titled is! Iterable) return false;
-            for (final value in titled) {
-              if (value is! Map ||
-                  value[Keys.const_] is! String ||
-                  value[Keys.title] is! String) {
-                return false;
-              }
-            }
-          } else {
-            return false;
-          }
+          if (!enumeration.isWellFormedMultiSelect) return false;
           break;
         case JsonType.object:
         case JsonType.nil:

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -1289,6 +1289,33 @@ extension type EnumSchema.fromMap(Map<String, Object?> _value)
   bool get isTitledMultiSelect =>
       type == JsonType.list &&
       (_value[Keys.items] as Map?)?[Keys.anyOf] != null;
+
+  /// Whether or not this schema is a multi-select enum matching what
+  /// [UntitledMultiSelectEnumSchema.new] and [TitledMultiSelectEnumSchema.new]
+  /// write.
+  ///
+  /// [isUntitledMultiSelect] and [isTitledMultiSelect] stop at the key `items`
+  /// carries, and still hold where reading `values` would throw.
+  bool get isWellFormedMultiSelect {
+    final items = _value[Keys.items];
+    if (items is! Map) return false;
+    if (isUntitledMultiSelect) {
+      if (items[Keys.type] != JsonType.string.typeName) return false;
+      final values = items[Keys.enum_];
+      return values is Iterable && values.every((value) => value is String);
+    }
+    if (isTitledMultiSelect) {
+      final values = items[Keys.anyOf];
+      return values is Iterable &&
+          values.every(
+            (value) =>
+                value is Map &&
+                value[Keys.const_] is String &&
+                value[Keys.title] is String,
+          );
+    }
+    return false;
+  }
 }
 
 /// Common properties for single-select enum schemas.

--- a/pkgs/dart_mcp/lib/src/api/tools.dart
+++ b/pkgs/dart_mcp/lib/src/api/tools.dart
@@ -1302,11 +1302,11 @@ extension type EnumSchema.fromMap(Map<String, Object?> _value)
     if (isUntitledMultiSelect) {
       if (items[Keys.type] != JsonType.string.typeName) return false;
       final values = items[Keys.enum_];
-      return values is Iterable && values.every((value) => value is String);
+      return values is List && values.every((value) => value is String);
     }
     if (isTitledMultiSelect) {
       final values = items[Keys.anyOf];
-      return values is Iterable &&
+      return values is List &&
           values.every(
             (value) =>
                 value is Map &&

--- a/pkgs/dart_mcp/test/api/elicitation_test.dart
+++ b/pkgs/dart_mcp/test/api/elicitation_test.dart
@@ -10,6 +10,26 @@ import 'package:test/test.dart';
 
 import '../test_utils.dart';
 
+// Fixture from the 2026-07-28 PrimitiveSchemaDefinition union.
+// https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/main/schema/2026-07-28/schema.json
+const _validMultiSelectSchemas = <Map<String, Object?>>[
+  <String, Object?>{
+    'type': 'array',
+    'items': <String, Object?>{
+      'type': 'string',
+      'enum': <Object?>['red', 'green'],
+    },
+  },
+  <String, Object?>{
+    'type': 'array',
+    'items': <String, Object?>{
+      'anyOf': <Object?>[
+        <String, Object?>{'const': '#FF0000', 'title': 'Red'},
+      ],
+    },
+  },
+];
+
 void main() {
   group('elicitation', () {
     test('a result without form data carries no content key', () {
@@ -35,27 +55,17 @@ void main() {
     });
 
     test('a form takes both multi-select enum schemas', () {
-      // Both schemas the spec lists, see
-      // https://modelcontextprotocol.io/specification/2026-07-28/client/elicitation.
-      expect(
-        () => ElicitRequest.form(
-          message: 'Pick your colours',
-          requestedSchema: ObjectSchema(
-            properties: {
-              'bare': UntitledMultiSelectEnumSchema(
-                values: ['red', 'green'],
-                minItems: 1,
-              ),
-              'titled': TitledMultiSelectEnumSchema(
-                values: [
-                  EnumValueWithTitle(title: 'Red', constValue: '#FF0000'),
-                ],
-              ),
-            },
+      for (final schema in _validMultiSelectSchemas) {
+        expect(
+          () => ElicitRequest.form(
+            message: 'Pick your colours',
+            requestedSchema: ObjectSchema(
+              properties: {'selection': Schema.fromMap(schema)},
+            ),
           ),
-        ),
-        returnsNormally,
-      );
+          returnsNormally,
+        );
+      }
     });
 
     test('refuses arrays that are not multi-select enums', () {
@@ -84,6 +94,14 @@ void main() {
         Schema.fromMap({
           'type': 'array',
           'items': {'type': 'string', 'enum': 'red'},
+        }),
+        // A Set is iterable but is not a JSON array.
+        Schema.fromMap({
+          'type': 'array',
+          'items': {
+            'type': 'string',
+            'enum': {'red', 'green'},
+          },
         }),
         // A titled entry pairs a const with a title. This one has no const.
         Schema.fromMap({
@@ -117,6 +135,15 @@ void main() {
             'anyOf': {'const': '#FF0000', 'title': 'Red'},
           },
         }),
+        // A Set of titled values is not a JSON array.
+        Schema.fromMap({
+          'type': 'array',
+          'items': {
+            'anyOf': {
+              {'const': '#FF0000', 'title': 'Red'},
+            },
+          },
+        }),
       ]) {
         expect(
           () => ElicitRequest.form(
@@ -126,6 +153,21 @@ void main() {
           throwsA(isA<AssertionError>()),
         );
       }
+    }, testOn: '!exe');
+
+    test('refuses a later invalid property', () {
+      expect(
+        () => ElicitRequest.form(
+          message: 'Pick your colours',
+          requestedSchema: ObjectSchema(
+            properties: {
+              'selection': Schema.fromMap(_validMultiSelectSchemas.first),
+              'nested': ObjectSchema(),
+            },
+          ),
+        ),
+        throwsA(isA<AssertionError>()),
+      );
     }, testOn: '!exe');
 
     test('server can elicit information from client', () async {

--- a/pkgs/dart_mcp/test/api/elicitation_test.dart
+++ b/pkgs/dart_mcp/test/api/elicitation_test.dart
@@ -34,7 +34,7 @@ void main() {
       );
     });
 
-    test('a multi-select enum is a schema a client can be asked for', () {
+    test('a form takes both multi-select enum schemas', () {
       // Both schemas the spec lists, see
       // https://modelcontextprotocol.io/specification/2026-07-28/client/elicitation.
       expect(
@@ -58,18 +58,18 @@ void main() {
       );
     });
 
-    test('an array that is not a multi-select enum is refused', () {
+    test('refuses arrays that are not multi-select enums', () {
       for (final property in [
         // Items the client would have to type into, not choose from.
         Schema.list(items: Schema.string()),
-        // No items at all, so nothing names the values.
-        Schema.list(),
-        // Values named, but the spec asks for strings.
+        // The items key holds a value, not a schema.
+        Schema.fromMap({'type': 'array', 'items': 'red'}),
+        // The values are strings, but the item type is not.
         Schema.fromMap({
           'type': 'array',
           'items': {
             'type': 'number',
-            'enum': [1, 2],
+            'enum': ['red', 'green'],
           },
         }),
         // The item type says string. The values are numbers.
@@ -78,16 +78,6 @@ void main() {
           'items': {
             'type': 'string',
             'enum': [1, 2],
-          },
-        }),
-        // Objects standing in for the strings.
-        Schema.fromMap({
-          'type': 'array',
-          'items': {
-            'type': 'string',
-            'enum': [
-              {'a': 1},
-            ],
           },
         }),
         // One value where the spec asks for a list of them.

--- a/pkgs/dart_mcp/test/api/elicitation_test.dart
+++ b/pkgs/dart_mcp/test/api/elicitation_test.dart
@@ -34,6 +34,110 @@ void main() {
       );
     });
 
+    test('a multi-select enum is a schema a client can be asked for', () {
+      // Both schemas the spec lists, see
+      // https://modelcontextprotocol.io/specification/2026-07-28/client/elicitation.
+      expect(
+        () => ElicitRequest.form(
+          message: 'Pick your colours',
+          requestedSchema: ObjectSchema(
+            properties: {
+              'bare': UntitledMultiSelectEnumSchema(
+                values: ['red', 'green'],
+                minItems: 1,
+              ),
+              'titled': TitledMultiSelectEnumSchema(
+                values: [
+                  EnumValueWithTitle(title: 'Red', constValue: '#FF0000'),
+                ],
+              ),
+            },
+          ),
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('an array that is not a multi-select enum is refused', () {
+      for (final property in [
+        // Items the client would have to type into, not choose from.
+        Schema.list(items: Schema.string()),
+        // No items at all, so nothing names the values.
+        Schema.list(),
+        // Values named, but the spec asks for strings.
+        Schema.fromMap({
+          'type': 'array',
+          'items': {
+            'type': 'number',
+            'enum': [1, 2],
+          },
+        }),
+        // The item type says string. The values are numbers.
+        Schema.fromMap({
+          'type': 'array',
+          'items': {
+            'type': 'string',
+            'enum': [1, 2],
+          },
+        }),
+        // Objects standing in for the strings.
+        Schema.fromMap({
+          'type': 'array',
+          'items': {
+            'type': 'string',
+            'enum': [
+              {'a': 1},
+            ],
+          },
+        }),
+        // One value where the spec asks for a list of them.
+        Schema.fromMap({
+          'type': 'array',
+          'items': {'type': 'string', 'enum': 'red'},
+        }),
+        // A titled entry pairs a const with a title. This one has no const.
+        Schema.fromMap({
+          'type': 'array',
+          'items': {
+            'anyOf': [
+              {'title': 'Red'},
+            ],
+          },
+        }),
+        // And this one has no title.
+        Schema.fromMap({
+          'type': 'array',
+          'items': {
+            'anyOf': [
+              {'const': '#FF0000'},
+            ],
+          },
+        }),
+        // A bare value in `anyOf` is not a titled entry at all.
+        Schema.fromMap({
+          'type': 'array',
+          'items': {
+            'anyOf': ['red'],
+          },
+        }),
+        // One entry sitting in `anyOf` where a list belongs.
+        Schema.fromMap({
+          'type': 'array',
+          'items': {
+            'anyOf': {'const': '#FF0000', 'title': 'Red'},
+          },
+        }),
+      ]) {
+        expect(
+          () => ElicitRequest.form(
+            message: 'Pick your colours',
+            requestedSchema: ObjectSchema(properties: {'freeform': property}),
+          ),
+          throwsA(isA<AssertionError>()),
+        );
+      }
+    }, testOn: '!exe');
+
     test('server can elicit information from client', () async {
       final elicitationCompleter = Completer<ElicitResult>();
       final environment = TestEnvironment(


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

The two multi-select enum shapes landed in #357, and the validator from #193 turned down every array, so a client answering one of our own schemas got refused.

The check now sits on `EnumSchema` and takes a JSON array, like the rest of the package does. A `Set` would just pass here and then fail at encoding. I built the fixture from the published schema instead of the package's own builders.
