### PR TITLE
run the mcp conformance suite weekly

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -1,0 +1,42 @@
+name: package:dart_mcp conformance
+permissions: read-all
+
+# The MCP conformance suite is an npm package that is still in alpha, so this
+# runs on a schedule and by hand rather than on every pull request.
+on:
+  schedule:
+    - cron: '0 0 * * 0' # weekly
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: pkgs/dart_mcp
+
+jobs:
+  conformance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - uses: dart-lang/setup-dart@6afc89df92d6eb3834022f73cd65adc8cdfcb92d
+        with:
+          sdk: stable
+      - run: dart pub get
+      - name: Server
+        run: |
+          dart run tool/conformance_server.dart > server.log &
+          for i in $(seq 1 30); do
+            grep -q '^http' server.log && break
+            sleep 1
+          done
+          URL="$(grep -m1 '^http' server.log)"
+          test -n "$URL"
+          npx @modelcontextprotocol/conformance@0.2.0-alpha.11 server \
+            --url "$URL" --requirements 2026-07-28
+      - name: Client
+        run: |
+          npx @modelcontextprotocol/conformance@0.2.0-alpha.11 client \
+            --command "dart run tool/conformance_client.dart" \
+            --requirements 2026-07-28 \
+            --expected-failures tool/conformance_expected_failures.yaml

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 name: package:dart_mcp conformance
 permissions: read-all
 

--- a/pkgs/dart_mcp/tool/conformance_expected_failures.yaml
+++ b/pkgs/dart_mcp/tool/conformance_expected_failures.yaml
@@ -1,0 +1,33 @@
+# Scenarios the conformance suite runs for 2026-07-28 that this package does not
+# pass yet. The client has no OAuth support, so every auth scenario fails.
+client:
+  - auth/metadata-default
+  - auth/metadata-var1
+  - auth/metadata-var2
+  - auth/metadata-var3
+  - auth/basic-cimd
+  - auth/scope-from-www-authenticate
+  - auth/scope-from-scopes-supported
+  - auth/scope-omitted-when-undefined
+  - auth/scope-step-up
+  - auth/scope-retry-limit
+  - auth/token-endpoint-auth-basic
+  - auth/token-endpoint-auth-post
+  - auth/token-endpoint-auth-none
+  - auth/pre-registration
+  - auth/offline-access-scope
+  - auth/offline-access-not-supported
+  - auth/authorization-server-migration
+  - auth/iss-supported
+  - auth/iss-not-advertised
+  - auth/iss-supported-missing
+  - auth/iss-wrong-issuer
+  - auth/iss-unexpected
+  - auth/iss-normalized
+  - auth/metadata-issuer-mismatch
+  - auth/client-credentials-jwt
+  - auth/client-credentials-basic
+  - auth/enterprise-managed-authorization
+  - auth/dpop
+  - auth/dpop-nonce
+  - auth/wif-jwt-bearer

--- a/pkgs/dart_mcp/tool/conformance_expected_failures.yaml
+++ b/pkgs/dart_mcp/tool/conformance_expected_failures.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
 # Scenarios the conformance suite runs for 2026-07-28 that this package does not
 # pass yet. The client has no OAuth support, so every auth scenario fails.
 client:


### PR DESCRIPTION
Runs the conformance suite against both fixtures under `tool/`. Triggers are the weekly schedule, a manual dispatch or any pull request that changes the package. Since the suite is still an alpha npm package, the job carries `continue-on-error`. A failure stays visible without failing the run. Every scored 2026-07-28 scenario passes on the server run, with only the `tasks` extension failing. On the client run a baseline file names the auth scenarios, the package has no OAuth client, and anything outside that list fails the job, as does a listed scenario that starts passing.

Follow-up to #491.
