### PR TITLE
cancel a request when its SSE response closes

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -310,8 +310,8 @@
 - Answer a request whose handler emits related notifications on an SSE
   response stream. A quiet handler keeps its JSON body. List changes and
   resource updates skip that request's stream, since this revision carries
-  those on a `subscriptions/listen` stream. Does not treat a closed stream as
-  cancellation, which the specification requires.
+  those on a `subscriptions/listen` stream. Closing that stream cancels the
+  request, shutting its server down without a final result.
 - Add `sseMessageStream`, decoding the `message` events of an SSE response
   into JSON objects. Undecodable data becomes an error event without ending
   the stream, though `await for` stops on the first one.

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -307,11 +307,12 @@
   takes `ttlMs` and `cacheScope` on the same terms as the other five cacheable
   results, so the sixth operation the caching rules name is no longer the one
   that cannot carry the hints.
-- Answer a request whose handler emits related notifications on an SSE
-  response stream. A quiet handler keeps its JSON body. List changes and
-  resource updates skip that request's stream, since this revision carries
-  those on a `subscriptions/listen` stream. Closing that stream cancels the
-  request, shutting its server down without a final result.
+- Use an SSE response when a request handler emits related notifications. A
+  quiet handler keeps its JSON body. List changes and resource updates stay on
+  `subscriptions/listen`. Closing the response cancels the request and shuts
+  its server down without a final result. The `handleStreamableHttpRequest`
+  parameter `listenKeepAliveInterval` is now `keepAliveInterval` because it
+  covers every SSE response.
 - Add `sseMessageStream`, decoding the `message` events of an SSE response
   into JSON objects. Undecodable data becomes an error event without ending
   the stream, though `await for` stops on the first one.

--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -309,10 +309,10 @@
   that cannot carry the hints.
 - Use an SSE response when a request handler emits related notifications. A
   quiet handler keeps its JSON body. List changes and resource updates stay on
-  `subscriptions/listen`. Closing the response cancels the request and shuts
-  its server down without a final result. The `handleStreamableHttpRequest`
-  parameter `listenKeepAliveInterval` is now `keepAliveInterval` because it
-  covers every SSE response.
+  `subscriptions/listen`. An open SSE response writes a keep-alive comment
+  every `keepAliveInterval`. Closing a started response cancels its request and
+  shuts the server down without a final result. A request that has not started
+  one keeps running.
 - Add `sseMessageStream`, decoding the `message` events of an SSE response
   into JSON objects. Undecodable data becomes an error event without ending
   the stream, though `await for` stops on the first one.

--- a/pkgs/dart_mcp/lib/src/server/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/src/server/streamable_http.dart
@@ -87,10 +87,9 @@ import 'server.dart';
 /// result follows it as the last event. A request answered without one gets a
 /// JSON body instead. Long-lived change notifications go only to a successful
 /// `subscriptions/listen` response whose acknowledged filter selects them.
-/// A listen response writes an SSE comment every [listenKeepAliveInterval] to
-/// keep an idle stream open, which is also what notices a client that went
-/// away. Closing that response shuts down its request server and ends the
-/// subscription without a final result.
+/// An SSE response writes a comment every [keepAliveInterval] to keep an
+/// idle stream open, which is also what notices a client that went away.
+/// Closing that response shuts down its request server without a final result.
 /// [onNotification] sees every notification either way, held back or not.
 /// When [subscriptionNotifications] is provided, each listen request reads
 /// matching changes from that stream. An embedder can pass the same broadcast
