### PR TITLE
pin the header walk past a matching property

### DIFF
--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -3162,6 +3162,20 @@ void main() {
       expect(errorCode(text), McpErrorCodes.headerMismatch);
     });
 
+    test('rejects a mismatched header after an earlier one matches', () async {
+      final (status, _, text) = await post(
+        headers: callWithHeaderParamHeaders({
+          'Mcp-Param-Region': 'us-west1',
+          'Mcp-Param-Count': '7',
+        }),
+        json: callWithHeaderParam({'region': 'us-west1', 'count': 42}),
+      );
+      expect(status, 400);
+      expect(errorCode(text), McpErrorCodes.headerMismatch);
+      expect(errorMessage(text), contains('Mcp-Param-Count'));
+      expect(errorMessage(text), contains('42'));
+    });
+
     test('compares a boolean property', () async {
       final (status, _, text) = await post(
         headers: callWithHeaderParamHeaders({'Mcp-Param-Flag': 'true'}),

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -3163,17 +3163,34 @@ void main() {
     });
 
     test('rejects a mismatched header after an earlier one matches', () async {
-      final (status, _, text) = await post(
-        headers: callWithHeaderParamHeaders({
-          'Mcp-Param-Region': 'us-west1',
-          'Mcp-Param-Count': '7',
-        }),
-        json: callWithHeaderParam({'region': 'us-west1', 'count': 42}),
-      );
-      expect(status, 400);
-      expect(errorCode(text), McpErrorCodes.headerMismatch);
-      expect(errorMessage(text), contains('Mcp-Param-Count'));
-      expect(errorMessage(text), contains('42'));
+      // Nothing fixes the order a server walks a schema's properties in, so a
+      // single case gets past a match only by luck. Whichever of the two
+      // properties the walk reads first, one case sends it matching.
+      for (final (mismatched, bodyValue, sent) in [
+        (
+          'Mcp-Param-Count',
+          '42',
+          {'Mcp-Param-Region': 'us-west1', 'Mcp-Param-Count': '7'},
+        ),
+        (
+          'Mcp-Param-Region',
+          'us-west1',
+          {'Mcp-Param-Region': 'eu-west1', 'Mcp-Param-Count': '42'},
+        ),
+      ]) {
+        final (status, _, text) = await post(
+          headers: callWithHeaderParamHeaders(sent),
+          json: callWithHeaderParam({'region': 'us-west1', 'count': 42}),
+        );
+        expect(status, 400, reason: mismatched);
+        expect(
+          errorCode(text),
+          McpErrorCodes.headerMismatch,
+          reason: mismatched,
+        );
+        expect(errorMessage(text), contains(mismatched), reason: mismatched);
+        expect(errorMessage(text), contains(bodyValue), reason: mismatched);
+      }
     });
 
     test('compares a boolean property', () async {


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

The revision has a server reject a request when any mirrored header disagrees with the body. The check walks every annotated property, and nothing held it to that. On main I stopped the loop after the first property that matches its header and the suite stayed green.

Nothing fixes the order the properties are walked in, so the test sends both arrangements. One pairs a matching `Mcp-Param-Region` with a mismatched `Mcp-Param-Count`, the other reverses them, and both expect 400, `-32020`, and a message naming the header and the body value.
