### PR TITLE
answer an unsupported media type with 415

### DIFF
--- a/pkgs/dart_mcp/lib/src/server/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/src/server/streamable_http.dart
@@ -21,13 +21,14 @@ import 'server.dart';
 /// created by [serverFactory] via [handleRequestScopedMessage], and writing
 /// the HTTP response.
 ///
-/// Spec-defined failures are answered with their JSON-RPC error codes and
+/// Rejected requests are answered with their JSON-RPC error codes and
 /// HTTP statuses: 400 for a malformed message, a failed header or envelope
 /// validation, an absent `Accept` header, an `Accept` header that does not
-/// cover both response shapes, or a non-`application/json` `Content-Type`, and
-/// 404 for a method this transport does not serve. The specification requires
-/// `400 Bad Request` on every `HeaderMismatch` body and names no other status
-/// for content negotiation, so 406 and 415 are not used. Every one of
+/// cover both response shapes, 404 for a method this transport does not serve,
+/// and 415 for a non-`application/json` `Content-Type`. The specification
+/// requires `400 Bad Request` for its defined `HeaderMismatch` failures but
+/// names no status for rejecting a request media type, so 406 is not used.
+/// Every one of
 /// those bodies also carries its source message under `error.data.request`,
 /// as the rest of this package does: the decoded
 /// message when there is one, the raw body text when it was not valid JSON,
@@ -133,7 +134,7 @@ Future<void> handleStreamableHttpRequest(
     }
     return _reject(
       response,
-      HttpStatus.badRequest,
+      HttpStatus.unsupportedMediaType,
       RpcException(
         McpErrorCodes.headerMismatch,
         'The request body must be sent as ${ContentType.json.mimeType}',

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -2533,7 +2533,7 @@ void main() {
         },
         json: body(listTools),
       );
-      expect(status, 400);
+      expect(status, 415);
       // Written out so the check does not read back the constant the
       // response was built from.
       expect(errorCode(text), -32020);
@@ -2545,7 +2545,7 @@ void main() {
         headers: {...headers(listTools), 'Content-Type': 'text/plain'},
         json: body(listTools),
       );
-      expect(status, 400);
+      expect(status, 415);
       expect(responseHeaders.contentType?.mimeType, 'application/json');
       expect(errorCode(text), McpErrorCodes.headerMismatch);
     });
@@ -2618,7 +2618,7 @@ void main() {
 
     test('rejects a Content-Type dart:io cannot parse', () async {
       // dart:io parses the header lazily and throws when it is first read,
-      // and that throw must land as a 400, not escape the handler and leave
+      // and that throw must land as a 415, not escape the handler and leave
       // the request unanswered.
       final requestBody = jsonEncode(body(listTools));
       final response = await rawRequest(
@@ -2631,7 +2631,7 @@ void main() {
         '\r\n'
         '$requestBody',
       );
-      expect(response, startsWith('HTTP/1.1 400'));
+      expect(response, startsWith('HTTP/1.1 415'));
       expect(errorCode(jsonBody(response)), McpErrorCodes.headerMismatch);
       expect(servers, isEmpty);
     });


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

A POST that isn't JSON got a 400 here. The revision doesn't name a status for that, so I just followed the three SDKs that do. TypeScript answers 415 in `streamableHttp.ts:770`, Go in `mcp/streamable.go:389`, Rust in `server_side_http.rs:258`. Python stays on 400 and marks its own 415 path unreachable.

The JSON-RPC code stays `-32020`. This path calls `_reject` directly, so the status table is untouched.
