### PR TITLE
add optional origin validation for Streamable HTTP

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.6.0-wip
 
+- Validate the `Origin` header against `allowedOrigins` on
+  `handleStreamableHttpRequest`, answering 403 when a request carries one the
+  list leaves out. Leaving the argument off keeps the header unread.
 - Add optional headers to `streamableHttpClientChannel`, with protocol headers
   taking precedence on each POST.
 - Convert schema enum values and multi-select defaults to fixed-length lists so

--- a/pkgs/dart_mcp/lib/src/server/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/src/server/streamable_http.dart
@@ -46,10 +46,11 @@ import 'server.dart';
 /// Notifications are acknowledged with `202 Accepted` and not dispatched,
 /// since this protocol revision defines no client-to-server notifications
 /// over HTTP. This handler reads a request body into memory, and caps it at
-/// [maxRequestBodyBytes]. It does not read the `Origin` header. The
-/// specification requires a server to validate that header and answer with
-/// 403. The check needs deployment knowledge this handler does not have, so it
-/// belongs to the embedding HTTP server, along with authentication.
+/// [maxRequestBodyBytes]. The specification requires a server to validate the
+/// `Origin` header and answer with 403. Pass [allowedOrigins] to have that
+/// check run here. Without it the check needs deployment knowledge this
+/// handler does not have, so it belongs to the embedding HTTP server, along
+/// with authentication.
 ///
 /// Responses produced by the dispatched server are written unchanged, so an
 /// error a request handler throws reaches the client with whatever payload
