### PR TITLE
add tool content types and a tools list for sampling

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Let `handleRequestScopedMessage` route server-to-client requests through an
   `onRequest` callback on revisions before 2026-07-28. Missing callbacks and
   invalid callback responses fail the server request without leaving it open.
+- Add `ToolUseContent` and `ToolResultContent` for sampling messages, and a
+  `tools` list on `CreateMessageRequest`.
 - **BREAKING**:
   - `MCPBase` (including the `MCPServer.fromStreamChannel` and
     `ServerConnection.fromStreamChannel` constructors),

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -502,7 +502,7 @@ enum CacheScope {
 /// Could be either [TextContent], [ImageContent], [AudioContent],
 /// [EmbeddedResource], [ToolUseContent] or [ToolResultContent].
 ///
-/// Use [isText], [isImage], [isEmbeddedResource], [isToolUse] and
+/// Use [isText], [isImage], [isAudio], [isEmbeddedResource], [isToolUse] and
 /// [isToolResult] before casting to the more specific types, or switch on the
 /// [type] and then cast.
 ///

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -538,11 +538,18 @@ extension type Content._(Map<String, Object?> _value) {
   bool get isEmbeddedResource =>
       _value[Keys.type] == EmbeddedResource.expectedType;
 
+  /// Whether this is a [ToolUseContent].
+  bool get isToolUse => _value[Keys.type] == ToolUseContent.expectedType;
+
+  /// Whether this is a [ToolResultContent].
+  bool get isToolResult => _value[Keys.type] == ToolResultContent.expectedType;
+
   /// The type of content.
   ///
   /// You can use this in a switch to handle the various types (see the static
-  /// `expectedType` getters), or you can use [isText], [isImage], [isAudio] and
-  /// [isEmbeddedResource] to determine the type and then do the cast.
+  /// `expectedType` getters), or you can use [isText], [isImage], [isAudio],
+  /// [isEmbeddedResource], [isToolUse] and [isToolResult] to determine the type
+  /// and then do the cast.
   String get type => _value[Keys.type] as String;
 }
 

--- a/pkgs/dart_mcp/lib/src/api/api.dart
+++ b/pkgs/dart_mcp/lib/src/api/api.dart
@@ -499,11 +499,12 @@ enum CacheScope {
   private,
 }
 
-/// Could be either [TextContent], [ImageContent], [AudioContent] or
-/// [EmbeddedResource].
+/// Could be either [TextContent], [ImageContent], [AudioContent],
+/// [EmbeddedResource], [ToolUseContent] or [ToolResultContent].
 ///
-/// Use [isText], [isImage] and [isEmbeddedResource] before casting to the more
-/// specific types, or switch on the [type] and then cast.
+/// Use [isText], [isImage], [isEmbeddedResource], [isToolUse] and
+/// [isToolResult] before casting to the more specific types, or switch on the
+/// [type] and then cast.
 ///
 /// Doing `is` checks does not work because these are just extension types, they
 /// all have the same runtime type (`Map<String, Object?>`).
@@ -525,6 +526,12 @@ extension type Content._(Map<String, Object?> _value) {
   /// Alias for [EmbeddedResource.new].
   static const embeddedResource = EmbeddedResource.new;
 
+  /// Alias for [ToolUseContent.new].
+  static const toolUse = ToolUseContent.new;
+
+  /// Alias for [ToolResultContent.new].
+  static const toolResult = ToolResultContent.new;
+
   /// Whether or not this is a [TextContent].
   bool get isText => _value[Keys.type] == TextContent.expectedType;
 
@@ -538,10 +545,10 @@ extension type Content._(Map<String, Object?> _value) {
   bool get isEmbeddedResource =>
       _value[Keys.type] == EmbeddedResource.expectedType;
 
-  /// Whether this is a [ToolUseContent].
+  /// Whether or not this is a [ToolUseContent].
   bool get isToolUse => _value[Keys.type] == ToolUseContent.expectedType;
 
-  /// Whether this is a [ToolResultContent].
+  /// Whether or not this is a [ToolResultContent].
   bool get isToolResult => _value[Keys.type] == ToolResultContent.expectedType;
 
   /// The type of content.

--- a/pkgs/dart_mcp/lib/src/api/sampling.dart
+++ b/pkgs/dart_mcp/lib/src/api/sampling.dart
@@ -36,6 +36,7 @@ extension type CreateMessageRequest.fromMap(Map<String, Object?> _value)
     required int maxTokens,
     List<String>? stopSequences,
     ToolChoice? toolChoice,
+    List<Tool>? tools,
     Map<String, Object?>? metadata,
     MetaWithProgressToken? meta,
   }) => CreateMessageRequest.fromMap({
@@ -47,6 +48,7 @@ extension type CreateMessageRequest.fromMap(Map<String, Object?> _value)
     Keys.maxTokens: maxTokens,
     if (stopSequences != null) Keys.stopSequences: stopSequences,
     if (toolChoice != null) Keys.toolChoice: toolChoice,
+    if (tools != null) Keys.tools: tools,
     if (metadata != null) Keys.metadata: metadata,
     if (meta != null) Keys.meta: meta,
   });
@@ -110,6 +112,9 @@ extension type CreateMessageRequest.fromMap(Map<String, Object?> _value)
 
   /// Controls how the model uses tools (if available).
   ToolChoice? get toolChoice => _value[Keys.toolChoice] as ToolChoice?;
+
+  /// Tools the model may call during this request.
+  List<Tool>? get tools => (_value[Keys.tools] as List?)?.cast<Tool>();
 
   /// Optional metadata to pass through to the LLM provider.
   ///

--- a/pkgs/dart_mcp/lib/src/api/sampling.dart
+++ b/pkgs/dart_mcp/lib/src/api/sampling.dart
@@ -166,6 +166,91 @@ extension type SamplingMessage.fromMap(Map<String, Object?> _value) {
   Content get content => _value[Keys.content] as Content;
 }
 
+/// A request from the assistant to call a tool.
+extension type ToolUseContent.fromMap(Map<String, Object?> _value)
+    implements Content, WithMetadata {
+  static const expectedType = 'tool_use';
+
+  factory ToolUseContent({
+    required String id,
+    required String name,
+    required Map<String, Object?> input,
+    Meta? meta,
+  }) => ToolUseContent.fromMap({
+    Keys.id: id,
+    Keys.input: input,
+    Keys.name: name,
+    Keys.type: expectedType,
+    if (meta != null) Keys.meta: meta,
+  });
+
+  /// The content type, always [expectedType].
+  String get type {
+    final type = _value[Keys.type] as String;
+    assert(type == expectedType);
+    return type;
+  }
+
+  /// The unique identifier for this tool use.
+  String get id => _value[Keys.id] as String;
+
+  /// The name of the tool to call.
+  String get name => _value[Keys.name] as String;
+
+  /// The arguments to pass to the tool.
+  Map<String, Object?> get input =>
+      (_value[Keys.input] as Map).cast<String, Object?>();
+}
+
+/// The result of a tool use, provided by the user back to the assistant.
+extension type ToolResultContent.fromMap(Map<String, Object?> _value)
+    implements Content, WithMetadata {
+  static const expectedType = 'tool_result';
+
+  factory ToolResultContent({
+    required List<Content> content,
+    required String toolUseId,
+    Map<String, Object?>? structuredContent,
+    bool? isError,
+    Meta? meta,
+  }) => ToolResultContent.fromMap({
+    Keys.content: content,
+    Keys.toolUseId: toolUseId,
+    Keys.type: expectedType,
+    if (structuredContent != null) Keys.structuredContent: structuredContent,
+    if (isError != null) Keys.isError: isError,
+    if (meta != null) Keys.meta: meta,
+  });
+
+  /// The content type, always [expectedType].
+  String get type {
+    final type = _value[Keys.type] as String;
+    assert(type == expectedType);
+    return type;
+  }
+
+  /// The content returned by the tool.
+  List<Content> get content {
+    final content = (_value[Keys.content] as List?)?.cast<Content>();
+    if (content == null) {
+      throw ArgumentError(
+        'Missing ${Keys.content} field in $ToolResultContent',
+      );
+    }
+    return content;
+  }
+
+  /// The structured result returned by the tool.
+  Map<String, Object?>? get structuredContent =>
+      _value[Keys.structuredContent] as Map<String, Object?>?;
+
+  /// Whether the tool use resulted in an error.
+  bool? get isError => _value[Keys.isError] as bool?;
+
+  /// The identifier of the tool use this result corresponds to.
+  String get toolUseId => _value[Keys.toolUseId] as String;
+}
+
 /// The server's preferences for model selection, requested of the client
 /// during sampling.
 ///

--- a/pkgs/dart_mcp/lib/src/api/sampling.dart
+++ b/pkgs/dart_mcp/lib/src/api/sampling.dart
@@ -150,8 +150,8 @@ extension type CreateMessageResult.fromMap(Map<String, Object?> _value)
 
   /// The reason why sampling stopped, if known.
   ///
-  /// Known reasons are "endTurn", "stopSequence", "maxTokens", or any other
-  /// reason.
+  /// Known reasons are "endTurn", "stopSequence", "maxTokens", "toolUse", or
+  /// any other reason.
   String? get stopReason => _value[Keys.stopReason] as String?;
 
   /// The JSON representation of this object.
@@ -172,6 +172,8 @@ extension type SamplingMessage.fromMap(Map<String, Object?> _value) {
 }
 
 /// A request from the assistant to call a tool.
+///
+/// From the 2025-11-25 revision.
 extension type ToolUseContent.fromMap(Map<String, Object?> _value)
     implements Content, WithMetadata {
   static const expectedType = 'tool_use';
@@ -208,6 +210,8 @@ extension type ToolUseContent.fromMap(Map<String, Object?> _value)
 }
 
 /// The result of a tool use, provided by the user back to the assistant.
+///
+/// From the 2025-11-25 revision.
 extension type ToolResultContent.fromMap(Map<String, Object?> _value)
     implements Content, WithMetadata {
   static const expectedType = 'tool_result';
@@ -234,7 +238,8 @@ extension type ToolResultContent.fromMap(Map<String, Object?> _value)
     return type;
   }
 
-  /// The content returned by the tool.
+  /// The content returned by the tool, either [TextContent], [ImageContent],
+  /// [AudioContent], [ResourceLink] or [EmbeddedResource].
   List<Content> get content {
     final content = (_value[Keys.content] as List?)?.cast<Content>();
     if (content == null) {

--- a/pkgs/dart_mcp/lib/src/utils/constants.dart
+++ b/pkgs/dart_mcp/lib/src/utils/constants.dart
@@ -67,6 +67,7 @@ extension Keys on Never {
   static const id = 'id';
   static const idempotentHint = 'idempotentHint';
   static const includeContext = 'includeContext';
+  static const input = 'input';
   static const inputRequests = 'inputRequests';
   static const inputResponses = 'inputResponses';
   static const inputSchema = 'inputSchema';
@@ -160,6 +161,7 @@ extension Keys on Never {
   static const theme = 'theme';
   static const title = 'title';
   static const toolChoice = 'toolChoice';
+  static const toolUseId = 'toolUseId';
   static const tools = 'tools';
   static const toolsListChanged = 'toolsListChanged';
   static const total = 'total';

--- a/pkgs/dart_mcp/test/api/sampling_test.dart
+++ b/pkgs/dart_mcp/test/api/sampling_test.dart
@@ -11,6 +11,28 @@ import 'package:test/test.dart';
 import '../test_utils.dart';
 
 void main() {
+  group('CreateMessageRequest tools', () {
+    test('writes and reads tools', () {
+      final request = CreateMessageRequest(
+        messages: [],
+        maxTokens: 1,
+        tools: [Tool(name: 'x', inputSchema: ObjectSchema())],
+      );
+      final wire = request as Map<String, Object?>;
+
+      expect(request.tools!.single.name, 'x');
+      expect(wire['tools'], hasLength(1));
+    });
+
+    test('omits tools when not provided', () {
+      final wire =
+          CreateMessageRequest(messages: [], maxTokens: 1)
+              as Map<String, Object?>;
+
+      expect(wire.containsKey('tools'), isFalse);
+    });
+  });
+
   test('includeContext round trips the values the schema names', () {
     for (final (value, wire) in const [
       (IncludeContext.none, 'none'),

--- a/pkgs/dart_mcp/test/api/sampling_test.dart
+++ b/pkgs/dart_mcp/test/api/sampling_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:dart_mcp/server.dart';
 import 'package:dart_mcp/src/client/client.dart';
@@ -11,6 +12,64 @@ import 'package:test/test.dart';
 import '../test_utils.dart';
 
 void main() {
+  group('tool content on the wire', () {
+    test('ToolUseContent survives a JSON round trip', () {
+      final content = ToolUseContent(
+        id: 'call-1',
+        name: 'lookup',
+        input: {'city': 'Ankara'},
+      );
+      final decoded = jsonDecode(jsonEncode(content)) as Map<String, Object?>;
+      final parsed = Content.fromMap(decoded);
+
+      expect(parsed.isToolUse, isTrue);
+      expect(parsed.isToolResult, isFalse);
+      expect((parsed as ToolUseContent).input, {'city': 'Ankara'});
+      expect(parsed.name, 'lookup');
+    });
+
+    test('ToolResultContent survives a JSON round trip', () {
+      final content = ToolResultContent(
+        content: [TextContent(text: 'sunny')],
+        toolUseId: 'call-1',
+        isError: false,
+      );
+      final decoded = jsonDecode(jsonEncode(content)) as Map<String, Object?>;
+      final parsed = Content.fromMap(decoded);
+
+      expect(parsed.isToolResult, isTrue);
+      expect(parsed.isToolUse, isFalse);
+      expect((parsed as ToolResultContent).toolUseId, 'call-1');
+      expect((parsed.content.single as TextContent).text, 'sunny');
+      expect(parsed.isError, isFalse);
+    });
+
+    test('a sampling message carries tool use content', () {
+      final message = SamplingMessage(
+        role: Role.assistant,
+        content: Content.toolUse(id: 'call-1', name: 'lookup', input: {}),
+      );
+      final decoded = jsonDecode(jsonEncode(message)) as Map<String, Object?>;
+      final parsed = SamplingMessage.fromMap(decoded);
+
+      expect(parsed.content.isToolUse, isTrue);
+      expect((parsed.content as ToolUseContent).id, 'call-1');
+    });
+
+    test('text content is neither tool use nor tool result', () {
+      final content = Content.text(text: 'hi');
+
+      expect(content.isToolUse, isFalse);
+      expect(content.isToolResult, isFalse);
+    });
+
+    test('tools reads as null when the key is absent', () {
+      final request = CreateMessageRequest(messages: [], maxTokens: 1);
+
+      expect(request.tools, isNull);
+    });
+  });
+
   group('CreateMessageRequest tools', () {
     test('writes and reads tools', () {
       final request = CreateMessageRequest(

--- a/pkgs/dart_mcp/test/api/sampling_test.dart
+++ b/pkgs/dart_mcp/test/api/sampling_test.dart
@@ -111,6 +111,132 @@ void main() {
     );
   });
 
+  group('ToolUseContent', () {
+    test('round trips through a map', () {
+      final content = ToolUseContent(
+        id: 'call-1',
+        name: 'lookup',
+        input: {'query': 'weather'},
+      );
+      final wire = content as Map<String, Object?>;
+
+      expect(wire, {
+        'type': 'tool_use',
+        'id': 'call-1',
+        'name': 'lookup',
+        'input': {'query': 'weather'},
+      });
+
+      final decoded = ToolUseContent.fromMap(wire);
+      expect(decoded.type, wire['type']);
+      expect(decoded.id, 'call-1');
+      expect(decoded.name, 'lookup');
+      expect(decoded.input, {'query': 'weather'});
+
+      final asContent = Content.fromMap(wire);
+      expect(asContent.isToolUse, isTrue);
+      expect(asContent.isText, isFalse);
+    });
+
+    test('writes metadata when provided', () {
+      final meta = Meta.fromMap({'source': 'tool'});
+      final content = ToolUseContent(
+        id: 'call-1',
+        name: 'lookup',
+        input: {},
+        meta: meta,
+      );
+
+      expect(content as Map<String, Object?>, {
+        'type': 'tool_use',
+        'id': 'call-1',
+        'name': 'lookup',
+        'input': <String, Object?>{},
+        '_meta': {'source': 'tool'},
+      });
+      expect(
+        ToolUseContent.fromMap(content as Map<String, Object?>).meta,
+        meta,
+      );
+    });
+  });
+
+  group('ToolResultContent', () {
+    test('round trips through a map', () {
+      final text = TextContent(text: 'done');
+      final result = ToolResultContent(toolUseId: 'call-1', content: [text]);
+      final wire = result as Map<String, Object?>;
+
+      expect(wire, {
+        'type': 'tool_result',
+        'toolUseId': 'call-1',
+        'content': [text],
+      });
+
+      final decoded = ToolResultContent.fromMap(wire);
+      expect(decoded.type, wire['type']);
+      expect(decoded.toolUseId, 'call-1');
+      expect(decoded.content, hasLength(1));
+      final decodedContent = decoded.content.single;
+      expect(decodedContent.isText, isTrue);
+      expect((decodedContent as TextContent).text, 'done');
+      expect(decoded.structuredContent, isNull);
+      expect(decoded.isError, isNull);
+
+      final asContent = Content.fromMap(wire);
+      expect(asContent.isToolResult, isTrue);
+      expect(asContent.isText, isFalse);
+    });
+
+    test('omits absent optional fields', () {
+      final result = ToolResultContent(
+        toolUseId: 'call-1',
+        content: [TextContent(text: 'done')],
+      );
+
+      final wire = result as Map<String, Object?>;
+      expect(wire.keys.toSet(), {'type', 'toolUseId', 'content'});
+      expect(result.structuredContent, isNull);
+      expect(result.isError, isNull);
+      expect(result.meta, isNull);
+    });
+
+    test('reads optional fields when provided', () {
+      final structuredContent = {'answer': '42'};
+      final meta = Meta.fromMap({'source': 'tool'});
+      final result = ToolResultContent(
+        toolUseId: 'call-1',
+        content: [TextContent(text: 'done')],
+        structuredContent: structuredContent,
+        isError: true,
+        meta: meta,
+      );
+
+      expect(result as Map<String, Object?>, {
+        'type': 'tool_result',
+        'toolUseId': 'call-1',
+        'content': [TextContent(text: 'done')],
+        'structuredContent': structuredContent,
+        'isError': true,
+        '_meta': {'source': 'tool'},
+      });
+      expect(result.structuredContent, structuredContent);
+      expect(result.isError, isTrue);
+      expect(result.meta, meta);
+    });
+
+    test('throws when content is missing', () {
+      expect(
+        () =>
+            ToolResultContent.fromMap({
+              'type': 'tool_result',
+              'toolUseId': 'call-1',
+            }).content,
+        throwsArgumentError,
+      );
+    });
+  });
+
   test('server can request LLM messages from the client', () async {
     final environment = TestEnvironment(
       SamplingTestMCPClient(),


### PR DESCRIPTION
The 2025-11-25 revision added tool use and tool result content to sampling messages, plus a tools list on the request. Both content types now sit under `SamplingMessageContentBlock`, the union the schema gives `SamplingMessage.content`. Plain `Content` keeps the arms a `tools/call` result can carry, while text, image and audio blocks implement both unions. Retyping `SamplingMessage.content` is breaking. A tool map read through `Content.fromMap` now trips an assert, since the static types alone cannot refuse one off the wire. I left `@Deprecated` off these types, because 2026-07-28 deprecates the sampling feature and the schema keeps them. Array-valued message content wants its own change.
