### PR TITLE
follow up on the review comments on #636

### DIFF
--- a/pkgs/dart_mcp/CHANGELOG.md
+++ b/pkgs/dart_mcp/CHANGELOG.md
@@ -15,6 +15,9 @@
 - Let `handleRequestScopedMessage` route server-to-client requests through an
   `onRequest` callback on revisions before 2026-07-28. Missing callbacks and
   invalid callback responses fail the server request without leaving it open.
+- Advertise the notification capabilities from a protected
+  `MCPServer.advertisedCapabilities` getter, which `SubscriptionsSupport`
+  overrides, instead of a type check on the server.
 - **BREAKING**:
   - `MCPBase` (including the `MCPServer.fromStreamChannel` and
     `ServerConnection.fromStreamChannel` constructors),

--- a/pkgs/dart_mcp/lib/src/api/subscriptions.dart
+++ b/pkgs/dart_mcp/lib/src/api/subscriptions.dart
@@ -93,7 +93,7 @@ extension type WithSubscriptionId._fromMap(Map<String, Object?> _value) {
     return MetaWithSubscriptionId.fromMap(meta as Map<String, Object?>);
   }
 
-  /// The JSON-RPC id of the [SubscriptionsListenRequest] which opened the
+  /// The JSON-RPC ID of the [SubscriptionsListenRequest] which opened the
   /// stream this message belongs to.
   ///
   /// Every message on the stream carries it under the
@@ -111,7 +111,7 @@ extension type MetaWithSubscriptionId.fromMap(Map<String, Object?> _value)
   factory MetaWithSubscriptionId({required RequestId subscriptionId}) =>
       MetaWithSubscriptionId.fromMap({Keys.subscriptionIdMeta: subscriptionId});
 