@@ -114,6 +115,7 @@ Future<void> handleStreamableHttpRequest(
   Stream<Map<String, Object?>>? subscriptionNotifications,
   Duration listenKeepAliveInterval = const Duration(seconds: 15),
   int maxRequestBodyBytes = 4 * 1024 * 1024,
+  Set<String>? allowedOrigins,
 }) async {
   RangeError.checkNotNegative(maxRequestBodyBytes, 'maxRequestBodyBytes');
   final response = request.response;
@@ -124,6 +126,21 @@ Future<void> handleStreamableHttpRequest(
       ..contentLength = 0;
     await response.close();
     return;
+  }
+
+  if (allowedOrigins != null) {
+    // Read the header as a list, the way the checks below read theirs. A
+    // request that repeats it carries no one origin to check, so it is turned
+    // down with the ones this server does not allow.
+    final origins = request.headers['origin'];
+    if (origins != null &&
+        (origins.length != 1 || !allowedOrigins.contains(origins.single))) {
+      response
+        ..statusCode = HttpStatus.forbidden
+        ..contentLength = 0;
+      await response.close();
+      return;
+    }
   }
 
   // A body cannot be parsed before its media type is known, so this precedes

--- a/pkgs/dart_mcp/lib/src/server/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/src/server/streamable_http.dart
@@ -47,10 +47,10 @@ import 'server.dart';
 /// since this protocol revision defines no client-to-server notifications
 /// over HTTP. This handler reads a request body into memory, and caps it at
 /// [maxRequestBodyBytes]. The specification requires a server to validate the
-/// `Origin` header and answer with 403. Pass [allowedOrigins] to have that
-/// check run here. Without it the check needs deployment knowledge this
-/// handler does not have, so it belongs to the embedding HTTP server, along
-/// with authentication.
+/// `Origin` header and answer with 403. That check needs the deployment's own
+/// list of origins, so [allowedOrigins] carries it. Without the list the header
+/// goes unread and the check stays with the embedding HTTP server, along with
+/// authentication.
 ///
 /// Responses produced by the dispatched server are written unchanged, so an
 /// error a request handler throws reaches the client with whatever payload

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -56,9 +56,6 @@ void main() {
 
   setUp(() async {
     serverFactory = _HttpTestServer.new;
-    servers.clear();
-    allowedOrigins = null;
-    notifications.clear();
     subscriptionNotifications = StreamController.broadcast(sync: true);
     httpServer = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
     uri = Uri.http('${httpServer.address.host}:${httpServer.port}', '/mcp');
@@ -83,6 +80,12 @@ void main() {
       await httpServer.close(force: true);
       await subscriptionNotifications.close();
     });
+  });
+
+  tearDown(() {
+    servers.clear();
+    allowedOrigins = null;
+    notifications.clear();
   });
 
   /// A request body for [method] carrying the standard envelope.

--- a/pkgs/dart_mcp/test/streamable_http_test.dart
+++ b/pkgs/dart_mcp/test/streamable_http_test.dart
@@ -50,12 +50,14 @@ void main() {
   late Uri uri;
   late MCPServerFactory serverFactory;
   late StreamController<Map<String, Object?>> subscriptionNotifications;
+  Set<String>? allowedOrigins;
   final servers = <MCPServer>[];
   final notifications = <Map<String, Object?>>[];
 
   setUp(() async {
     serverFactory = _HttpTestServer.new;
     servers.clear();
+    allowedOrigins = null;
     notifications.clear();
     subscriptionNotifications = StreamController.broadcast(sync: true);
     httpServer = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
@@ -74,6 +76,7 @@ void main() {
         },
         subscriptionNotifications: subscriptionNotifications.stream,
         listenKeepAliveInterval: const Duration(milliseconds: 50),
+        allowedOrigins: allowedOrigins,
       ),
     );
     addTearDown(() async {
@@ -1887,6 +1890,101 @@ void main() {
       final result = decode(text)[Keys.result] as Map<String, Object?>;
       final content = result[Keys.content] as List;
       expect((content.single as Map<String, Object?>)[Keys.text], '1.2.3');
+    });
+  });
+
+  group('origin validation', () {
+    test('serves a request carrying an origin with no allowlist', () async {
+      final (status, _, text) = await post(
+        headers: {...headers(listTools), 'Origin': 'https://client.example'},
+        json: body(listTools),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
+
+    test('accepts an origin in the allowlist', () async {
+      allowedOrigins = {'https://client.example'};
+      final (status, _, text) = await post(
+        headers: {...headers(listTools), 'Origin': 'https://client.example'},
+        json: body(listTools),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
+
+    test('rejects an origin outside the allowlist', () async {
+      allowedOrigins = {'https://client.example'};
+      final (status, _, text) = await post(
+        headers: {...headers(listTools), 'Origin': 'https://other.example'},
+        json: body(listTools),
+      );
+      expect(status, HttpStatus.forbidden);
+      expect(text, isEmpty);
+      expect(servers, isEmpty);
+    });
+
+    test('rejects an origin sent as two separate field lines', () async {
+      allowedOrigins = {'https://client.example'};
+      final requestBody = jsonEncode(body(listTools));
+      final response = await rawRequest(
+        'POST /mcp HTTP/1.1\r\n'
+        'Host: localhost\r\n'
+        'Content-Type: application/json\r\n'
+        'Accept: application/json, text/event-stream\r\n'
+        'Mcp-Protocol-Version: $version\r\n'
+        'Mcp-Method: $listTools\r\n'
+        'Origin: https://client.example\r\n'
+        'Origin: https://other.example\r\n'
+        'Content-Length: ${requestBody.length}\r\n'
+        'Connection: close\r\n'
+        '\r\n'
+        '$requestBody',
+      );
+      // The first line is in the allowlist, so only the line count can be
+      // what this rejection is about.
+      expect(response, startsWith('HTTP/1.1 403'));
+      expect(servers, isEmpty);
+    });
+
+    test('serves two origin field lines with no allowlist', () async {
+      final requestBody = jsonEncode(body(listTools));
+      final response = await rawRequest(
+        'POST /mcp HTTP/1.1\r\n'
+        'Host: localhost\r\n'
+        'Content-Type: application/json\r\n'
+        'Accept: application/json, text/event-stream\r\n'
+        'Mcp-Protocol-Version: $version\r\n'
+        'Mcp-Method: $listTools\r\n'
+        'Origin: https://client.example\r\n'
+        'Origin: https://other.example\r\n'
+        'Content-Length: ${requestBody.length}\r\n'
+        'Connection: close\r\n'
+        '\r\n'
+        '$requestBody',
+      );
+      expect(response, startsWith('HTTP/1.1 200'));
+      expect(errorCode(jsonBody(response)), isNull);
+    });
+    test('accepts a request without origin', () async {
+      allowedOrigins = {'https://client.example'};
+      final (status, _, text) = await post(
+        headers: headers(listTools),
+        json: body(listTools),
+      );
+      expect(status, 200);
+      expect(errorCode(text), isNull);
+    });
+
+    test('rejects any origin when the allowlist is empty', () async {
+      allowedOrigins = {};
+      final (status, _, text) = await post(
+        headers: {...headers(listTools), 'Origin': 'https://client.example'},
+        json: body(listTools),
+      );
+      expect(status, HttpStatus.forbidden);
+      expect(text, isEmpty);
+      expect(servers, isEmpty);
     });
   });
 


### PR DESCRIPTION
Adds optional `allowedOrigins` to `handleStreamableHttpRequest`, leaving default behavior unchanged. With it set, absent or allowed origins pass, while unlisted or repeated Origin headers return an empty 403 response.

I chose opt-in validation, as in TypeScript middleware and the Go handler. This is just the Origin half I said was ready in #162, and closing it is an answer if validation belongs outside the package.

Part of dart-lang/ai#162
