### PR TITLE
pin the retry and request state contracts

### DIFF
--- a/pkgs/dart_mcp/test/api/input_required_test.dart
+++ b/pkgs/dart_mcp/test/api/input_required_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:dart_mcp/client.dart';
 import 'package:test/test.dart';
 
@@ -194,6 +196,17 @@ void main() {
         'inputResponses': {'github_login': elicited, 'capital': sampled},
         'requestState': 'an opaque blob',
       });
+    });
+
+    test('keeps untrusted requestState unchanged across JSON', () {
+      final wire =
+          jsonDecode('{"uri":"file:///a","requestState":"  client.state/+  "}')
+              as Map<String, Object?>;
+
+      expect(
+        ReadResourceRequest.fromMap(wire).requestState,
+        '  client.state/+  ',
+      );
     });
 
     test('a first attempt writes neither field', () {

--- a/pkgs/dart_mcp/test/conformance_server_test.dart
+++ b/pkgs/dart_mcp/test/conformance_server_test.dart
@@ -16,6 +16,7 @@ const _protocolVersion = '2026-07-28';
 const _simpleTextTool = 'test_simple_text';
 const _inputElicitationTool = 'test_input_required_result_elicitation';
 const _inputStateTool = 'test_input_required_result_request_state';
+const _inputMultiRoundTool = 'test_input_required_result_multi_round';
 const _inputTamperedTool = 'test_input_required_result_tampered_state';
 const _templateUri = 'test://template/{id}/data';
 const _expandedTemplateUri = 'test://template/123/data';
@@ -234,6 +235,31 @@ void main() {
         (refused['error'] as Map<String, Object?>)['message'],
         contains('failed integrity validation'),
       );
+    });
+
+    test('starts another round when a retry omits input', () async {
+      Future<Map<String, Object?>> call(Map<String, Object?> params) => _post(
+        endpoint,
+        'tools/call',
+        params: params,
+        capabilities: _formElicitationCapabilities,
+      );
+      final issuedResult =
+          (await call({'name': _inputMultiRoundTool}))['result']
+              as Map<String, Object?>;
+      final requestState = issuedResult['requestState'] as String;
+      final retriedResult =
+          (await call({
+                'name': _inputMultiRoundTool,
+                'requestState': requestState,
+              }))['result']
+              as Map<String, Object?>;
+
+      expect(retriedResult['resultType'], 'input_required');
+      expect(retriedResult['requestState'], requestState);
+      expect((retriedResult['inputRequests'] as Map<String, Object?>).keys, [
+        'step1',
+      ]);
     });
 
     test('delivers a list change from another request on a listen '

--- a/pkgs/dart_mcp/test/server/request_scoped_test.dart
+++ b/pkgs/dart_mcp/test/server/request_scoped_test.dart
@@ -597,6 +597,13 @@ void main() {
       }
     });
 
+    test('closes after input_required without a retry', () async {
+      final harness = _DispatcherHarness();
+      await harness.dispatch(_callTool('interim'), _initialization());
+
+      expect(harness.servers.single.isActive, isFalse);
+    });
+
     test('refuses an input request the client cannot answer', () async {
       final harness = _DispatcherHarness();
       for (final (tool, capability, required) in [


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

Two things the revision asks of a server held here but had no test. Nothing carried `requestState` through a round trip to show it comes back untouched, and nothing exercised a client that answers an `InputRequiredResult` without retrying.

Three tests cover both now. I just left the integrity half of that paragraph alone, since this package never authorizes on the field.
