### PR TITLE
cap request bodies in the Streamable HTTP handler

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -137,8 +137,8 @@
     before it reads the completed result.
 - Cap the request body in `handleStreamableHttpRequest` at
   `maxRequestBodyBytes`, 4 MiB by default, matching the TypeScript and Go SDKs.
-  Larger bodies get `413` and an invalid request error. Negative caps throw a
-  `RangeError`.
+  Larger bodies get `413` and an invalid request error. The same cap is the
+  discard budget, measured in stream chunks. Negative caps throw a `RangeError`.
 - Add `supportsFormElicitation` and `supportsUrlElicitation` for a server to
   ask before it sends. An empty `elicitation` object still means form, the way
   `elicitation` read before the split.

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -138,7 +138,8 @@
 - Cap the request body in `handleStreamableHttpRequest` at
   `maxRequestBodyBytes`, 4 MiB by default.
   Larger bodies get `413` and an invalid request error. The same cap is the
-  discard budget, measured in stream chunks. Negative caps throw a `RangeError`.
+  discard budget, measured in stream chunks. A client that has not finished
+  sending may not read the response. Negative caps throw a `RangeError`.
 - Add `supportsFormElicitation` and `supportsUrlElicitation` for a server to
   ask before it sends. An empty `elicitation` object still means form, the way
   `elicitation` read before the split.

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -138,8 +138,8 @@
 - Cap the request body in `handleStreamableHttpRequest` at
   `maxRequestBodyBytes`, 4 MiB by default.
   Larger bodies get `413` and an invalid request error. The same cap is the
-  discard budget, measured in stream chunks. A client that has not finished
-  sending may not read the response. Negative caps throw a `RangeError`.
+  discard budget. A client that has not finished sending may not read the
+  response. Negative caps throw a `RangeError`.
 - Add `supportsFormElicitation` and `supportsUrlElicitation` for a server to
   ask before it sends. An empty `elicitation` object still means form, the way
   `elicitation` read before the split.

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -137,8 +137,8 @@
     before it reads the completed result.
 - Cap the request body in `handleStreamableHttpRequest` at
   `maxRequestBodyBytes`, 4 MiB by default, matching the TypeScript and Go SDKs.
-  Larger bodies get `413` and an invalid request error, and the handler stops
-  reading at the cap. Negative caps throw a `RangeError`.
+  Larger bodies get `413` and an invalid request error. The same cap is the
+  discard budget, measured in stream chunks. Negative caps throw a `RangeError`.
 - Add `supportsFormElicitation` and `supportsUrlElicitation` for a server to
   ask before it sends. An empty `elicitation` object still means form, the way
   `elicitation` read before the split.

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -137,8 +137,8 @@
     before it reads the completed result.
 - Cap the request body in `handleStreamableHttpRequest` at
   `maxRequestBodyBytes`, 4 MiB by default, matching the TypeScript and Go SDKs.
-  Larger bodies get `413` and an invalid request error. The same cap is the
-  discard budget, measured in stream chunks. Negative caps throw a `RangeError`.
+  Larger bodies get `413` and an invalid request error, and the handler stops
+  reading at the cap. Negative caps throw a `RangeError`.
 - Add `supportsFormElicitation` and `supportsUrlElicitation` for a server to
   ask before it sends. An empty `elicitation` object still means form, the way
   `elicitation` read before the split.

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -136,7 +136,7 @@
     declares the wider return type, then checks `isInputRequired` and casts
     before it reads the completed result.
 - Cap the request body in `handleStreamableHttpRequest` at
-  `maxRequestBodyBytes`, 4 MiB by default, matching the TypeScript and Go SDKs.
+  `maxRequestBodyBytes`, 4 MiB by default.
   Larger bodies get `413` and an invalid request error. The same cap is the
   discard budget, measured in stream chunks. Negative caps throw a `RangeError`.
 - Add `supportsFormElicitation` and `supportsUrlElicitation` for a server to

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -135,6 +135,10 @@
     supertypes. A subclass or mixin overriding one of those three methods
     declares the wider return type, then checks `isInputRequired` and casts
     before it reads the completed result.
+- Cap the request body in `handleStreamableHttpRequest` at
+  `maxRequestBodyBytes`, 4 MiB by default, matching the TypeScript and Go SDKs.
+  Larger bodies get `413` and an invalid request error. Negative caps throw a
+  `RangeError`.
 - Add `supportsFormElicitation` and `supportsUrlElicitation` for a server to
   ask before it sends. An empty `elicitation` object still means form, the way
   `elicitation` read before the split.

--- a/pkgs/dart_mcp/example/streamable_http_server.dart
+++ b/pkgs/dart_mcp/example/streamable_http_server.dart
@@ -50,9 +50,9 @@ void main() async {
       return;
     }
 
-    // The handler leaves two more jobs to the host, and this example does
-    // neither: authenticating the caller, and bounding the size of the body it
-    // reads. A server reachable from anywhere but this machine needs both.
+    // The handler also leaves authentication to the host. This example does
+    // not authenticate the caller. A server reachable from anywhere but this
+    // machine needs it.
 
     // Every POST gets its own server: this protocol revision carries the client
     // context on the request instead of an `initialize` handshake, so there is

--- a/pkgs/dart_mcp/lib/src/server/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/src/server/streamable_http.dart
@@ -99,14 +99,14 @@ import 'server.dart';
 /// change produced by one request's server to reach another request's listen
 /// stream.
 ///
