### PR TITLE
add a client fixture for the conformance suite

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -6,6 +6,7 @@
   without changing its public API.
 - Stop sending `notifications/roots/list_changed` to a server that speaks
   2026-07-28. An unsettled connection still gets it.
+- Add a client fixture for the MCP conformance suite under `tool/`.
 - **BREAKING**:
   - `MCPBase` (including the `MCPServer.fromStreamChannel` and
     `ServerConnection.fromStreamChannel` constructors),

--- a/pkgs/dart_mcp/test/conformance_client_test.dart
+++ b/pkgs/dart_mcp/test/conformance_client_test.dart
@@ -1,0 +1,221 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+const _protocolVersion = '2026-07-28';
+// The transport does not support this version. It comes first in the
+// server's supported list, so the fixture has to look past it.
+const _olderVersion = '2025-11-25';
+const _addNumbersTool = 'add_numbers';
+const _scenarioVariable = 'MCP_CONFORMANCE_SCENARIO';
+// An input request and its answer share one key.
+const _formKey = 'form';
+
+void main() {
+  group('conformance client', () {
+    late HttpServer server;
+    late Uri endpoint;
+    late List<_Received> received;
+
+    setUp(() async {
+      server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      endpoint = Uri.http('${server.address.host}:${server.port}', '/mcp');
+      received = [];
+      addTearDown(() => server.close(force: true));
+    });
+
+    /// Answers each request with [reply], after recording it.
+    void serve(
+      Map<String, Object?>? Function(_Received request, int count) reply,
+    ) {
+      server.listen((request) async {
+        final body =
+            jsonDecode(await utf8.decodeStream(request))
+                as Map<String, Object?>;
+        // A notification carries no id and gets no reply.
+        if (!body.containsKey('id')) {
+          request.response.statusCode = HttpStatus.accepted;
+          await request.response.close();
+          return;
+        }
+        final entry = _Received(
+          method: body['method'] as String,
+          version: request.headers.value('MCP-Protocol-Version'),
+          params: body['params'] as Map<String, Object?>? ?? const {},
+        );
+        received.add(entry);
+        final answer = reply(entry, received.length);
+        request.response
+          ..statusCode =
+              answer?['error'] == null ? HttpStatus.ok : HttpStatus.badRequest
+          ..headers.contentType = ContentType.json
+          ..write(jsonEncode({'jsonrpc': '2.0', 'id': body['id'], ...?answer}));
+        await request.response.close();
+      });
+    }
+
+    test('lists and calls the tool its scenario names', () async {
+      serve((request, _) => _result(request.method));
+
+      await _runFixture(endpoint, 'tools_call');
+
+      expect(received.map((request) => request.method), [
+        'tools/list',
+        'tools/call',
+      ]);
+      expect(received.last.params['name'], _addNumbersTool);
+      expect(received.last.params['arguments'], {'a': 5, 'b': 7});
+    });
+
+    test('retries on a version the transport supports', () async {
+      serve(
+        (request, count) =>
+            count == 1
+                ? {
+                  'error': {
+                    'code': -32022,
+                    'message': 'Unsupported protocol version',
+                    // The rejected version comes first, so a fixture that
+                    // takes the first name it is given picks a version the
+                    // transport cannot open.
+                    'data': {
+                      'supported': [_olderVersion, _protocolVersion],
+                      'requested': request.version,
+                    },
+                  },
+                }
+                : _result(request.method),
+      );
+
+      await _runFixture(endpoint, 'tools_call');
+
+      expect(received.map((request) => request.method), [
+        'tools/list',
+        'tools/list',
+        'tools/call',
+      ]);
+      expect(received.last.version, _protocolVersion);
+    });
+
+    test('answers each elicitation property with its declared type', () async {
+      serve(
+        (request, count) =>
+            count == 2
+                ? {
+                  'result': {
+                    'resultType': 'input_required',
+                    'inputRequests': {
+                      _formKey: {
+                        'method': 'elicitation/create',
+                        'params': {
+                          'mode': 'form',
+                          'message': 'conformance',
+                          'requestedSchema': {
+                            'type': 'object',
+                            'properties': {
+                              'flag': {'type': 'boolean'},
+                              'count': {'type': 'integer'},
+                              'ratio': {'type': 'number'},
+                              'label': {'type': 'string'},
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                }
+                : _result(request.method),
+      );
+
+      await _runFixture(endpoint, 'tools_call');
+
+      final responses =
+          received.last.params['inputResponses'] as Map<String, Object?>;
+      final answer = responses[_formKey] as Map<String, Object?>;
+      expect(answer['action'], 'accept');
+      // The value has to carry the declared type. An answer of the
+      // wrong type still fills the form, and a scenario that only checks for
+      // an accept would score it as a pass.
+      expect(answer['content'], {
+        'flag': isA<bool>(),
+        'count': isA<int>(),
+        'ratio': isA<double>(),
+        'label': isA<String>(),
+      });
+    });
+    // Once compiled, `Platform.resolvedExecutable` is this test's own
+    // binary, so there is nothing to start the fixture with.
+  }, testOn: '!exe');
+}
+
+/// A request the fixture put on the wire.
+final class _Received {
+  _Received({
+    required this.method,
+    required this.version,
+    required this.params,
+  });
+
+  final String method;
+  final String? version;
+  final Map<String, Object?> params;
+}
+
+/// A well-formed result for a [method] request.
+Map<String, Object?> _result(String method) => {
+  'result': switch (method) {
+    'tools/call' => {
+      'content': [
+        {'type': 'text', 'text': '12'},
+      ],
+    },
+    _ => {
+      'tools': [
+        {
+          'name': _addNumbersTool,
+          'inputSchema': {'type': 'object'},
+        },
+      ],
+    },
+  },
+};
+
+/// Runs the fixture against [endpoint] as the suite would, and expects it to
+/// succeed.
+///
+/// Reports what the fixture wrote before the runner's 30 second default, since
+/// one that neither finishes nor exits leaves nothing behind to read. The wait
+/// is close to that default so that a loaded bot still gets to finish.
+Future<void> _runFixture(Uri endpoint, String scenario) async {
+  final process = await Process.start(
+    Platform.resolvedExecutable,
+    ['tool/conformance_client.dart', endpoint.toString()],
+    workingDirectory: Directory.current.path,
+    environment: {_scenarioVariable: scenario},
+  );
+  final output = StringBuffer();
+  final drained = Future.wait([
+    process.stdout.transform(utf8.decoder).forEach(output.write),
+    process.stderr.transform(utf8.decoder).forEach(output.write),
+  ]);
+  const timedOut = -1;
+  final code = await process.exitCode.timeout(
+    const Duration(seconds: 25),
+    onTimeout: () {
+      process.kill();
+      return timedOut;
+    },
+  );
+  await drained;
+  if (code == timedOut) fail('The fixture never exited. It wrote: $output');
+  expect(code, 0, reason: output.toString());
+}

--- a/pkgs/dart_mcp/test/conformance_client_test.dart
+++ b/pkgs/dart_mcp/test/conformance_client_test.dart
@@ -202,6 +202,8 @@ Future<void> _runFixture(Uri endpoint, String scenario) async {
     workingDirectory: Directory.current.path,
     environment: {_scenarioVariable: scenario},
   );
+  // A failure before the wait below leaves the child running otherwise.
+  addTearDown(process.kill);
   final output = StringBuffer();
   final drained = Future.wait([
     process.stdout.transform(utf8.decoder).forEach(output.write),

--- a/pkgs/dart_mcp/tool/conformance_client.dart
+++ b/pkgs/dart_mcp/tool/conformance_client.dart
@@ -1,0 +1,237 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_mcp/client.dart';
+import 'package:dart_mcp/streamable_http.dart';
+import 'package:json_rpc_2/json_rpc_2.dart';
+
+/// Runs the client fixture used by the MCP conformance suite.
+///
+/// The suite appends its endpoint as the last argument and names the scenario
+/// in `MCP_CONFORMANCE_SCENARIO`. Run the suite against this fixture with
+///
+/// ```sh
+/// npx @modelcontextprotocol/conformance@0.2.0-alpha.11 \
+///   client --command "dart run tool/conformance_client.dart" \
+///   --requirements 2026-07-28
+/// ```
+Future<void> main(List<String> arguments) async {
+  if (arguments.isEmpty) {
+    stderr.writeln('Expected the conformance endpoint as the last argument.');
+    exitCode = 2;
+    return;
+  }
+  final endpoint = Uri.parse(arguments.last);
+  final environment = Platform.environment;
+  final scenario = environment[_scenarioVariable];
+  if (scenario == null) {
+    stderr.writeln('Expected a scenario name in $_scenarioVariable.');
+    exitCode = 2;
+    return;
+  }
+  final rawContext = environment[_contextVariable];
+  final context =
+      rawContext == null
+          ? const <String, Object?>{}
+          : (jsonDecode(rawContext) as Map).cast<String, Object?>();
+
+  var protocolVersion =
+      ProtocolVersion.tryParse(environment[_versionVariable] ?? '') ??
+      ProtocolVersion.v2026_07_28;
+  // The request-metadata scenario turns down the first offered version.
+  // Retrying once on a version from that reply is part of the scenario.
+  for (var attempt = 0; ; attempt++) {
+    try {
+      await _run(scenario, endpoint, protocolVersion, context);
+      return;
+    } on RpcException catch (error) {
+      final offered = attempt == 0 ? _offeredVersion(error) : null;
+      if (offered == null) {
+        stderr.writeln('$scenario: $error');
+        exitCode = 1;
+        return;
+      }
+      protocolVersion = offered;
+    }
+  }
+}
+
+const _scenarioVariable = 'MCP_CONFORMANCE_SCENARIO';
+const _versionVariable = 'MCP_CONFORMANCE_PROTOCOL_VERSION';
+const _contextVariable = 'MCP_CONFORMANCE_CONTEXT';
+
+const _addNumbersTool = 'add_numbers';
+const _echoStateTool = 'test_mrtr_echo_state';
+const _noStateTool = 'test_mrtr_no_state';
+const _unrelatedTool = 'test_mrtr_unrelated';
+const _noResultTypeTool = 'test_mrtr_no_result_type';
+
+/// Connects to [endpoint] and drives the traffic [scenario] scores.
+Future<void> _run(
+  String scenario,
+  Uri endpoint,
+  ProtocolVersion protocolVersion,
+  Map<String, Object?> context,
+) async {
+  final client = _ConformanceClient();
+  final connection = client.connectServer(
+    streamableHttpClientChannel(
+      endpoint,
+      protocolVersion: protocolVersion,
+      clientCapabilities: client.capabilities,
+      clientInfo: client.implementation,
+    ),
+  );
+  // This revision settles the version on the transport outside the handshake,
+  // and the multi-round retry path reads it off the connection.
+  connection.protocolVersion = protocolVersion;
+  try {
+    // Every scenario lists first. The header scenarios score the list request
+    // itself, and a later call mirrors the annotations the list carried.
+    final tools = await connection.listTools();
+    switch (scenario) {
+      case 'tools_call':
+        await connection.callTool(
+          CallToolRequest(name: _addNumbersTool, arguments: {'a': 5, 'b': 7}),
+        );
+      case 'http-standard-headers':
+        await _exerciseNamedMethods(connection, tools);
+      case 'http-custom-headers':
+        for (final call in _toolCalls(context)) {
+          await connection.callTool(call);
+        }
+      case 'http-invalid-tool-headers':
+        // The transport drops tools with invalid header annotations, so the
+        // list only holds the ones it kept. Call each of them.
+        for (final tool in tools.tools) {
+          await connection.callTool(
+            CallToolRequest(name: tool.name, arguments: const {}),
+          );
+        }
+      case 'sep-2322-client-request-state':
+        await _driveMultiRound(connection);
+    }
+  } finally {
+    await client.shutdown();
+  }
+}
+
+/// Calls each method that carries a name in a header.
+///
+/// The header scenario reads that name off `tools/call`, `resources/read` and
+/// `prompts/get`. Each one has to be sent for its check to be scored.
+Future<void> _exerciseNamedMethods(
+  ServerConnection connection,
+  ListToolsResult tools,
+) async {
+  if (tools.tools.isNotEmpty) {
+    await connection.callTool(
+      CallToolRequest(name: tools.tools.first.name, arguments: const {}),
+    );
+  }
+  final resources = (await connection.listResources()).resources;
+  if (resources.isNotEmpty) {
+    await connection.readResource(
+      ReadResourceRequest(uri: resources.first.uri),
+    );
+  }
+  final prompts = (await connection.listPrompts()).prompts;
+  if (prompts.isNotEmpty) {
+    await connection.getPrompt(GetPromptRequest(name: prompts.first.name));
+  }
+}
+
+/// Calls each tool the request-state scenario scores.
+///
+/// The unrelated call starts together with the multi-round one, so the
+/// scenario can see that one call's state stays out of another's.
+Future<void> _driveMultiRound(ServerConnection connection) async {
+  await Future.wait([
+    connection.callTool(CallToolRequest(name: _echoStateTool)),
+    connection.callTool(CallToolRequest(name: _unrelatedTool)),
+  ]);
+  await connection.callTool(CallToolRequest(name: _noStateTool));
+  await connection.callTool(CallToolRequest(name: _noResultTypeTool));
+}
+
+/// Reads the tool calls the suite asked for out of its scenario context.
+Iterable<CallToolRequest> _toolCalls(Map<String, Object?> context) sync* {
+  final calls = context['toolCalls'];
+  if (calls is! List) return;
+  for (final call in calls) {
+    if (call is! Map) continue;
+    final name = call['name'];
+    if (name is! String) continue;
+    final arguments = call['arguments'];
+    yield CallToolRequest(
+      name: name,
+      arguments: arguments is Map ? arguments.cast<String, Object?>() : null,
+    );
+  }
+}
+
+/// Picks a version this transport can speak out of a rejected handshake.
+ProtocolVersion? _offeredVersion(RpcException error) {
+  if (error.code != McpErrorCodes.unsupportedProtocolVersion) return null;
+  final data = error.data;
+  final supported = data is Map ? data['supported'] : null;
+  if (supported is! List) return null;
+  for (final version in supported) {
+    if (version is! String) continue;
+    final parsed = ProtocolVersion.tryParse(version);
+    if (parsed != null && parsed.supportsStreamableHttp) return parsed;
+  }
+  return null;
+}
+
+/// A client that answers the input requests a multi-round result carries.
+///
+/// The mixins declare the roots, sampling and elicitation capabilities the
+/// metadata scenario reads back out of `_meta`.
+final class _ConformanceClient extends MCPClient
+    with RootsSupport, SamplingSupport, ElicitationFormSupport {
+  _ConformanceClient()
+    : super(
+        Implementation(name: 'dart_mcp conformance client', version: '0.1.0'),
+      );
+
+  @override
+  ElicitResult handleElicitation(
+    ElicitRequest request,
+    ServerConnection connection,
+  ) => ElicitResult(
+    action: ElicitationAction.accept,
+    content: _filled(request.requestedSchema),
+  );
+
+  @override
+  CreateMessageResult handleCreateMessage(
+    CreateMessageRequest request,
+    Implementation serverInfo,
+  ) => CreateMessageResult(
+    role: Role.assistant,
+    content: TextContent(text: 'conformance'),
+    model: 'conformance',
+  );
+}
+
+/// Answers every property [schema] asks for with a value of its type.
+Map<String, Object?> _filled(ObjectSchema? schema) {
+  final properties = schema?.properties;
+  if (properties == null) return const {};
+  final content = <String, Object?>{};
+  for (final MapEntry(:key, :value) in properties.entries) {
+    final type = (value as Map<String, Object?>)['type'];
+    content[key] = switch (type) {
+      final String type when type == JsonType.bool.typeName => true,
+      final String type when type == JsonType.int.typeName => 1,
+      final String type when type == JsonType.num.typeName => 1.0,
+      _ => 'conformance',
+    };
+  }
+  return content;
+}

--- a/pkgs/dart_mcp/tool/conformance_client.dart
+++ b/pkgs/dart_mcp/tool/conformance_client.dart
@@ -69,6 +69,8 @@ const _echoStateTool = 'test_mrtr_echo_state';
 const _noStateTool = 'test_mrtr_no_state';
 const _unrelatedTool = 'test_mrtr_unrelated';
 const _noResultTypeTool = 'test_mrtr_no_result_type';
+const _jsonSchemaTool = 'json_schema_2020_12_tool';
+const _jsonSchemaEchoTool = 'json_schema_echo';
 
 /// Connects to [endpoint] and drives the traffic [scenario] scores.
 Future<void> _run(
@@ -114,6 +116,8 @@ Future<void> _run(
         }
       case 'sep-2322-client-request-state':
         await _driveMultiRound(connection);
+      case 'json-schema-2020-12-preservation':
+        await _echoJsonSchema(connection, tools);
     }
   } finally {
     await client.shutdown();
@@ -142,6 +146,27 @@ Future<void> _exerciseNamedMethods(
   final prompts = (await connection.listPrompts()).prompts;
   if (prompts.isNotEmpty) {
     await connection.getPrompt(GetPromptRequest(name: prompts.first.name));
+  }
+}
+
+/// Calls `json_schema_echo` with the focal tool's inputSchema.
+///
+/// The scenario scores whether the schema keywords the client decoded off
+/// the list response come back unchanged on this call, so the schema is
+/// forwarded as-is.
+Future<void> _echoJsonSchema(
+  ServerConnection connection,
+  ListToolsResult tools,
+) async {
+  for (final tool in tools.tools) {
+    if (tool.name != _jsonSchemaTool) continue;
+    await connection.callTool(
+      CallToolRequest(
+        name: _jsonSchemaEchoTool,
+        arguments: {'schema': tool.inputSchema},
+      ),
+    );
+    return;
   }
 }
 


### PR DESCRIPTION
The suite tests clients as well as servers, but `tool/` only carried the server fixture, so there was nothing to run the client leg against.

This one just branches on the scenario name the suite passes in the environment, and drives the traffic it scores. Tests run it against a server on the wire, and cover the retry when that server turns its version down. Non-auth scenarios pass 63 checks, run one at a time. The suite's parallel mode starts a client per scenario and they fall over each other here. I left `auth/*` out, since the package has no OAuth client.

    npx @modelcontextprotocol/conformance@0.2.0-alpha.11 \
      client --command "dart run tool/conformance_client.dart" \
      --spec-version 2026-07-28 --scenario tools_call