@@ -102,7 +101,7 @@ Future<void> handleStreamableHttpRequest(
   MCPServerFactory serverFactory, {
   void Function(Map<String, Object?> notification)? onNotification,
   Stream<Map<String, Object?>>? subscriptionNotifications,
-  Duration listenKeepAliveInterval = const Duration(seconds: 15),
+  Duration keepAliveInterval = const Duration(seconds: 15),
 }) async {
   final response = request.response;
   if (request.method != 'POST') {
@@ -443,33 +442,26 @@ Future<void> handleStreamableHttpRequest(
     );
   }
 
-  final answer = _Answer(
-    response,
-    keepAliveInterval:
-        method == SubscriptionsListenRequest.methodName
-            ? listenKeepAliveInterval
-            : null,
-  );
+  final answer = _Answer(response, keepAliveInterval: keepAliveInterval);
   var pendingNotifications =
       method == CallToolRequest.methodName ? <Map<String, Object?>>[] : null;
   MCPServer? activeServer;
   StreamSubscription<Map<String, Object?>>? notificationSubscription;
   var responseClosed = false;
   var listenFailed = false;
-  if (method == SubscriptionsListenRequest.methodName) {
-    unawaited(() async {
-      try {
-        await response.done;
-      } catch (_) {
-        // A disconnected client cannot receive another response.
-      }
-      responseClosed = true;
-      answer.cancel();
-      await notificationSubscription?.cancel();
-      final server = activeServer;
-      if (server != null && server.isActive) await server.shutdown();
-    }());
-  }
+  unawaited(() async {
+    try {
+      await response.done;
+    } catch (_) {
+      // A disconnected client cannot receive another response.
+    }
+    if (!answer.isStreaming || answer.isFinished) return;
+    responseClosed = true;
+    answer.cancel();
+    await notificationSubscription?.cancel();
+    final server = activeServer;
+    if (server != null && server.isActive) await server.shutdown();
+  }());
 
   /// Writes [notification] to the response stream, skipping the ones an
   /// embedder serves on a listen stream.
@@ -677,13 +669,16 @@ String _sseEvent(Map<String, Object?> message) =>
 /// no longer applies to it, including the `400` this revision requires of a
 /// missing client capability.
 class _Answer {
-  _Answer(this._response, {this.keepAliveInterval});
+  _Answer(this._response, {required this.keepAliveInterval});
 
   final HttpResponse _response;
-  final Duration? keepAliveInterval;
+  final Duration keepAliveInterval;
   bool _committed = false;
   bool _finished = false;
   Timer? _keepAlive;
+
+  bool get isStreaming => _committed;
+  bool get isFinished => _finished;
 
   /// Sends [notification] on the stream, committing to it if this is the first.
   void notify(Map<String, Object?> notification) {
@@ -703,12 +698,10 @@ class _Answer {
       )
       ..headers.set(HttpHeaders.cacheControlHeader, 'no-cache, no-transform')
       ..headers.set('x-accel-buffering', 'no');
-    if (keepAliveInterval case final interval?) {
-      _keepAlive = Timer.periodic(
-        interval,
-        (_) => _response.write(_sseKeepAlive),
-      );
-    }
+    _keepAlive = Timer.periodic(
+      keepAliveInterval,
+      (_) => _response.write(_sseKeepAlive),
+    );
   }
 
   /// Sends [result] and closes. A second call is ignored.

--- a/pkgs/dart_mcp/lib/src/server/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/src/server/streamable_http.dart
@@ -89,7 +89,9 @@ import 'server.dart';
 /// `subscriptions/listen` response whose acknowledged filter selects them.
 /// An SSE response writes a comment every [keepAliveInterval] to keep an
 /// idle stream open, which is also what notices a client that went away.
-/// Closing that response shuts down its request server without a final result.
+/// Closing one shuts down its request server and ends any subscription it
+/// feeds, without a final result. A request that has not started an SSE
+/// response keeps running.
 /// [onNotification] sees every notification either way, held back or not.
 /// When [subscriptionNotifications] is provided, each listen request reads
 /// matching changes from that stream. An embedder can pass the same broadcast
@@ -455,7 +457,7 @@ Future<void> handleStreamableHttpRequest(
     } catch (_) {
       // A disconnected client cannot receive another response.
     }
-    if (!answer.isStreaming || answer.isFinished) return;
+    if (!answer._committed || answer._finished) return;
     responseClosed = true;
     answer.cancel();
     await notificationSubscription?.cancel();
@@ -676,9 +678,6 @@ class _Answer {
   bool _committed = false;
   bool _finished = false;
   Timer? _keepAlive;
-
-  bool get isStreaming => _committed;
-  bool get isFinished => _finished;
 
   /// Sends [notification] on the stream, committing to it if this is the first.
   void notify(Map<String, Object?> notification) {

--- a/pkgs/dart_mcp/lib/src/server/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/src/server/streamable_http.dart
@@ -749,6 +749,9 @@ class _Answer {
     _response.write(_sseEvent(notification));
   }
 
+  /// Turns the response into an SSE stream with the headers that keep proxies
+  /// from buffering it, and starts the keep-alive timer. Runs once, before the
+  /// first event.
   void _commit() {
     _committed = true;
     _response

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -71,7 +71,7 @@ void main() {
           subscriptionNotifications.add(notification);
         },
         subscriptionNotifications: subscriptionNotifications.stream,
-        listenKeepAliveInterval: const Duration(milliseconds: 50),
+        keepAliveInterval: const Duration(milliseconds: 50),
       ),
     );
     addTearDown(() async {
@@ -3502,6 +3502,101 @@ void main() {
       expect(status, 200);
       expect(errorCode(text), isNull);
     });
+
+    test('cancels a request when its SSE response closes', () async {
+      releaseDisconnectHandler = Completer<void>();
+      addTearDown(() {
+        if (!releaseDisconnectHandler.isCompleted) {
+          releaseDisconnectHandler.complete();
+        }
+      });
+      final client = HttpClient();
+      addTearDown(client.close);
+      final request = await client.postUrl(uri);
+      headers(callTool).forEach(request.headers.set);
+      request.headers.set('Mcp-Name', 'test/disconnect');
+      request.write(
+        jsonEncode(body(callTool, params: {Keys.name: 'test/disconnect'})),
+      );
+      final response = await request.close();
+      final firstFrame = Completer<void>();
+      final chunks = StringBuffer();
+      final subscription = response.transform(utf8.decoder).listen((chunk) {
+        chunks.write(chunk);
+        if (!firstFrame.isCompleted && chunks.toString().contains('\n\n')) {
+          firstFrame.complete();
+        }
+      }, onError: (Object _) {});
+      addTearDown(subscription.cancel);
+
+      await firstFrame.future.timeout(const Duration(seconds: 5));
+      expect(events(chunks.toString()), hasLength(1));
+      final server = servers.single;
+      client.close(force: true);
+
+      await server.done.timeout(const Duration(seconds: 5));
+      expect(server.isActive, isFalse);
+      releaseDisconnectHandler.complete();
+      await pumpEventQueue(times: 20);
+      expect(events(chunks.toString()), hasLength(1));
+    });
+
+    test('does not cancel before an SSE response starts', () async {
+      _noStreamHandlerEntered = Completer<void>();
+      _releaseNoStreamHandler = Completer<void>();
+      addTearDown(() {
+        if (!_releaseNoStreamHandler.isCompleted) {
+          _releaseNoStreamHandler.complete();
+        }
+      });
+      final quiet = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => quiet.close(force: true));
+      final handled = Completer<void>();
+      quiet.listen((request) {
+        () async {
+          Timer? keepAlive;
+          try {
+            final handling = handleStreamableHttpRequest(request, (channel) {
+              final server = _NoStreamServer(channel);
+              servers.add(server);
+              return server;
+            });
+            await _noStreamHandlerEntered.future;
+            request.response.bufferOutput = false;
+            keepAlive = Timer.periodic(
+              const Duration(milliseconds: 10),
+              (_) => request.response.write('ready'),
+            );
+            request.response.write('ready');
+            await request.response.flush();
+            await handling;
+          } finally {
+            keepAlive?.cancel();
+            handled.complete();
+          }
+        }().ignore();
+      });
+      final client = HttpClient();
+      addTearDown(client.close);
+      final request = await client.postUrl(
+        Uri.http('${quiet.address.host}:${quiet.port}', '/mcp'),
+      );
+      headers('test/no-stream').forEach(request.headers.set);
+      request.write(jsonEncode(body('test/no-stream')));
+      final response = await request.close();
+      final subscription = response.listen((_) {}, onError: (Object _) {});
+      addTearDown(subscription.cancel);
+      await _noStreamHandlerEntered.future.timeout(const Duration(seconds: 5));
+      final server = servers.single;
+
+      client.close(force: true);
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(server.isActive, isTrue);
+
+      _releaseNoStreamHandler.complete();
+      await server.done.timeout(const Duration(seconds: 5));
+      await handled.future.timeout(const Duration(seconds: 5));
+    });
   });
 
   group('malformed bodies', () {
@@ -4181,6 +4276,28 @@ void main() {
 /// Held by `test/notify-then-wait` until a test releases it.
 Completer<void> releaseNotifyThenWait = Completer<void>();
 
+/// Held by `test/disconnect` until its response stream has closed.
+Completer<void> releaseDisconnectHandler = Completer<void>();
+
+Completer<void> _noStreamHandlerEntered = Completer<void>();
+Completer<void> _releaseNoStreamHandler = Completer<void>();
+
+base class _NoStreamServer extends MCPServer {
+  _NoStreamServer(super.channel)
+    : super.fromStreamChannel(
+        implementation: Implementation(
+          name: 'no stream test server',
+          version: '0.1.0',
+        ),
+      ) {
+    registerRequestHandler<Request?, Result?>('test/no-stream', (_) async {
+      _noStreamHandlerEntered.complete();
+      await _releaseNoStreamHandler.future;
+      return EmptyResult();
+    });
+  }
+}
+
 base class _HttpTestServer extends MCPServer
     with LoggingSupport, ToolsSupport, SubscriptionsSupport {
   bool get _declaredSampling => clientCapabilities.sampling != null;
@@ -4365,6 +4482,26 @@ base class _HttpTestServer extends MCPServer
         return CallToolResult(content: [TextContent(text: 'released')]);
       },
     );
+    registerTool(Tool(name: 'test/disconnect', inputSchema: ObjectSchema()), (
+      _,
+    ) async {
+      sendNotification(
+        LoggingMessageNotification.methodName,
+        LoggingMessageNotification(
+          level: LoggingLevel.error,
+          data: 'before disconnect',
+        ),
+      );
+      await releaseDisconnectHandler.future;
+      sendNotification(
+        LoggingMessageNotification.methodName,
+        LoggingMessageNotification(
+          level: LoggingLevel.error,
+          data: 'after disconnect',
+        ),
+      );
+      return CallToolResult(content: [TextContent(text: 'late result')]);
+    });
     registerTool(
       Tool(name: 'test/notify-then-throw', inputSchema: ObjectSchema()),
       (_) {

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -154,9 +154,13 @@ void main() {
   ];
 
   /// The JSON-RPC messages an SSE response [text] carries, in order.
+  ///
+  /// A keep-alive comment is a frame with no field lines at all, and no
+  /// message, so it is left out here.
   List<Map<String, Object?>> events(String text) => [
     for (final frame in frames(text))
-      jsonDecode(frame['data']!) as Map<String, Object?>,
+      if (frame['data'] case final data?)
+        jsonDecode(data) as Map<String, Object?>,
   ];
 
   Object? errorCode(String text) =>
@@ -3542,17 +3546,21 @@ void main() {
     });
 
     test('does not cancel before an SSE response starts', () async {
-      _noStreamHandlerEntered = Completer<void>();
-      _releaseNoStreamHandler = Completer<void>();
+      noStreamHandlerEntered = Completer<void>();
+      releaseNoStreamHandler = Completer<void>();
       addTearDown(() {
-        if (!_releaseNoStreamHandler.isCompleted) {
-          _releaseNoStreamHandler.complete();
+        if (!releaseNoStreamHandler.isCompleted) {
+          releaseNoStreamHandler.complete();
         }
       });
       final quiet = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
       addTearDown(() => quiet.close(force: true));
       final handled = Completer<void>();
       quiet.listen((request) {
+        // A parked handler writes nothing, and a response nobody writes to
+        // never reports the disconnect this test is about, so the bytes below
+        // stand in for one. They cost the handler its own status line, which
+        // is why this probe keeps its errors to itself.
         () async {
           Timer? keepAlive;
           try {
@@ -3561,7 +3569,7 @@ void main() {
               servers.add(server);
               return server;
             });
-            await _noStreamHandlerEntered.future;
+            await noStreamHandlerEntered.future;
             request.response.bufferOutput = false;
             keepAlive = Timer.periodic(
               const Duration(milliseconds: 10),
@@ -3586,14 +3594,14 @@ void main() {
       final response = await request.close();
       final subscription = response.listen((_) {}, onError: (Object _) {});
       addTearDown(subscription.cancel);
-      await _noStreamHandlerEntered.future.timeout(const Duration(seconds: 5));
+      await noStreamHandlerEntered.future.timeout(const Duration(seconds: 5));
       final server = servers.single;
 
       client.close(force: true);
       await Future<void>.delayed(const Duration(milliseconds: 100));
       expect(server.isActive, isTrue);
 
-      _releaseNoStreamHandler.complete();
+      releaseNoStreamHandler.complete();
       await server.done.timeout(const Duration(seconds: 5));
       await handled.future.timeout(const Duration(seconds: 5));
     });
@@ -4065,6 +4073,53 @@ void main() {
       expect(events(chunks.toString()), hasLength(2));
     });
 
+    test('keeps a notifying stream alive with an SSE comment', () async {
+      releaseNotifyThenWait = Completer<void>();
+      addTearDown(() {
+        if (!releaseNotifyThenWait.isCompleted) {
+          releaseNotifyThenWait.complete();
+        }
+      });
+      final client = HttpClient();
+      addTearDown(client.close);
+      final request = await client.openUrl('POST', uri);
+      headers(callTool).forEach(request.headers.set);
+      request.headers.set('Mcp-Name', 'test/notify-then-wait');
+      request.write(
+        jsonEncode(
+          body(callTool, params: {Keys.name: 'test/notify-then-wait'}),
+        ),
+      );
+      final response = await request.close();
+
+      // The handler stays parked past the keep-alive interval, so a comment
+      // lands between the notification and the result.
+      final chunks = StringBuffer();
+      final keptAlive = Completer<void>();
+      final subscription = response.transform(utf8.decoder).listen((chunk) {
+        chunks.write(chunk);
+        if (!keptAlive.isCompleted &&
+            chunks.toString().split('\n\n').any((f) => f.startsWith(':'))) {
+          keptAlive.complete();
+        }
+      });
+      addTearDown(subscription.cancel);
+
+      await keptAlive.future.timeout(const Duration(seconds: 5));
+      releaseNotifyThenWait.complete();
+      await subscription.asFuture<void>();
+
+      final text = chunks.toString();
+      expect(frames(text), hasLength(greaterThan(2)));
+      final messages = events(text);
+      expect(messages, hasLength(2));
+      expect(
+        messages.first[Keys.method],
+        LoggingMessageNotification.methodName,
+      );
+      expect(messages.last[Keys.id], 1);
+    });
+
     test('keeps the stream open for a second notification', () async {
       final (status, responseHeaders, text) = await post(
         headers: {...headers(callTool), 'Mcp-Name': 'test/notify-twice'},
@@ -4279,8 +4334,11 @@ Completer<void> releaseNotifyThenWait = Completer<void>();
 /// Held by `test/disconnect` until its response stream has closed.
 Completer<void> releaseDisconnectHandler = Completer<void>();
 
-Completer<void> _noStreamHandlerEntered = Completer<void>();
-Completer<void> _releaseNoStreamHandler = Completer<void>();
+/// Completed by `test/no-stream` once its handler is running.
+Completer<void> noStreamHandlerEntered = Completer<void>();
+
+/// Held by `test/no-stream` until a test releases it.
+Completer<void> releaseNoStreamHandler = Completer<void>();
 
 base class _NoStreamServer extends MCPServer {
   _NoStreamServer(super.channel)
@@ -4291,8 +4349,8 @@ base class _NoStreamServer extends MCPServer {
         ),
       ) {
     registerRequestHandler<Request?, Result?>('test/no-stream', (_) async {
-      _noStreamHandlerEntered.complete();
-      await _releaseNoStreamHandler.future;
+      noStreamHandlerEntered.complete();
+      await releaseNoStreamHandler.future;
       return EmptyResult();
     });
   }


### PR DESCRIPTION
Answering a request on an SSE response means a disconnect should cancel it. This
watches `response.done`, then shuts the server down once the response has
started. A request still on its JSON body keeps running, and a test pins that.

Widening keep-alive to every SSE response also exposed the suite's `events`
helper. A `: keep-alive` frame carries no field lines, so `frame['data']!` threw
`Null check operator used on a null value` whenever a handler parked past the
50ms interval these tests use. I left comment frames out of `events` and added a
test that reads a stream across one.