-/// A request body is capped at [maxRequestBodyBytes], 4 MiB by default like
-/// the TypeScript and Go SDKs. A body over the cap is answered with
-/// `413 Request Entity Too Large` and not parsed. The handler stops reading at
-/// the chunk that crosses the cap and never holds more than one chunk past it.
-/// It writes the 413 before it stops, since a response written after the read
-/// is cancelled never reaches the client. A client still sending when the
-/// connection closes may not get to read the 413. A body rejected by its media type is read only to this
-/// cap. A negative cap throws a [RangeError].
+/// A request body is capped at [maxRequestBodyBytes], 4 MiB by default like the
+/// TypeScript and Go SDKs. A body over the cap is answered with `413 Request
+/// Entity Too Large` and not parsed. The handler stops reading at the chunk
+/// that crosses the cap and never holds more than one chunk past it. It writes
+/// the 413 before it stops, since a response written after the read is
+/// cancelled never reaches the client. A client still sending when the
+/// connection closes may not get to read the 413. A body rejected by its media
+/// type is read only to this cap. A negative cap throws a [RangeError].
 Future<void> handleStreamableHttpRequest(
   HttpRequest request,
   MCPServerFactory serverFactory, {

--- a/pkgs/dart_mcp/lib/src/server/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/src/server/streamable_http.dart
@@ -101,12 +101,14 @@ import 'server.dart';
 ///
 /// A request body is capped at [maxRequestBodyBytes], 4 MiB by default like the
 /// TypeScript and Go SDKs. A body over the cap is answered with `413 Request
-/// Entity Too Large` and not parsed. The handler stops reading at the chunk
-/// that crosses the cap and never holds more than one chunk past it. It writes
-/// the 413 before it stops, since a response written after the read is
-/// cancelled never reaches the client. A client still sending when the
-/// connection closes may not get to read the 413. A body rejected by its media
-/// type is read only to this cap. A negative cap throws a [RangeError].
+/// Entity Too Large` and not parsed. It is still read, up to another
+/// [maxRequestBodyBytes], so that a body a little over the cap finishes and is
+/// answered on a connection that stays open. Past that the handler answers and
+/// stops reading, in that order: `dart:io` closes a connection as soon as a
+/// body it is still receiving is cancelled, and a response written after that
+/// never reaches the client. A client still sending when the connection closes
+/// may not get to read the 413. A body rejected by its media type is read the
+/// same way. A negative cap throws a [RangeError].
 Future<void> handleStreamableHttpRequest(
   HttpRequest request,
   MCPServerFactory serverFactory, {
@@ -147,8 +149,8 @@ Future<void> handleStreamableHttpRequest(
       null,
     );
     try {
-      // A body within the cap is read to its end. That keeps the connection
-      // open for the next request.
+      // A body that ends within the read is answered on a connection that
+      // stays open for the next request.
       if (await _readBody(
         request,
         maxRequestBodyBytes,
@@ -796,12 +798,14 @@ Future<void> _rejectTooLarge(HttpResponse response, int maxRequestBodyBytes) =>
 /// Reads the body of [request] while it fits in [cap] bytes, handing each
 /// chunk to [keep], and returns whether all of it did.
 ///
-/// A chunked body carries no length, so the count runs as chunks arrive. On
-/// the chunk that would cross the cap the read stops, after [reject] has
-/// written the response. That order matters. Leaving the loop cancels the
-/// subscription, `dart:io` closes a connection as soon as a body it is still
-/// receiving is cancelled, and a response written after that never reaches
-/// the socket.
+/// A chunked body carries no length, so the count runs as chunks arrive. A body
+/// over the cap is still read, up to another [cap] bytes, so that one a little
+/// over finishes and is answered on a connection that stays open. Past that the
+/// read stops, after [reject] has written the response. That order matters.
+/// Leaving the loop cancels the subscription, `dart:io` closes a connection as
+/// soon as a body it is still receiving is cancelled, and a response written
+/// after that never reaches the socket. [reject] is called once for a body over
+/// the cap, whichever way the read ends.
 Future<bool> _readBody(
   HttpRequest request,
   int cap, {
@@ -809,15 +813,24 @@ Future<bool> _readBody(
   required Future<void> Function() reject,
 }) async {
   var read = 0;
+  var discarded = 0;
+  var tooLarge = false;
   await for (final chunk in request) {
-    if (read + chunk.length > cap) {
+    if (!tooLarge && read + chunk.length <= cap) {
+      read += chunk.length;
+      keep?.call(chunk);
+      continue;
+    }
+    tooLarge = true;
+    discarded += chunk.length;
+    if (discarded >= cap) {
       await reject();
       return false;
     }
-    read += chunk.length;
-    keep?.call(chunk);
   }
-  return true;
+  if (!tooLarge) return true;
+  await reject();
+  return false;
 }
 
 /// Returns the single value of [name], or `null` if it is missing or was sent

--- a/pkgs/dart_mcp/lib/src/server/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/src/server/streamable_http.dart
@@ -103,9 +103,7 @@ import 'server.dart';
 /// over the cap is answered with `413 Request Entity Too Large` and not parsed.
 /// It is still read, up to another [maxRequestBodyBytes], so that a body a
 /// little over the cap finishes and is answered on a connection that stays
-/// open. Past that the handler answers and stops reading, in that order:
-/// `dart:io` closes a connection as soon as a body it is still receiving is
-/// cancelled, and a response written after that never reaches the client. A
+/// open. Past that the handler answers and stops reading, in that order. A
 /// client still sending when the connection closes may not get to read the 413.
 /// A body rejected by its media type is read the same way. A negative cap
 /// throws a [RangeError].
@@ -148,20 +146,21 @@ Future<void> handleStreamableHttpRequest(
       ),
       null,
     );
+    final bool fits;
     try {
       // A body that ends within the read is answered on a connection that
       // stays open for the next request.
-      if (await _readBody(
+      fits = await _readBody(
         request,
         maxRequestBodyBytes,
         reject: rejectMediaType,
-      )) {
-        await rejectMediaType();
-      }
+      );
     } on IOException {
       // The client disconnected before its body arrived. There is no
       // response left to write.
+      return;
     }
+    if (fits) await rejectMediaType();
     return;
   }
 

--- a/pkgs/dart_mcp/lib/src/server/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/src/server/streamable_http.dart
@@ -100,10 +100,12 @@ import 'server.dart';
 /// stream.
 ///
 /// A single request body is capped at [maxRequestBodyBytes]. A larger body is
-/// answered with `413 Request Entity Too Large` and never parsed. It is still
-/// read to its end first, so the cap bounds what the handler holds and not
-/// what crosses the wire. The default is the 4 MiB the TypeScript and Go SDKs
-/// also default to. A negative cap throws a [RangeError].
+/// answered with `413 Request Entity Too Large` and never parsed. To let a body
+/// just over the limit finish sending and receive the response, the handler
+/// discards chunks until their total reaches another [maxRequestBodyBytes],
+/// then stops reading. The default is the 4 MiB the TypeScript and Go SDKs also
+/// default to. A body rejected by its media type is also read only to this cap.
+/// A negative cap throws a [RangeError].
 Future<void> handleStreamableHttpRequest(
   HttpRequest request,
   MCPServerFactory serverFactory, {
@@ -135,7 +137,13 @@ Future<void> handleStreamableHttpRequest(
   }
   if (contentType?.mimeType != ContentType.json.mimeType) {
     try {
-      await request.drain<void>();
+      if (maxRequestBodyBytes > 0) {
+        var discardedBytes = 0;
+        await for (final chunk in request) {
+          discardedBytes += chunk.length;
+          if (discardedBytes >= maxRequestBodyBytes) break;
+        }
+      }
     } on IOException {
       // The client disconnected before its body arrived. There is no
       // response left to write.
@@ -159,13 +167,19 @@ Future<void> handleStreamableHttpRequest(
     // length, so nothing can bound it before the read.
     final bytes = BytesBuilder(copy: false);
     var tooLarge = false;
+    var discardedBytes = 0;
     await for (final chunk in request) {
-      if (tooLarge) continue;
+      if (tooLarge) {
+        discardedBytes += chunk.length;
+        if (discardedBytes >= maxRequestBodyBytes) break;
+        continue;
+      }
       if (bytes.length + chunk.length > maxRequestBodyBytes) {
-        // The rest of the body is still read and dropped as it arrives.
-        // Answering while the client is still sending reaches a connection it
-        // sees reset instead, so the 413 never lands.
+        // This drain lets a body just over the limit finish before the 413 is
+        // written. The configured limit also sets when draining stops.
         tooLarge = true;
+        discardedBytes = chunk.length;
+        if (discardedBytes >= maxRequestBodyBytes) break;
         continue;
       }
       bytes.add(chunk);

--- a/pkgs/dart_mcp/lib/src/server/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/src/server/streamable_http.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
 import 'package:json_rpc_2/error_code.dart' as error_code;
@@ -44,11 +45,11 @@ import 'server.dart';
 ///
 /// Notifications are acknowledged with `202 Accepted` and not dispatched,
 /// since this protocol revision defines no client-to-server notifications
-/// over HTTP. This handler reads the whole request body into memory. It does
-/// not read the `Origin` header. The specification requires a server to
-/// validate that header and answer with 403: the check needs deployment
-/// knowledge this handler does not have, so it belongs to the embedding
-/// HTTP server, along with authentication and request size limits.
+/// over HTTP. This handler reads a request body into memory, and caps it at
+/// [maxRequestBodyBytes]. It does not read the `Origin` header. The
+/// specification requires a server to validate that header and answer with
+/// 403. The check needs deployment knowledge this handler does not have, so it
+/// belongs to the embedding HTTP server, along with authentication.
 ///
 /// Responses produced by the dispatched server are written unchanged, so an
 /// error a request handler throws reaches the client with whatever payload
@@ -97,13 +98,21 @@ import 'server.dart';
 /// stream to every request and add [onNotification] values to it, allowing a
 /// change produced by one request's server to reach another request's listen
 /// stream.
+///
+/// A single request body is capped at [maxRequestBodyBytes]. A larger body is
+/// answered with `413 Request Entity Too Large` and never parsed. It is still
+/// read to its end first, so the cap bounds what the handler holds and not
+/// what crosses the wire. The default is the 4 MiB the TypeScript and Go SDKs
+/// also default to. A negative cap throws a [RangeError].
 Future<void> handleStreamableHttpRequest(
   HttpRequest request,
   MCPServerFactory serverFactory, {
   void Function(Map<String, Object?> notification)? onNotification,
   Stream<Map<String, Object?>>? subscriptionNotifications,
   Duration listenKeepAliveInterval = const Duration(seconds: 15),
+  int maxRequestBodyBytes = 4 * 1024 * 1024,
 }) async {
+  RangeError.checkNotNegative(maxRequestBodyBytes, 'maxRequestBodyBytes');
   final response = request.response;
   if (request.method != 'POST') {
     response
@@ -146,7 +155,23 @@ Future<void> handleStreamableHttpRequest(
   final Object? decoded;
   String? body;
   try {
-    body = await utf8.decodeStream(request);
+    // The counter bounds what actually arrives. A chunked body carries no
+    // length, so nothing can bound it before the read.
+    final bytes = BytesBuilder(copy: false);
+    var tooLarge = false;
+    await for (final chunk in request) {
+      if (tooLarge) continue;
+      if (bytes.length + chunk.length > maxRequestBodyBytes) {
+        // The rest of the body is still read and dropped as it arrives.
+        // Answering while the client is still sending reaches a connection it
+        // sees reset instead, so the 413 never lands.
+        tooLarge = true;
+        continue;
+      }
+      bytes.add(chunk);
+    }
+    if (tooLarge) return await _rejectTooLarge(response, maxRequestBodyBytes);
+    body = utf8.decode(bytes.takeBytes());
     decoded = jsonDecode(body);
   } on FormatException catch (e) {
     return _reject(
@@ -746,6 +771,24 @@ Future<void> _reject(
     ..write(jsonEncode(exception.serialize(origin)));
   await response.close();
 }
+
+/// Refuses a body over [maxRequestBodyBytes] with `413`.
+///
+/// The specification names no status for an oversized body and allocates no
+/// error code for one. 413 is what the TypeScript and Go SDKs answer with.
+/// The code is the one this transport already refuses a batch with.
+/// TypeScript pairs its 413 with `-32000` instead, which here is
+/// `SERVER_ERROR`, a code [_statusFor] maps to 500.
+Future<void> _rejectTooLarge(HttpResponse response, int maxRequestBodyBytes) =>
+    _reject(
+      response,
+      HttpStatus.requestEntityTooLarge,
+      RpcException(
+        error_code.INVALID_REQUEST,
+        'The request body must not exceed $maxRequestBodyBytes bytes',
+      ),
+      null,
+    );
 
 /// Returns the single value of [name], or `null` if it is missing or was sent
 /// more than once as separate values.

--- a/pkgs/dart_mcp/lib/src/server/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/src/server/streamable_http.dart
@@ -99,13 +99,14 @@ import 'server.dart';
 /// change produced by one request's server to reach another request's listen
 /// stream.
 ///
-/// A single request body is capped at [maxRequestBodyBytes]. A larger body is
-/// answered with `413 Request Entity Too Large` and never parsed. To let a body
-/// just over the limit finish sending and receive the response, the handler
-/// discards chunks until their total reaches another [maxRequestBodyBytes],
-/// then stops reading. The default is the 4 MiB the TypeScript and Go SDKs also
-/// default to. A body rejected by its media type is also read only to this cap.
-/// A negative cap throws a [RangeError].
+/// A request body is capped at [maxRequestBodyBytes], 4 MiB by default like
+/// the TypeScript and Go SDKs. A body over the cap is answered with
+/// `413 Request Entity Too Large` and not parsed. The handler stops reading at
+/// the chunk that crosses the cap and never holds more than one chunk past it.
+/// It writes the 413 before it stops, since a response written after the read
+/// is cancelled never reaches the client. A client still sending when the
+/// connection closes may not get to read the 413. A body rejected by its media type is read only to this
+/// cap. A negative cap throws a [RangeError].
 Future<void> handleStreamableHttpRequest(
   HttpRequest request,
   MCPServerFactory serverFactory, {
@@ -136,20 +137,7 @@ Future<void> handleStreamableHttpRequest(
     contentType = null;
   }
   if (contentType?.mimeType != ContentType.json.mimeType) {
-    try {
-      if (maxRequestBodyBytes > 0) {
-        var discardedBytes = 0;
-        await for (final chunk in request) {
-          discardedBytes += chunk.length;
-          if (discardedBytes >= maxRequestBodyBytes) break;
-        }
-      }
-    } on IOException {
-      // The client disconnected before its body arrived. There is no
-      // response left to write.
-      return;
-    }
-    return _reject(
+    Future<void> rejectMediaType() => _reject(
       response,
       HttpStatus.unsupportedMediaType,
       RpcException(
@@ -158,33 +146,34 @@ Future<void> handleStreamableHttpRequest(
       ),
       null,
     );
+    try {
+      // A body within the cap is read to its end. That keeps the connection
+      // open for the next request.
+      if (await _readBody(
+        request,
+        maxRequestBodyBytes,
+        reject: rejectMediaType,
+      )) {
+        await rejectMediaType();
+      }
+    } on IOException {
+      // The client disconnected before its body arrived. There is no
+      // response left to write.
+    }
+    return;
   }
 
   final Object? decoded;
   String? body;
   try {
-    // The counter bounds what actually arrives. A chunked body carries no
-    // length, so nothing can bound it before the read.
     final bytes = BytesBuilder(copy: false);
-    var tooLarge = false;
-    var discardedBytes = 0;
-    await for (final chunk in request) {
-      if (tooLarge) {
-        discardedBytes += chunk.length;
-        if (discardedBytes >= maxRequestBodyBytes) break;
-        continue;
-      }
-      if (bytes.length + chunk.length > maxRequestBodyBytes) {
-        // This drain lets a body just over the limit finish before the 413 is
-        // written. The configured limit also sets when draining stops.
-        tooLarge = true;
-        discardedBytes = chunk.length;
-        if (discardedBytes >= maxRequestBodyBytes) break;
-        continue;
-      }
-      bytes.add(chunk);
-    }
-    if (tooLarge) return await _rejectTooLarge(response, maxRequestBodyBytes);
+    final fits = await _readBody(
+      request,
+      maxRequestBodyBytes,
+      keep: bytes.add,
+      reject: () => _rejectTooLarge(response, maxRequestBodyBytes),
+    );
+    if (!fits) return;
     body = utf8.decode(bytes.takeBytes());
     decoded = jsonDecode(body);
   } on FormatException catch (e) {
@@ -803,6 +792,33 @@ Future<void> _rejectTooLarge(HttpResponse response, int maxRequestBodyBytes) =>
       ),
       null,
     );
+
+/// Reads the body of [request] while it fits in [cap] bytes, handing each
+/// chunk to [keep], and returns whether all of it did.
+///
+/// A chunked body carries no length, so the count runs as chunks arrive. On
+/// the chunk that would cross the cap the read stops, after [reject] has
+/// written the response. That order matters. Leaving the loop cancels the
+/// subscription, `dart:io` closes a connection as soon as a body it is still
+/// receiving is cancelled, and a response written after that never reaches
+/// the socket.
+Future<bool> _readBody(
+  HttpRequest request,
+  int cap, {
+  void Function(Uint8List chunk)? keep,
+  required Future<void> Function() reject,
+}) async {
+  var read = 0;
+  await for (final chunk in request) {
+    if (read + chunk.length > cap) {
+      await reject();
+      return false;
+    }
+    read += chunk.length;
+    keep?.call(chunk);
+  }
+  return true;
+}
 
 /// Returns the single value of [name], or `null` if it is missing or was sent
 /// more than once as separate values.

--- a/pkgs/dart_mcp/lib/src/server/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/src/server/streamable_http.dart
@@ -99,16 +99,16 @@ import 'server.dart';
 /// change produced by one request's server to reach another request's listen
 /// stream.
 ///
-/// A request body is capped at [maxRequestBodyBytes], 4 MiB by default like the
-/// TypeScript and Go SDKs. A body over the cap is answered with `413 Request
-/// Entity Too Large` and not parsed. It is still read, up to another
-/// [maxRequestBodyBytes], so that a body a little over the cap finishes and is
-/// answered on a connection that stays open. Past that the handler answers and
-/// stops reading, in that order: `dart:io` closes a connection as soon as a
-/// body it is still receiving is cancelled, and a response written after that
-/// never reaches the client. A client still sending when the connection closes
-/// may not get to read the 413. A body rejected by its media type is read the
-/// same way. A negative cap throws a [RangeError].
+/// A request body is capped at [maxRequestBodyBytes], 4 MiB by default. A body
+/// over the cap is answered with `413 Request Entity Too Large` and not parsed.
+/// It is still read, up to another [maxRequestBodyBytes], so that a body a
+/// little over the cap finishes and is answered on a connection that stays
+/// open. Past that the handler answers and stops reading, in that order:
+/// `dart:io` closes a connection as soon as a body it is still receiving is
+/// cancelled, and a response written after that never reaches the client. A
+/// client still sending when the connection closes may not get to read the 413.
+/// A body rejected by its media type is read the same way. A negative cap
+/// throws a [RangeError].
 Future<void> handleStreamableHttpRequest(
   HttpRequest request,
   MCPServerFactory serverFactory, {
@@ -780,10 +780,8 @@ Future<void> _reject(
 /// Refuses a body over [maxRequestBodyBytes] with `413`.
 ///
 /// The specification names no status for an oversized body and allocates no
-/// error code for one. 413 is what the TypeScript and Go SDKs answer with.
-/// The code is the one this transport already refuses a batch with.
-/// TypeScript pairs its 413 with `-32000` instead, which here is
-/// `SERVER_ERROR`, a code [_statusFor] maps to 500.
+/// error code for one. The code is the one this transport already refuses a
+/// batch with.
 Future<void> _rejectTooLarge(HttpResponse response, int maxRequestBodyBytes) =>
     _reject(
       response,

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -3831,6 +3831,23 @@ void main() {
       expect(errorCode(text), error_code.INVALID_REQUEST);
     });
 
+    test('answers a late body of the wrong media type', () async {
+      // The media type branch reads through the same helper, so it meets the
+      // same read boundary. Pinning it here keeps the ordering from being lost
+      // if that branch ever stops sharing the helper.
+      final (status, text) = await sendRaw([
+        utf8.encode(
+          rawHead(
+            contentLength: overTheLimit.length,
+            contentType: 'text/plain',
+          ),
+        ),
+        overTheLimit,
+      ], between: (_) => headersSeen.future);
+      expect(status, 415);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
+    });
+
     test('reads a smaller overflow to its end', () async {
       const limit = 1024 * 1024;
       customLimit = limit;

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -8,6 +8,7 @@ library;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:dart_mcp/server.dart';
 import 'package:dart_mcp/src/utils/constants.dart';
@@ -3566,6 +3567,8 @@ void main() {
     late Uri cappedUri;
     late HttpClient client;
     late int? customLimit;
+    late List<Future<void>> handledRequests;
+    late List<_CountingHttpRequest> receivedRequests;
 
     /// The `Content-Length` of each request the capped server received, or
     /// -1 for a chunked one.
@@ -3577,6 +3580,8 @@ void main() {
 
     setUp(() async {
       declaredLengths = [];
+      handledRequests = [];
+      receivedRequests = [];
       customLimit = atTheLimit.length;
       capped = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
       addTearDown(() => capped.close(force: true));
@@ -3584,15 +3589,24 @@ void main() {
       /// Records how [request] was framed before the handler consumes it.
       Future<void> serve(HttpRequest request) {
         declaredLengths.add(request.contentLength);
+        final countedRequest = _CountingHttpRequest(request);
+        receivedRequests.add(countedRequest);
         final limit = customLimit;
         if (limit == null) {
-          return handleStreamableHttpRequest(request, _HttpTestServer.new);
+          final handled = handleStreamableHttpRequest(
+            countedRequest,
+            _HttpTestServer.new,
+          );
+          handledRequests.add(handled);
+          return handled;
         }
-        return handleStreamableHttpRequest(
-          request,
+        final handled = handleStreamableHttpRequest(
+          countedRequest,
           _HttpTestServer.new,
           maxRequestBodyBytes: limit,
         );
+        handledRequests.add(handled);
+        return handled;
       }
 
       capped.listen(serve);
@@ -3707,25 +3721,58 @@ void main() {
       expect(errorCode(text), error_code.INVALID_REQUEST);
     });
 
-    test('rejects a chunked body larger than the socket buffers', () async {
-      // The bodies above fit in the socket buffers. This one does not. The
-      // client is still sending when the handler answers, and the rest of
-      // the body has to be read for the answer to arrive at all. 512 KiB
-      // still fit on the machine this was measured on, and 8 MiB did not.
-      final request = await client.postUrl(cappedUri);
-      headers(listTools).forEach(request.headers.set);
+    test('bounds the drain and preserves 413 for a smaller overflow', () async {
+      const limit = 1024 * 1024;
       final chunk = utf8.encode('x' * (64 * 1024));
-      for (var sent = 0; sent < 8 * 1024 * 1024; sent += chunk.length) {
-        request.add(chunk);
-        await request.flush();
+      customLimit = limit;
+
+      Future<Object> postBytes(
+        int length, {
+        String contentType = 'application/json',
+      }) async {
+        final request = await client.postUrl(cappedUri);
+        final requestHeaders = headers(listTools);
+        requestHeaders['Content-Type'] = contentType;
+        requestHeaders.forEach(request.headers.set);
+        try {
+          for (var sent = 0; sent < length; sent += chunk.length) {
+            request.add(chunk);
+            await request.flush();
+          }
+          final response = await request.close();
+          await response.drain<void>();
+          return response.statusCode;
+        } on IOException catch (error) {
+          return error;
+        }
       }
-      final response = await request.close();
-      expect(declaredLengths.single, -1);
-      expect(response.statusCode, 413);
+
+      final nearbyOutcome = await postBytes(limit + limit ~/ 2);
+      await handledRequests[0];
+      expect(nearbyOutcome, 413);
+      expect(receivedRequests[0].bytesRead, limit + limit ~/ 2);
+
+      final distantOutcome = await postBytes(3 * limit);
+      await handledRequests[1];
+      expect(distantOutcome, anyOf(413, isA<IOException>()));
       expect(
-        errorCode(await utf8.decodeStream(response)),
-        error_code.INVALID_REQUEST,
+        receivedRequests[1].bytesRead,
+        inInclusiveRange(2 * limit, 2 * limit + chunk.length),
       );
+      expect(receivedRequests[1].bytesRead, lessThan(3 * limit));
+
+      final mediaTypeOutcome = await postBytes(
+        3 * limit,
+        contentType: 'text/plain',
+      );
+      await handledRequests[2];
+      expect(mediaTypeOutcome, anyOf(400, isA<IOException>()));
+      expect(
+        receivedRequests[2].bytesRead,
+        inInclusiveRange(limit, limit + chunk.length),
+      );
+      expect(receivedRequests[2].bytesRead, lessThan(3 * limit));
+      expect(declaredLengths, everyElement(-1));
     });
 
     test('throws on a negative cap', () async {
@@ -4393,6 +4440,43 @@ void main() {
       expect(swallowed, isNotEmpty);
     });
   });
+}
+
+final class _CountingHttpRequest extends Stream<Uint8List>
+    implements HttpRequest {
+  _CountingHttpRequest(this._inner);
+
+  final HttpRequest _inner;
+  int bytesRead = 0;
+
+  @override
+  HttpHeaders get headers => _inner.headers;
+
+  @override
+  String get method => _inner.method;
+
+  @override
+  HttpResponse get response => _inner.response;
+
+  @override
+  StreamSubscription<Uint8List> listen(
+    void Function(Uint8List)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) => _inner.listen(
+    (chunk) {
+      bytesRead += chunk.length;
+      onData?.call(chunk);
+    },
+    onError: onError,
+    onDone: onDone,
+    cancelOnError: cancelOnError,
+  );
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnsupportedError('${invocation.memberName}');
 }
 
 /// Held by `test/notify-then-wait` until a test releases it.

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -3570,18 +3570,22 @@ void main() {
     late List<Future<void>> handledRequests;
     late List<_CountingHttpRequest> receivedRequests;
 
+    /// Completes once the capped server has parsed a request's headers, which
+    /// is before any of its body is read.
+    late Completer<void> headersSeen;
+
     /// The `Content-Length` of each request the capped server received, or
     /// -1 for a chunked one.
     ///
     /// The cap has to hold over both framings, so the tests below cover
-    /// both. Each checks the framing it actually got, without assuming
-    /// [HttpClient] picked the intended one.
+    /// both. Each checks the framing it actually got.
     late List<int> declaredLengths;
 
     setUp(() async {
       declaredLengths = [];
       handledRequests = [];
       receivedRequests = [];
+      headersSeen = Completer<void>();
       customLimit = atTheLimit.length;
       capped = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
       addTearDown(() => capped.close(force: true));
@@ -3589,22 +3593,21 @@ void main() {
       /// Records how [request] was framed before the handler consumes it.
       Future<void> serve(HttpRequest request) {
         declaredLengths.add(request.contentLength);
+        if (!headersSeen.isCompleted) headersSeen.complete();
         final countedRequest = _CountingHttpRequest(request);
         receivedRequests.add(countedRequest);
         final limit = customLimit;
-        if (limit == null) {
-          final handled = handleStreamableHttpRequest(
-            countedRequest,
-            _HttpTestServer.new,
-          );
-          handledRequests.add(handled);
-          return handled;
-        }
-        final handled = handleStreamableHttpRequest(
-          countedRequest,
-          _HttpTestServer.new,
-          maxRequestBodyBytes: limit,
-        );
+        final handled =
+            limit == null
+                ? handleStreamableHttpRequest(
+                  countedRequest,
+                  _HttpTestServer.new,
+                )
+                : handleStreamableHttpRequest(
+                  countedRequest,
+                  _HttpTestServer.new,
+                  maxRequestBodyBytes: limit,
+                );
         handledRequests.add(handled);
         return handled;
       }
@@ -3628,9 +3631,6 @@ void main() {
 
     /// Posts [chunks] as one chunked body, flushing between them so that
     /// each one reaches the handler on its own.
-    ///
-    /// Chunked is the framing an embedder cannot bound ahead of the handler,
-    /// and it carries no length however many chunks it is sent in.
     Future<(int, String)> postChunks(List<List<int>> chunks) async {
       final request = await client.postUrl(cappedUri);
       headers(listTools).forEach(request.headers.set);
@@ -3640,6 +3640,92 @@ void main() {
       }
       final response = await request.close();
       return (response.statusCode, await utf8.decodeStream(response));
+    }
+
+    /// Posts [length] bytes of [contentType] in flushed 64 KiB pieces and
+    /// returns the status code, or the [IOException] that ended the exchange.
+    ///
+    /// The handler answers a body over the cap while the client may still be
+    /// sending, and the server then closes a connection whose body it never
+    /// finished receiving. Whether the client reads the response before it
+    /// runs into that close is up to its TCP stack, so callers accept either.
+    Future<Object> postFlushed(
+      int length, {
+      String contentType = 'application/json',
+    }) async {
+      final piece = Uint8List(64 * 1024)..fillRange(0, 64 * 1024, 0x78);
+      final request = await client.postUrl(cappedUri);
+      final requestHeaders = headers(listTools);
+      requestHeaders['Content-Type'] = contentType;
+      requestHeaders.forEach(request.headers.set);
+      try {
+        for (var sent = 0; sent < length; sent += piece.length) {
+          request.add(piece);
+          await request.flush();
+        }
+        final response = await request.close();
+        await response.drain<void>();
+        return response.statusCode;
+      } on IOException catch (error) {
+        return error;
+      }
+    }
+
+    /// The request line and headers of a raw POST to the capped server. It
+    /// asks for `Connection: close`. The response then ends with the
+    /// connection, and [sendRaw] reads to the end of it.
+    String rawHead({int? contentLength}) {
+      final head = StringBuffer(
+        'POST /mcp HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n',
+      );
+      headers(
+        listTools,
+      ).forEach((name, value) => head.write('$name: $value\r\n'));
+      head.write(
+        contentLength == null
+            ? 'Transfer-Encoding: chunked\r\n'
+            : 'Content-Length: $contentLength\r\n',
+      );
+      return '$head\r\n';
+    }
+
+    /// [data] framed as one chunk of a chunked body.
+    List<int> chunk(List<int> data) => [
+      ...utf8.encode('${data.length.toRadixString(16)}\r\n'),
+      ...data,
+      ...utf8.encode('\r\n'),
+    ];
+    final lastChunk = utf8.encode('0\r\n\r\n');
+
+    /// Writes [segments] to the capped server one write at a time, awaiting
+    /// [between] after each but the last, and returns the status code and
+    /// JSON body of the response.
+    ///
+    /// A socket puts the split between writes where the test wants it.
+    /// [HttpClient] decides that on its own, and not the same way on every
+    /// platform.
+    Future<(int, String)> sendRaw(
+      List<List<int>> segments, {
+      Future<void> Function()? between,
+    }) async {
+      final socket = await Socket.connect(capped.address, capped.port);
+      final received = socket.fold(
+        <int>[],
+        (bytes, piece) => bytes..addAll(piece),
+      );
+      for (var i = 0; i < segments.length; i++) {
+        socket.add(segments[i]);
+        await socket.flush();
+        if (between != null && i < segments.length - 1) await between();
+      }
+      final response = utf8.decode(await received);
+      socket.destroy();
+      if (!response.startsWith('HTTP/1.1 ')) {
+        fail(
+          'The connection closed without a response: ${jsonEncode(response)}',
+        );
+      }
+      return (int.parse(response.split(' ')[1]), jsonBody(response));
     }
 
     test('serves a body at the limit', () async {
@@ -3652,24 +3738,27 @@ void main() {
     test('uses the default 4 MiB limit', () async {
       customLimit = null;
       final belowDefault = bodyNearDefault(-1024);
-      final aboveDefault = bodyNearDefault(1024);
-
       expect(belowDefault.length, lessThan(defaultLimit));
       final (acceptedStatus, acceptedText) = await postDeclared(belowDefault);
       expect(acceptedStatus, 200);
       expect(errorCode(acceptedText), isNull);
 
+      final aboveDefault = bodyNearDefault(1024);
       expect(aboveDefault.length, greaterThan(defaultLimit));
-      final (rejectedStatus, rejectedText) = await postDeclared(aboveDefault);
-      expect(rejectedStatus, 413);
-      expect(errorCode(rejectedText), error_code.INVALID_REQUEST);
-    });
-
-    test('applies a smaller custom limit', () async {
-      customLimit = atTheLimit.length;
-      final (status, text) = await postDeclared(overTheLimit);
-      expect(status, 413);
-      expect(errorCode(text), error_code.INVALID_REQUEST);
+      Object rejected;
+      try {
+        rejected = (await postDeclared(aboveDefault)).$1;
+      } on IOException catch (error) {
+        rejected = error;
+      }
+      await handledRequests[1];
+      expect(receivedRequests[1].response.statusCode, 413);
+      expect(
+        receivedRequests[1].readBeforeLastChunk,
+        lessThanOrEqualTo(defaultLimit),
+      );
+      expect(receivedRequests[1].bytesRead, greaterThan(defaultLimit));
+      expect(rejected, anyOf(413, isA<IOException>()));
     });
 
     test('applies a larger custom limit', () async {
@@ -3681,8 +3770,13 @@ void main() {
     });
 
     test('rejects a declared body over the limit with 413', () async {
-      final (status, text) = await postDeclared(overTheLimit);
-      expect(declaredLengths.single, greaterThan(atTheLimit.length));
+      final (status, text) = await sendRaw([
+        [
+          ...utf8.encode(rawHead(contentLength: overTheLimit.length)),
+          ...overTheLimit,
+        ],
+      ]);
+      expect(declaredLengths.single, overTheLimit.length);
       expect(status, 413);
       expect(errorCode(text), error_code.INVALID_REQUEST);
       expect(
@@ -3694,7 +3788,9 @@ void main() {
     });
 
     test('rejects a chunked body over the limit with 413', () async {
-      final (status, text) = await postChunks([overTheLimit]);
+      final (status, text) = await sendRaw([
+        [...utf8.encode(rawHead()), ...chunk(overTheLimit), ...lastChunk],
+      ]);
       expect(declaredLengths.single, -1);
       expect(status, 413);
       expect(errorCode(text), error_code.INVALID_REQUEST);
@@ -3715,64 +3811,59 @@ void main() {
     test('rejects chunks that only exceed the limit together', () async {
       // Neither of these is over the cap on its own, so the counter has to
       // measure the body and not the chunk it is reading.
-      final (status, text) = await postChunks([atTheLimit, atTheLimit]);
+      final (status, text) = await sendRaw([
+        [
+          ...utf8.encode(rawHead()),
+          ...chunk(atTheLimit),
+          ...chunk(atTheLimit),
+          ...lastChunk,
+        ],
+      ]);
       expect(declaredLengths.single, -1);
       expect(status, 413);
       expect(errorCode(text), error_code.INVALID_REQUEST);
     });
 
-    test('bounds the drain and preserves 413 for a smaller overflow', () async {
+    test('answers a body that arrives after its headers', () async {
+      // When the headers came in an earlier read, dart:io runs the handler's
+      // loop body inside the read that delivers the chunk, before it has seen
+      // the end of the body. Cancelling the body there closes the connection
+      // at once and drops a response written afterwards, so the 413 has to be
+      // written before the loop is left. A single write of the whole request
+      // never takes that path.
+      final (status, text) = await sendRaw([
+        utf8.encode(rawHead(contentLength: overTheLimit.length)),
+        overTheLimit,
+      ], between: () => headersSeen.future);
+      expect(status, 413);
+      expect(errorCode(text), error_code.INVALID_REQUEST);
+    });
+
+    test('stops reading a JSON body at the limit', () async {
       const limit = 1024 * 1024;
-      final chunk = utf8.encode('x' * (64 * 1024));
       customLimit = limit;
+      final outcome = await postFlushed(3 * limit);
+      await handledRequests.single;
+      final received = receivedRequests.single;
+      expect(received.response.statusCode, 413);
+      // Everything the handler kept fits under the cap, and the chunk that
+      // crossed it is the last one it read, however much more was sent.
+      expect(received.readBeforeLastChunk, lessThanOrEqualTo(limit));
+      expect(received.bytesRead, greaterThan(limit));
+      expect(outcome, anyOf(413, isA<IOException>()));
+      expect(declaredLengths.single, -1);
+    });
 
-      Future<Object> postBytes(
-        int length, {
-        String contentType = 'application/json',
-      }) async {
-        final request = await client.postUrl(cappedUri);
-        final requestHeaders = headers(listTools);
-        requestHeaders['Content-Type'] = contentType;
-        requestHeaders.forEach(request.headers.set);
-        try {
-          for (var sent = 0; sent < length; sent += chunk.length) {
-            request.add(chunk);
-            await request.flush();
-          }
-          final response = await request.close();
-          await response.drain<void>();
-          return response.statusCode;
-        } on IOException catch (error) {
-          return error;
-        }
-      }
-
-      final nearbyOutcome = await postBytes(limit + limit ~/ 2);
-      await handledRequests[0];
-      expect(nearbyOutcome, 413);
-      expect(receivedRequests[0].bytesRead, limit + limit ~/ 2);
-
-      final distantOutcome = await postBytes(3 * limit);
-      await handledRequests[1];
-      expect(distantOutcome, anyOf(413, isA<IOException>()));
-      expect(
-        receivedRequests[1].bytesRead,
-        inInclusiveRange(2 * limit, 2 * limit + chunk.length),
-      );
-      expect(receivedRequests[1].bytesRead, lessThan(3 * limit));
-
-      final mediaTypeOutcome = await postBytes(
-        3 * limit,
-        contentType: 'text/plain',
-      );
-      await handledRequests[2];
-      expect(mediaTypeOutcome, anyOf(400, isA<IOException>()));
-      expect(
-        receivedRequests[2].bytesRead,
-        inInclusiveRange(limit, limit + chunk.length),
-      );
-      expect(receivedRequests[2].bytesRead, lessThan(3 * limit));
-      expect(declaredLengths, everyElement(-1));
+    test('reads a body of the wrong media type only to the limit', () async {
+      const limit = 1024 * 1024;
+      customLimit = limit;
+      final outcome = await postFlushed(3 * limit, contentType: 'text/plain');
+      await handledRequests.single;
+      final received = receivedRequests.single;
+      expect(received.response.statusCode, 415);
+      expect(received.readBeforeLastChunk, lessThanOrEqualTo(limit));
+      expect(received.bytesRead, greaterThan(limit));
+      expect(outcome, anyOf(415, isA<IOException>()));
     });
 
     test('throws on a negative cap', () async {
@@ -4447,7 +4538,15 @@ final class _CountingHttpRequest extends Stream<Uint8List>
   _CountingHttpRequest(this._inner);
 
   final HttpRequest _inner;
-  int bytesRead = 0;
+
+  /// The length of each chunk the handler received, in order.
+  final chunkLengths = <int>[];
+
+  int get bytesRead => chunkLengths.fold(0, (sum, length) => sum + length);
+
+  /// What the handler read before its last chunk. A handler that stops on the
+  /// chunk crossing its cap kept exactly this much.
+  int get readBeforeLastChunk => bytesRead - chunkLengths.last;
 
   @override
   HttpHeaders get headers => _inner.headers;
@@ -4466,7 +4565,7 @@ final class _CountingHttpRequest extends Stream<Uint8List>
     bool? cancelOnError,
   }) => _inner.listen(
     (chunk) {
-      bytesRead += chunk.length;
+      chunkLengths.add(chunk.length);
       onData?.call(chunk);
     },
     onError: onError,

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -3543,6 +3543,223 @@ void main() {
     });
   });
 
+  group('request body limit', () {
+    const defaultLimit = 4 * 1024 * 1024;
+
+    /// A well-formed `tools/list` body, and one padded past it.
+    ///
+    /// The cap is set to [atTheLimit]'s own length below. That puts the first
+    /// test on the boundary itself, and keeps the others just past it instead
+    /// of a megabyte past.
+    final atTheLimit = utf8.encode(jsonEncode(body(listTools)));
+    final overTheLimit = utf8.encode(
+      jsonEncode(body(listTools, params: {'pad': 'x' * 64})),
+    );
+
+    List<int> bodyNearDefault(int difference) => utf8.encode(
+      jsonEncode(
+        body(listTools, params: {'pad': 'x' * (defaultLimit + difference)}),
+      ),
+    );
+
+    late HttpServer capped;
+    late Uri cappedUri;
+    late HttpClient client;
+    late int? customLimit;
+
+    /// The `Content-Length` of each request the capped server received, or
+    /// -1 for a chunked one.
+    ///
+    /// The cap has to hold over both framings, so the tests below cover
+    /// both. Each checks the framing it actually got, without assuming
+    /// [HttpClient] picked the intended one.
+    late List<int> declaredLengths;
+
+    setUp(() async {
+      declaredLengths = [];
+      customLimit = atTheLimit.length;
+      capped = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => capped.close(force: true));
+
+      /// Records how [request] was framed before the handler consumes it.
+      Future<void> serve(HttpRequest request) {
+        declaredLengths.add(request.contentLength);
+        final limit = customLimit;
+        if (limit == null) {
+          return handleStreamableHttpRequest(request, _HttpTestServer.new);
+        }
+        return handleStreamableHttpRequest(
+          request,
+          _HttpTestServer.new,
+          maxRequestBodyBytes: limit,
+        );
+      }
+
+      capped.listen(serve);
+      cappedUri = Uri.http('${capped.address.host}:${capped.port}', '/mcp');
+      client = HttpClient();
+      addTearDown(client.close);
+    });
+
+    /// Posts [payload] to the capped server under a declared
+    /// `Content-Length`.
+    Future<(int, String)> postDeclared(List<int> payload) async {
+      final request = await client.postUrl(cappedUri);
+      headers(listTools).forEach(request.headers.set);
+      request.contentLength = payload.length;
+      request.add(payload);
+      final response = await request.close();
+      return (response.statusCode, await utf8.decodeStream(response));
+    }
+
+    /// Posts [chunks] as one chunked body, flushing between them so that
+    /// each one reaches the handler on its own.
+    ///
+    /// Chunked is the framing an embedder cannot bound ahead of the handler,
+    /// and it carries no length however many chunks it is sent in.
+    Future<(int, String)> postChunks(List<List<int>> chunks) async {
+      final request = await client.postUrl(cappedUri);
+      headers(listTools).forEach(request.headers.set);
+      for (final chunk in chunks) {
+        request.add(chunk);
+        await request.flush();
+      }
+      final response = await request.close();
+      return (response.statusCode, await utf8.decodeStream(response));
+    }
+
+    test('serves a body at the limit', () async {
+      final (status, text) = await postDeclared(atTheLimit);
+      expect(declaredLengths.single, atTheLimit.length);
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
+
+    test('uses the default 4 MiB limit', () async {
+      customLimit = null;
+      final belowDefault = bodyNearDefault(-1024);
+      final aboveDefault = bodyNearDefault(1024);
+
+      expect(belowDefault.length, lessThan(defaultLimit));
+      final (acceptedStatus, acceptedText) = await postDeclared(belowDefault);
+      expect(acceptedStatus, 200);
+      expect(errorCode(acceptedText), isNull);
+
+      expect(aboveDefault.length, greaterThan(defaultLimit));
+      final (rejectedStatus, rejectedText) = await postDeclared(aboveDefault);
+      expect(rejectedStatus, 413);
+      expect(errorCode(rejectedText), error_code.INVALID_REQUEST);
+    });
+
+    test('applies a smaller custom limit', () async {
+      customLimit = atTheLimit.length;
+      final (status, text) = await postDeclared(overTheLimit);
+      expect(status, 413);
+      expect(errorCode(text), error_code.INVALID_REQUEST);
+    });
+
+    test('applies a larger custom limit', () async {
+      final aboveDefault = bodyNearDefault(1024);
+      customLimit = aboveDefault.length;
+      final (status, text) = await postDeclared(aboveDefault);
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
+
+    test('rejects a declared body over the limit with 413', () async {
+      final (status, text) = await postDeclared(overTheLimit);
+      expect(declaredLengths.single, greaterThan(atTheLimit.length));
+      expect(status, 413);
+      expect(errorCode(text), error_code.INVALID_REQUEST);
+      expect(
+        errorMessage(text),
+        contains('must not exceed ${atTheLimit.length} bytes'),
+      );
+      final error = decode(text)[Keys.error] as Map<String, Object?>;
+      expect((error[Keys.data] as Map<String, Object?>)[Keys.request], isNull);
+    });
+
+    test('rejects a chunked body over the limit with 413', () async {
+      final (status, text) = await postChunks([overTheLimit]);
+      expect(declaredLengths.single, -1);
+      expect(status, 413);
+      expect(errorCode(text), error_code.INVALID_REQUEST);
+    });
+
+    test('serves a body split across chunks', () async {
+      // Every chunk has to be kept, not just the one the body ends on.
+      final half = atTheLimit.length ~/ 2;
+      final (status, text) = await postChunks([
+        atTheLimit.sublist(0, half),
+        atTheLimit.sublist(half),
+      ]);
+      expect(declaredLengths.single, -1);
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
+
+    test('rejects chunks that only exceed the limit together', () async {
+      // Neither of these is over the cap on its own, so the counter has to
+      // measure the body and not the chunk it is reading.
+      final (status, text) = await postChunks([atTheLimit, atTheLimit]);
+      expect(declaredLengths.single, -1);
+      expect(status, 413);
+      expect(errorCode(text), error_code.INVALID_REQUEST);
+    });
+
+    test('rejects a chunked body larger than the socket buffers', () async {
+      // The bodies above fit in the socket buffers. This one does not. The
+      // client is still sending when the handler answers, and the rest of
+      // the body has to be read for the answer to arrive at all. 512 KiB
+      // still fit on the machine this was measured on, and 8 MiB did not.
+      final request = await client.postUrl(cappedUri);
+      headers(listTools).forEach(request.headers.set);
+      final chunk = utf8.encode('x' * (64 * 1024));
+      for (var sent = 0; sent < 8 * 1024 * 1024; sent += chunk.length) {
+        request.add(chunk);
+        await request.flush();
+      }
+      final response = await request.close();
+      expect(declaredLengths.single, -1);
+      expect(response.statusCode, 413);
+      expect(
+        errorCode(await utf8.decodeStream(response)),
+        error_code.INVALID_REQUEST,
+      );
+    });
+
+    test('throws on a negative cap', () async {
+      // A negative cap is not an off switch. Without the check, a handler
+      // given one answers 413 to every body that carries a byte.
+      final thrown = Completer<Object>();
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      server.listen(
+        (request) => handleStreamableHttpRequest(
+          request,
+          _HttpTestServer.new,
+          maxRequestBodyBytes: -1,
+        ).onError<Object>((error, _) => thrown.complete(error)),
+      );
+
+      // A handler that threw writes nothing, so the response never arrives.
+      // Racing the two lets a handler that answered 413 fail this fast.
+      final unanswered = HttpClient();
+      addTearDown(() => unanswered.close(force: true));
+      final uri = Uri.http('${server.address.host}:${server.port}', '/mcp');
+      final request = await unanswered.postUrl(uri);
+      headers(listTools).forEach(request.headers.set);
+      request.add(atTheLimit);
+      final outcome = await Future.any<Object>([
+        thrown.future,
+        request.close().then((response) => response.statusCode),
+      ]);
+
+      expect(outcome, isRangeError);
+      expect((outcome as RangeError).name, 'maxRequestBodyBytes');
+    });
+  });
+
   group('rejection bodies', () {
     Map<String, Object?> errorData(String text) =>
         (decode(text)[Keys.error] as Map<String, Object?>)[Keys.data]

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -3642,45 +3642,19 @@ void main() {
       return (response.statusCode, await utf8.decodeStream(response));
     }
 
-    /// Posts [length] bytes of [contentType] in flushed 64 KiB pieces and
-    /// returns the status code, or the [IOException] that ended the exchange.
-    ///
-    /// The handler answers a body over the cap while the client may still be
-    /// sending, and the server then closes a connection whose body it never
-    /// finished receiving. Whether the client reads the response before it
-    /// runs into that close is up to its TCP stack, so callers accept either.
-    Future<Object> postFlushed(
-      int length, {
-      String contentType = 'application/json',
-    }) async {
-      final piece = Uint8List(64 * 1024)..fillRange(0, 64 * 1024, 0x78);
-      final request = await client.postUrl(cappedUri);
-      final requestHeaders = headers(listTools);
-      requestHeaders['Content-Type'] = contentType;
-      requestHeaders.forEach(request.headers.set);
-      try {
-        for (var sent = 0; sent < length; sent += piece.length) {
-          request.add(piece);
-          await request.flush();
-        }
-        final response = await request.close();
-        await response.drain<void>();
-        return response.statusCode;
-      } on IOException catch (error) {
-        return error;
-      }
-    }
-
     /// The request line and headers of a raw POST to the capped server. It
     /// asks for `Connection: close`. The response then ends with the
     /// connection, and [sendRaw] reads to the end of it.
-    String rawHead({int? contentLength}) {
+    String rawHead({
+      int? contentLength,
+      String contentType = 'application/json',
+    }) {
       final head = StringBuffer(
         'POST /mcp HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n',
       );
-      headers(
-        listTools,
-      ).forEach((name, value) => head.write('$name: $value\r\n'));
+      final requestHeaders = headers(listTools);
+      requestHeaders['Content-Type'] = contentType;
+      requestHeaders.forEach((name, value) => head.write('$name: $value\r\n'));
       head.write(
         contentLength == null
             ? 'Transfer-Encoding: chunked\r\n'
@@ -3698,15 +3672,15 @@ void main() {
     final lastChunk = utf8.encode('0\r\n\r\n');
 
     /// Writes [segments] to the capped server one write at a time, awaiting
-    /// [between] after each but the last, and returns the status code and
-    /// JSON body of the response.
+    /// [between] after each but the last with the number of segments written
+    /// so far, and returns the status code and JSON body of the response.
     ///
     /// A socket puts the split between writes where the test wants it.
     /// [HttpClient] decides that on its own, and not the same way on every
     /// platform.
     Future<(int, String)> sendRaw(
       List<List<int>> segments, {
-      Future<void> Function()? between,
+      Future<void> Function(int written)? between,
     }) async {
       final socket = await Socket.connect(capped.address, capped.port);
       final received = socket.fold(
@@ -3716,7 +3690,7 @@ void main() {
       for (var i = 0; i < segments.length; i++) {
         socket.add(segments[i]);
         await socket.flush();
-        if (between != null && i < segments.length - 1) await between();
+        if (between != null && i < segments.length - 1) await between(i + 1);
       }
       final response = utf8.decode(await received);
       socket.destroy();
@@ -3726,6 +3700,31 @@ void main() {
         );
       }
       return (int.parse(response.split(' ')[1]), jsonBody(response));
+    }
+
+    /// Sends [total] bytes of body under a declared [declared], in writes of
+    /// [piece] bytes. Each write is held back until the handler has read the
+    /// one before it, so every write reaches the handler as a chunk of its
+    /// own and the body crosses the cap [piece] bytes at a time.
+    Future<(int, String)> sendPaced(
+      int declared, {
+      required int total,
+      int piece = 256 * 1024,
+      String contentType = 'application/json',
+    }) {
+      final bytes = Uint8List(piece)..fillRange(0, piece, 0x78);
+      return sendRaw(
+        [
+          utf8.encode(
+            rawHead(contentLength: declared, contentType: contentType),
+          ),
+          for (var sent = 0; sent < total; sent += piece) bytes,
+        ],
+        between: (written) async {
+          await headersSeen.future;
+          await receivedRequests.single.whenRead((written - 1) * piece);
+        },
+      );
     }
 
     test('serves a body at the limit', () async {
@@ -3745,20 +3744,12 @@ void main() {
 
       final aboveDefault = bodyNearDefault(1024);
       expect(aboveDefault.length, greaterThan(defaultLimit));
-      Object rejected;
-      try {
-        rejected = (await postDeclared(aboveDefault)).$1;
-      } on IOException catch (error) {
-        rejected = error;
-      }
-      await handledRequests[1];
-      expect(receivedRequests[1].response.statusCode, 413);
-      expect(
-        receivedRequests[1].readBeforeLastChunk,
-        lessThanOrEqualTo(defaultLimit),
-      );
-      expect(receivedRequests[1].bytesRead, greaterThan(defaultLimit));
-      expect(rejected, anyOf(413, isA<IOException>()));
+      final (rejectedStatus, rejectedText) = await postDeclared(aboveDefault);
+      expect(rejectedStatus, 413);
+      expect(errorCode(rejectedText), error_code.INVALID_REQUEST);
+      // A body this little over the cap is read to its end, which is what
+      // lets the client see the 413.
+      expect(receivedRequests[1].bytesRead, aboveDefault.length);
     });
 
     test('applies a larger custom limit', () async {
@@ -3830,40 +3821,51 @@ void main() {
       // the end of the body. Cancelling the body there closes the connection
       // at once and drops a response written afterwards, so the 413 has to be
       // written before the loop is left. A single write of the whole request
-      // never takes that path.
+      // never takes that path. The cap here is small enough that this one
+      // chunk also uses up the discard budget.
       final (status, text) = await sendRaw([
         utf8.encode(rawHead(contentLength: overTheLimit.length)),
         overTheLimit,
-      ], between: () => headersSeen.future);
+      ], between: (_) => headersSeen.future);
       expect(status, 413);
       expect(errorCode(text), error_code.INVALID_REQUEST);
     });
 
-    test('stops reading a JSON body at the limit', () async {
+    test('reads a smaller overflow to its end', () async {
       const limit = 1024 * 1024;
       customLimit = limit;
-      final outcome = await postFlushed(3 * limit);
-      await handledRequests.single;
-      final received = receivedRequests.single;
-      expect(received.response.statusCode, 413);
-      // Everything the handler kept fits under the cap, and the chunk that
-      // crossed it is the last one it read, however much more was sent.
-      expect(received.readBeforeLastChunk, lessThanOrEqualTo(limit));
-      expect(received.bytesRead, greaterThan(limit));
-      expect(outcome, anyOf(413, isA<IOException>()));
-      expect(declaredLengths.single, -1);
+      final (status, text) = await sendPaced(
+        limit + limit ~/ 2,
+        total: limit + limit ~/ 2,
+      );
+      expect(status, 413);
+      expect(errorCode(text), error_code.INVALID_REQUEST);
+      expect(receivedRequests.single.bytesRead, limit + limit ~/ 2);
     });
 
-    test('reads a body of the wrong media type only to the limit', () async {
+    test('stops discarding at another limit', () async {
       const limit = 1024 * 1024;
       customLimit = limit;
-      final outcome = await postFlushed(3 * limit, contentType: 'text/plain');
-      await handledRequests.single;
-      final received = receivedRequests.single;
-      expect(received.response.statusCode, 415);
-      expect(received.readBeforeLastChunk, lessThanOrEqualTo(limit));
-      expect(received.bytesRead, greaterThan(limit));
-      expect(outcome, anyOf(415, isA<IOException>()));
+      // The client sends twice the cap of a body it declared three times the
+      // cap long, then waits. The handler has to answer on the write that
+      // fills the discard budget, or the response never comes.
+      final (status, text) = await sendPaced(3 * limit, total: 2 * limit);
+      expect(status, 413);
+      expect(errorCode(text), error_code.INVALID_REQUEST);
+      expect(receivedRequests.single.bytesRead, 2 * limit);
+    });
+
+    test('discards a body of the wrong media type the same way', () async {
+      const limit = 1024 * 1024;
+      customLimit = limit;
+      final (status, text) = await sendPaced(
+        3 * limit,
+        total: 2 * limit,
+        contentType: 'text/plain',
+      );
+      expect(status, 415);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
+      expect(receivedRequests.single.bytesRead, 2 * limit);
     });
 
     test('throws on a negative cap', () async {
@@ -4544,9 +4546,15 @@ final class _CountingHttpRequest extends Stream<Uint8List>
 
   int get bytesRead => chunkLengths.fold(0, (sum, length) => sum + length);
 
-  /// What the handler read before its last chunk. A handler that stops on the
-  /// chunk crossing its cap kept exactly this much.
-  int get readBeforeLastChunk => bytesRead - chunkLengths.last;
+  final _readWaiters = <(int, Completer<void>)>[];
+
+  /// Completes once the handler has read at least [bytes] of the body.
+  Future<void> whenRead(int bytes) {
+    if (bytesRead >= bytes) return Future.value();
+    final waiter = Completer<void>();
+    _readWaiters.add((bytes, waiter));
+    return waiter.future;
+  }
 
   @override
   HttpHeaders get headers => _inner.headers;
@@ -4566,6 +4574,12 @@ final class _CountingHttpRequest extends Stream<Uint8List>
   }) => _inner.listen(
     (chunk) {
       chunkLengths.add(chunk.length);
+      final read = bytesRead;
+      for (final (bytes, waiter) in _readWaiters.toList()) {
+        if (read < bytes) continue;
+        _readWaiters.remove((bytes, waiter));
+        waiter.complete();
+      }
       onData?.call(chunk);
     },
     onError: onError,


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

Nothing capped a request body here. On a chunked one `contentLength` is -1, so the handler counts the bytes as they arrive. The TypeScript and Go SDKs both stop at 4 MiB with a 413, so I just did the same, as a `maxRequestBodyBytes` argument with that default. Reading past the cap stops at another `maxRequestBodyBytes`, so a body a little over still finishes and sees the response.

The error body carries `-32600`, the code this handler already uses when it refuses a batch before parsing. TypeScript answers `-32000` there.
