### PR TITLE
name the transports in the package description

### DIFF
--- a/pkgs/dart_mcp/pubspec.yaml
+++ b/pkgs/dart_mcp/pubspec.yaml
@@ -4,7 +4,9 @@
 
 name: dart_mcp
 version: 0.6.0-wip
-description: A package for making MCP servers and clients.
+description: >-
+  A package for making MCP servers and clients, over stdio or the Streamable
+  HTTP transport.
 repository: https://github.com/dart-lang/ai/tree/main/pkgs/dart_mcp
 issue_tracker: https://github.com/dart-lang/ai/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Adart_mcp
 


### PR DESCRIPTION
The pubspec report asks for 50 characters and this one is 45, so `dart_mcp` loses the pubspec points on its listing. Naming the transports carries it past the minimum without saying anything new about the package.
