### PR TITLE
add a padded request state to five write paths

### DIFF
--- a/pkgs/dart_mcp/test/api/input_required_test.dart
+++ b/pkgs/dart_mcp/test/api/input_required_test.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 
 import 'package:dart_mcp/client.dart';
+import 'package:dart_mcp/src/utils/constants.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -104,6 +105,13 @@ void main() {
           },
         },
       );
+    });
+
+    test('writes a padded request state unchanged', () {
+      const padded = '  client.state/+  ';
+      final result = InputRequiredResult(requestState: padded);
+
+      expect((result as Map<String, Object?>)[Keys.requestState], padded);
     });
 
     test('reads back the requests a server sent', () {
@@ -209,18 +217,16 @@ void main() {
       );
     });
 
-    test('keeps a padded requestState unchanged through encode and decode', () {
-      final request = ReadResourceRequest(
-        uri: 'file:///a',
-        requestState: '  client.state/+  ',
-      );
-
-      final wire = jsonDecode(jsonEncode(request)) as Map<String, Object?>;
-
-      expect(
-        ReadResourceRequest.fromMap(wire).requestState,
-        '  client.state/+  ',
-      );
+    test('keeps padded requestState unchanged in the JSON it writes', () {
+      const padded = '  client.state/+  ';
+      for (var request in <WithInputResponses>[
+        CallToolRequest(name: 'deploy', requestState: padded),
+        GetPromptRequest(name: 'review', requestState: padded),
+        ReadResourceRequest(uri: 'file:///a', requestState: padded),
+      ]) {
+        final wire = jsonDecode(jsonEncode(request)) as Map<String, Object?>;
+        expect(wire[Keys.requestState], padded);
+      }
     });
 
     test('a first attempt writes neither field', () {

--- a/pkgs/dart_mcp/test/api/input_required_test.dart
+++ b/pkgs/dart_mcp/test/api/input_required_test.dart
@@ -198,7 +198,7 @@ void main() {
       });
     });
 
-    test('keeps untrusted requestState unchanged across JSON', () {
+    test('keeps untrusted requestState unchanged after JSON decoding', () {
       final wire =
           jsonDecode('{"uri":"file:///a","requestState":"  client.state/+  "}')
               as Map<String, Object?>;

--- a/pkgs/dart_mcp/test/api/input_required_test.dart
+++ b/pkgs/dart_mcp/test/api/input_required_test.dart
@@ -209,6 +209,20 @@ void main() {
       );
     });
 
+    test('keeps a padded requestState unchanged through encode and decode', () {
+      final request = ReadResourceRequest(
+        uri: 'file:///a',
+        requestState: '  client.state/+  ',
+      );
+
+      final wire = jsonDecode(jsonEncode(request)) as Map<String, Object?>;
+
+      expect(
+        ReadResourceRequest.fromMap(wire).requestState,
+        '  client.state/+  ',
+      );
+    });
+
     test('a first attempt writes neither field', () {
       expect(CallToolRequest(name: 'deploy') as Map<String, Object?>, {
         'name': 'deploy',

--- a/pkgs/dart_mcp/test/client/input_required_test.dart
+++ b/pkgs/dart_mcp/test/client/input_required_test.dart
@@ -416,6 +416,14 @@ void main() {
       },
       expectedState: null,
     ),
+    (
+      name: 'a padded request state',
+      result: <String, Object?>{
+        'resultType': 'input_required',
+        'requestState': '  client.state/+  ',
+      },
+      expectedState: '  client.state/+  ',
+    ),
   ]) {
     test('retries with ${boundaryCase.name}', () async {
       final harness = _WireHarness(


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

These tests wrote no padded request states. Trimming any of the five writes changed nothing they could see. Padded values run through all five now.

The old test name said `across JSON`, but it just decoded. I narrowed it to what the test checks.