-  /// The JSON-RPC id of the [SubscriptionsListenRequest] which opened the
+  /// The JSON-RPC ID of the [SubscriptionsListenRequest] which opened the
   /// stream this metadata belongs to.
   RequestId get subscriptionId {
     final subscriptionId = _value[Keys.subscriptionIdMeta];
@@ -147,7 +147,7 @@ extension type SubscriptionsListenResult.fromMap(Map<String, Object?> _value)
 /// Sent by the server to acknowledge a [SubscriptionsListenRequest] and report
 /// the notification types it agreed to send.
 ///
-/// This is the first message carrying the subscription's id. Over stdio every
+/// This is the first message carrying the subscription's ID. Over stdio every
 /// subscription shares one channel, so messages from other subscriptions may
 /// arrive before this acknowledgement.
 ///

--- a/pkgs/dart_mcp/lib/src/client/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/src/client/streamable_http.dart
@@ -21,8 +21,8 @@ import '../utils/streamable_http.dart';
 /// written to `_meta` and `MCP-Protocol-Version`. [clientCapabilities] and
 /// [clientInfo] merge into `_meta`. JSON replies use `jsonDecode` and SSE
 /// replies use [sseMessageStream]. A failed POST is a JSON-RPC error for that
-/// request id, or an error on the channel itself when it carried a
-/// notification. Notifications have no id to carry an error. A response
+/// request ID, or an error on the channel itself when it carried a
+/// notification. Notifications have no ID to carry an error. A response
 /// stream that ends without answering the request fails it the same way. A
 /// `202` on a notification is not an inbound message. Valid `x-mcp-header`
 /// annotations from `tools/list` are mirrored on later `tools/call` requests.
@@ -216,7 +216,7 @@ Stream<Map<String, Object?>> _sendStreamableHttpMessage(
     );
   } catch (error, stackTrace) {
     if (!message.containsKey(Keys.id)) {
-      // A notification has no id to attach a JSON-RPC error to. A message this
+      // A notification has no ID to attach a JSON-RPC error to. A message this
       // client never sent is the caller's to fix, but a POST that failed on
       // the wire has nothing else to report it.
       if (posting) Error.throwWithStackTrace(error, stackTrace);

--- a/pkgs/dart_mcp/lib/src/server/request_scoped.dart
+++ b/pkgs/dart_mcp/lib/src/server/request_scoped.dart
@@ -36,9 +36,9 @@ typedef MCPServerFactory =
 /// `resultType`, and, for the requests the caching rules name, carries `ttlMs`
 /// and `cacheScope` unless it is an interim `resources/read` result, which is
 /// not cacheable. The acknowledgement and result for `subscriptions/listen`
-/// carry the request id under `io.modelcontextprotocol/subscriptionId`.
+/// carry the request ID under `io.modelcontextprotocol/subscriptionId`.
 /// A listen request is named before delivery by setting
-/// [SubscriptionsSupport.nextSubscriptionId] to that id. A
+/// [SubscriptionsSupport.nextSubscriptionId] to that ID. A
 /// field the handler left out is filled in: a `resultType`
 /// left `null` becomes `complete`, a `ttlMs` which is `null` becomes `0`, and
 /// a `cacheScope` which is `null` becomes `private`. The dispatcher cannot
@@ -77,7 +77,7 @@ typedef MCPServerFactory =
 ///
 /// On revisions before 2026-07-28, requests from the server back to the client
 /// are passed to [onRequest]. Its response must be a JSON-RPC response carrying
-/// the request id. A callback error or an invalid response fails the server's
+/// the request ID. A callback error or an invalid response fails the server's
 /// request with an internal error. A response completed after the exchange has
 /// closed is discarded. Without [onRequest], server requests fail immediately.
 /// The callback is not used on 2026-07-28.
@@ -87,7 +87,7 @@ typedef MCPServerFactory =
 /// receive the serialized error and notifications receive no response.
 ///
 /// Throws an [ArgumentError] if [message] is not a JSON-RPC request or
-/// notification (no string `method`, a `null` id, or a `result` or `error`
+/// notification (no string `method`, a `null` ID, or a `result` or `error`
 /// member), or if its method is the legacy `initialize` request or
 /// `initialized` notification; classifying a message as legacy or
 /// request-scoped is the transport's job. Errors thrown by [serverFactory] or
@@ -275,7 +275,7 @@ Future<Map<String, Object?>?> handleRequestScopedMessage(
 }
 
 /// Returns the answer for a server [request], or an internal error carrying
-/// its id when [onRequest] fails or returns an invalid response.
+/// its ID when [onRequest] fails or returns an invalid response.
 Future<Map<String, Object?>> _answerServerRequest(
   Map<String, Object?> request,
   FutureOr<Map<String, Object?>> Function(Map<String, Object?> request)

--- a/pkgs/dart_mcp/lib/src/server/server.dart
+++ b/pkgs/dart_mcp/lib/src/server/server.dart
@@ -200,7 +200,7 @@ abstract base class MCPServer extends MCPBase {
             if (version.methodIsValid(DiscoverRequest.methodName))
               version.versionString,
         ],
-        capabilities: _advertisedCapabilities,
+        capabilities: advertisedCapabilities,
         instructions: instructions,
       );
 
@@ -212,37 +212,34 @@ abstract base class MCPServer extends MCPBase {
   /// `resourceSubscriptions` filter. [SubscriptionsSupport] acknowledges the
   /// request, and the Streamable HTTP transport routes matching notifications
   /// from that request's server. A server with [SubscriptionsSupport] therefore
-  /// advertises the capabilities it registered. Without that mixin the four
-  /// bits standing for those notifications come off here: `listChanged` on
-  /// each of the three, and `subscribe` on [ServerCapabilities.resources].
+  /// advertises the capabilities it registered, and overrides this to do so.
+  /// Without that mixin the four bits standing for those notifications come off
+  /// here: `listChanged` on each of the three, and `subscribe` on
+  /// [ServerCapabilities.resources].
   /// Every other key the server registered is passed through, and
   /// `initializeLegacy` keeps all of them, since the revisions that handshake
   /// negotiates still serve `resources/subscribe` and send the list changes
   /// without a filter.
-  ServerCapabilities get _advertisedCapabilities =>
-      this is SubscriptionsSupport
-          ? ServerCapabilities.fromMap({
-            ...capabilities as Map<String, Object?>,
-          })
-          : ServerCapabilities.fromMap({
-            ...capabilities as Map<String, Object?>,
-            if (capabilities.prompts case final prompts?)
-              Keys.prompts: Prompts.fromMap(
-                Map<String, Object?>.from(prompts as Map<String, Object?>)
-                  ..remove(Keys.listChanged),
-              ),
-            if (capabilities.resources case final resources?)
-              Keys.resources: Resources.fromMap(
-                Map<String, Object?>.from(resources as Map<String, Object?>)
-                  ..remove(Keys.listChanged)
-                  ..remove(Keys.subscribe),
-              ),
-            if (capabilities.tools case final tools?)
-              Keys.tools: Tools.fromMap(
-                Map<String, Object?>.from(tools as Map<String, Object?>)
-                  ..remove(Keys.listChanged),
-              ),
-          });
+  @protected
+  ServerCapabilities get advertisedCapabilities => ServerCapabilities.fromMap({
+    ...capabilities as Map<String, Object?>,
+    if (capabilities.prompts case final prompts?)
+      Keys.prompts: Prompts.fromMap(
+        Map<String, Object?>.from(prompts as Map<String, Object?>)
+          ..remove(Keys.listChanged),
+      ),
+    if (capabilities.resources case final resources?)
+      Keys.resources: Resources.fromMap(
+        Map<String, Object?>.from(resources as Map<String, Object?>)
+          ..remove(Keys.listChanged)
+          ..remove(Keys.subscribe),
+      ),
+    if (capabilities.tools case final tools?)
+      Keys.tools: Tools.fromMap(
+        Map<String, Object?>.from(tools as Map<String, Object?>)
+          ..remove(Keys.listChanged),
+      ),
+  });
 
   @mustCallSuper
   /// Handles the initialize request used by legacy MCP protocols.

--- a/pkgs/dart_mcp/lib/src/server/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/src/server/streamable_http.dart
@@ -72,7 +72,7 @@ import 'server.dart';
 /// future completes normally without writing a response.
 ///
 /// `Mcp-Session-Id` and `Last-Event-ID` headers are ignored, and no session
-/// id is ever minted: sessions and resumable streams were removed in this
+/// ID is ever minted: sessions and resumable streams were removed in this
 /// revision.
 ///
 /// For `tools/call`, a string, integer, or boolean property annotated with

--- a/pkgs/dart_mcp/lib/src/server/streamable_http.dart
+++ b/pkgs/dart_mcp/lib/src/server/streamable_http.dart
@@ -523,7 +523,7 @@ Future<void> handleStreamableHttpRequest(
     unawaited(() async {
       try {
         await response.done;
-      } catch (_) {
+      } on IOException {
         // A disconnected client cannot receive another response.
       }
       responseClosed = true;

--- a/pkgs/dart_mcp/lib/src/server/subscriptions_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/subscriptions_support.dart
@@ -27,6 +27,13 @@ base mixin SubscriptionsSupport on MCPServer {
   /// this before delivering it. Leaving it `null` refuses the request.
   RequestId? nextSubscriptionId;
 
+  /// Advertises every registered capability, since this server serves the
+  /// `subscriptions/listen` requests a client opens to hear those
+  /// notifications on. The copy keeps the advertisement off server state.
+  @override
+  ServerCapabilities get advertisedCapabilities =>
+      ServerCapabilities.fromMap({...capabilities as Map<String, Object?>});
+
   @override
   FutureOr<void> initialize(MCPServerInitialization initialization) async {
     if (initialization.protocolVersion.methodIsValid(

--- a/pkgs/dart_mcp/lib/src/server/subscriptions_support.dart
+++ b/pkgs/dart_mcp/lib/src/server/subscriptions_support.dart
@@ -6,24 +6,24 @@ part of 'server.dart';
 
 /// A mixin for MCP servers which serve `subscriptions/listen` requests.
 ///
-/// Stamps the subscription id on the acknowledgement and holds the request
-/// until shutdown. A `package:json_rpc_2` handler does not receive that id,
+/// Stamps the subscription ID on the acknowledgement and holds the request
+/// until shutdown. A `package:json_rpc_2` handler does not receive that ID,
 /// so a transport sets [nextSubscriptionId] before delivering the request.
 /// [handleRequestScopedMessage] does. A request without one is refused.
 ///
 /// See https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/subscriptions.
 base mixin SubscriptionsSupport on MCPServer {
-  /// Ends each open subscription, under the id it was opened with.
+  /// Ends each open subscription, under the ID it was opened with.
   final Map<RequestId, Completer<void>> _subscriptions = {};
 
   /// The first [shutdown] call, which every later one waits on.
   Completer<void>? _shutdown;
 
-  /// The id the next `subscriptions/listen` request opens its subscription
+  /// The ID the next `subscriptions/listen` request opens its subscription
   /// under.
   ///
-  /// A handler cannot read the JSON-RPC id of the request it answers, and a
-  /// subscription is named by that id. The transport serving the request sets
+  /// A handler cannot read the JSON-RPC ID of the request it answers, and a
+  /// subscription is named by that ID. The transport serving the request sets
   /// this before delivering it. Leaving it `null` refuses the request.
   RequestId? nextSubscriptionId;
 
@@ -81,7 +81,7 @@ base mixin SubscriptionsSupport on MCPServer {
 
   /// Acknowledges [request] and keeps it open until the server shuts down.
   ///
-  /// The acknowledgement and the result both carry the subscription id under
+  /// The acknowledgement and the result both carry the subscription ID under
   /// `io.modelcontextprotocol/subscriptionId`. On a server with
   /// [ResourcesSupport], every URI the acknowledged `resourceSubscriptions`
   /// filter names starts sending [ResourceUpdatedNotification]s, so that
@@ -155,15 +155,15 @@ base mixin SubscriptionsSupport on MCPServer {
       throw RpcException(
         error_code.INVALID_REQUEST,
         'A `${SubscriptionsListenRequest.methodName}` subscription is named '
-        'by the JSON-RPC id of the request which opens it, and this server '
-        'was given no id to name this one by.',
+        'by the JSON-RPC ID of the request which opens it, and this server '
+        'was given no ID to name this one by.',
       );
     }
     if (_subscriptions.containsKey(subscriptionId)) {
       throw RpcException(
         error_code.INVALID_REQUEST,
         'A `${SubscriptionsListenRequest.methodName}` subscription is already '
-        'open under this request id.',
+        'open under this request ID.',
       );
     }
     final subscriptionEnd = Completer<void>();

--- a/pkgs/dart_mcp/lib/src/utils/json_rpc_2_object.dart
+++ b/pkgs/dart_mcp/lib/src/utils/json_rpc_2_object.dart
@@ -32,9 +32,9 @@ extension type JsonRpc2Object.fromMap(Map<String, Object?> _value) {
     return method;
   }
 
-  /// The id of this message, if it is a request or response.
+  /// The ID of this message, if it is a request or response.
   ///
-  /// A JSON-RPC id is a `String` or an `int`.
+  /// A JSON-RPC ID is a `String` or an `int`.
   Object? get id => _value[Keys.id];
 }
 


### PR DESCRIPTION
Answers three comments on #636 in code.

`_advertisedCapabilities` becomes a protected `advertisedCapabilities` getter and `SubscriptionsSupport` overrides it. The type check on `this` goes away. The `response.done` catch is now `on IOException`, and `id` is capitalized in the library prose.

The race question is answered on its thread, with no code change.
