### PR TITLE
let a caller add headers to the client channel

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.6.0-wip
 
+- Add optional headers to `streamableHttpClientChannel`, with protocol headers
+  taking precedence on each POST.
 - Convert schema enum values and multi-select defaults to fixed-length lists so
   schemas built from sets or lazy iterables can be JSON encoded.
 - Split the Streamable HTTP implementation into client and server libraries

--- a/pkgs/dart_mcp/lib/src/client/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/src/client/streamable_http.dart
@@ -25,13 +25,16 @@ import '../utils/streamable_http.dart';
 /// notification. Notifications have no id to carry an error. A response
 /// stream that ends without answering the request fails it the same way. A
 /// `202` on a notification is not an inbound message. Valid `x-mcp-header`
-/// annotations from `tools/list` are mirrored on later `tools/call` requests. Invalid tool
-/// definitions are dropped. Does not send `initialize`.
+/// annotations from `tools/list` are mirrored on later `tools/call` requests.
+/// Invalid tool definitions are dropped. The [headers] map is written to each
+/// POST, and the protocol's own headers override it. Does not send
+/// `initialize`.
 StreamChannel<Map<String, Object?>> streamableHttpClientChannel(
   Uri uri, {
   required ProtocolVersion protocolVersion,
   required ClientCapabilities clientCapabilities,
   Implementation? clientInfo,
+  Map<String, String>? headers,
 }) {
   if (!protocolVersion.supportsStreamableHttp) {
     final supportedVersions = ProtocolVersion.values
@@ -59,6 +62,7 @@ StreamChannel<Map<String, Object?>> streamableHttpClientChannel(
           protocolVersion,
           clientCapabilities,
           clientInfo,
+          headers,
           state,
         ),
       )
@@ -78,6 +82,7 @@ Stream<Map<String, Object?>> _sendStreamableHttpMessage(
   ProtocolVersion protocolVersion,
   ClientCapabilities clientCapabilities,
   Implementation? clientInfo,
+  Map<String, String>? headers,
   _StreamableHttpClientState state,
 ) async* {
   // Shape errors happen before this turns true, transport errors after.
@@ -130,6 +135,7 @@ Stream<Map<String, Object?>> _sendStreamableHttpMessage(
             : const <String, String>{};
     posting = true;
     final request = await httpClient.postUrl(uri);
+    headers?.forEach(request.headers.set);
     request.headers
       ..contentType = ContentType.json
       ..set(

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -11,6 +11,7 @@ import 'dart:io';
 
 import 'package:dart_mcp/server.dart';
 import 'package:dart_mcp/src/utils/constants.dart';
+import 'package:dart_mcp/src/utils/streamable_http.dart';
 import 'package:dart_mcp/streamable_http.dart';
 import 'package:json_rpc_2/error_code.dart' as error_code;
 import 'package:json_rpc_2/json_rpc_2.dart';
@@ -191,6 +192,132 @@ void main() {
       response.substring(response.indexOf('{'), response.lastIndexOf('}') + 1);
 
   group('client channel', () {
+    test('omits custom headers by default', () async {
+      final wireServer = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => wireServer.close(force: true));
+      final observed = Completer<void>();
+      wireServer.listen((request) async {
+        try {
+          expect(
+            request.headers.value(HttpHeaders.authorizationHeader),
+            isNull,
+          );
+          expect(request.headers.value(protocolVersionHeader), version);
+          observed.complete();
+        } catch (error, stackTrace) {
+          observed.completeError(error, stackTrace);
+        } finally {
+          request.response
+            ..headers.contentType = ContentType.json
+            ..write(
+              jsonEncode({
+                Keys.jsonrpc: '2.0',
+                Keys.id: 1,
+                Keys.result: <String, Object?>{},
+              }),
+            );
+          await request.response.close();
+        }
+      });
+
+      final channel = streamableHttpClientChannel(
+        Uri.http('${wireServer.address.host}:${wireServer.port}', '/mcp'),
+        protocolVersion: ProtocolVersion.v2026_07_28,
+        clientCapabilities: ClientCapabilities(),
+      );
+      addTearDown(() => channel.sink.close());
+      channel.sink.add({
+        Keys.jsonrpc: '2.0',
+        Keys.id: 1,
+        Keys.method: 'test/request',
+      });
+
+      await Future.wait([channel.stream.first, observed.future]);
+    });
+
+    test('sends caller authorization headers', () async {
+      final wireServer = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => wireServer.close(force: true));
+      final observed = Completer<void>();
+      wireServer.listen((request) async {
+        try {
+          expect(
+            request.headers.value(HttpHeaders.authorizationHeader),
+            'Bearer t',
+          );
+          observed.complete();
+        } catch (error, stackTrace) {
+          observed.completeError(error, stackTrace);
+        } finally {
+          request.response
+            ..headers.contentType = ContentType.json
+            ..write(
+              jsonEncode({
+                Keys.jsonrpc: '2.0',
+                Keys.id: 1,
+                Keys.result: <String, Object?>{},
+              }),
+            );
+          await request.response.close();
+        }
+      });
+
+      final channel = streamableHttpClientChannel(
+        Uri.http('${wireServer.address.host}:${wireServer.port}', '/mcp'),
+        protocolVersion: ProtocolVersion.v2026_07_28,
+        clientCapabilities: ClientCapabilities(),
+        headers: {'Authorization': 'Bearer t'},
+      );
+      addTearDown(() => channel.sink.close());
+      channel.sink.add({
+        Keys.jsonrpc: '2.0',
+        Keys.id: 1,
+        Keys.method: 'test/request',
+      });
+
+      await Future.wait([channel.stream.first, observed.future]);
+    });
+
+    test('keeps protocol version over caller headers', () async {
+      final wireServer = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => wireServer.close(force: true));
+      final observed = Completer<void>();
+      wireServer.listen((request) async {
+        try {
+          expect(request.headers.value(protocolVersionHeader), version);
+          observed.complete();
+        } catch (error, stackTrace) {
+          observed.completeError(error, stackTrace);
+        } finally {
+          request.response
+            ..headers.contentType = ContentType.json
+            ..write(
+              jsonEncode({
+                Keys.jsonrpc: '2.0',
+                Keys.id: 1,
+                Keys.result: <String, Object?>{},
+              }),
+            );
+          await request.response.close();
+        }
+      });
+
+      final channel = streamableHttpClientChannel(
+        Uri.http('${wireServer.address.host}:${wireServer.port}', '/mcp'),
+        protocolVersion: ProtocolVersion.v2026_07_28,
+        clientCapabilities: ClientCapabilities(),
+        headers: {protocolVersionHeader: 'caller-version'},
+      );
+      addTearDown(() => channel.sink.close());
+      channel.sink.add({
+        Keys.jsonrpc: '2.0',
+        Keys.id: 1,
+        Keys.method: 'test/request',
+      });
+
+      await Future.wait([channel.stream.first, observed.future]);
+    });
+
     test('posts request metadata and emits the JSON response', () async {
       final wireServer = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
       addTearDown(() => wireServer.close(force: true));


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/162

The server handler leaves authentication to the embedding server. On the client side there was no way to send any. The channel builds its own `HttpClient`, and there was no way to hand it an `Authorization` header.

It takes a map now. The protocol's own headers are written after it, so a caller cannot replace the version, the method or a mirrored parameter.
